### PR TITLE
fix(ui): always default the quality profile in add dialogs

### DIFF
--- a/web/src/components/movies/add-movie-dialog.tsx
+++ b/web/src/components/movies/add-movie-dialog.tsx
@@ -70,6 +70,16 @@ export function AddMovieDialog({
     }
   }, [open, qualityProfiles, libraries, mediaPrefs]);
 
+  // Guarantee a valid quality profile is always selected once profiles load,
+  // independent of dialog open state. Preserves any still-valid selection.
+  useEffect(() => {
+    if (qualityProfiles.length === 0) return;
+    setSelectedProfile((prev) => {
+      if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
+      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0].id;
+    });
+  }, [qualityProfiles, libraries, mediaPrefs]);
+
   const handleLibraryChange = useCallback((libId: string) => {
     setSelectedLibrary(libId);
     const lib = libraries.find(l => l.id === libId);

--- a/web/src/components/person-discover-dialog.tsx
+++ b/web/src/components/person-discover-dialog.tsx
@@ -124,6 +124,15 @@ export function PersonDiscoverDialog({
     }
   }, [open, personId, fetchFilmography]);
 
+  // Guarantee a valid quality profile is always selected once profiles load.
+  useEffect(() => {
+    if (qualityProfiles.length === 0) return;
+    setSelectedProfile((prev) => {
+      if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
+      return libraries[0]?.quality_profile_id || qualityProfiles[0].id;
+    });
+  }, [qualityProfiles, libraries]);
+
   const movieCredits = data?.credits.filter(c => c.media_type === "movie") ?? [];
   const tvCredits = data?.credits.filter(c => c.media_type === "tv") ?? [];
 

--- a/web/src/components/series/add-series-dialog.tsx
+++ b/web/src/components/series/add-series-dialog.tsx
@@ -73,6 +73,16 @@ export function AddSeriesDialog({
     }
   }, [open, qualityProfiles, libraries, mediaPrefs]);
 
+  // Guarantee a valid quality profile is always selected once profiles load,
+  // independent of dialog open state. Preserves any still-valid selection.
+  useEffect(() => {
+    if (qualityProfiles.length === 0) return;
+    setSelectedProfile((prev) => {
+      if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
+      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0].id;
+    });
+  }, [qualityProfiles, libraries, mediaPrefs]);
+
   const handleLibraryChange = useCallback((libId: string) => {
     setSelectedLibrary(libId);
     const lib = libraries.find(l => l.id === libId);


### PR DESCRIPTION
## What
Ensures the **Quality Profile** select is always pre-populated when adding a Movie or TV Show (and in the person-discover add flow).

## Why
`selectedProfile` was initialized from `qualityProfiles[0]` before the async profile list loaded, and the default was only re-applied inside the on-open effect. If profiles loaded after open — or a library had no bound profile and no default media preference was set — the select rendered empty and the **Add** button stayed disabled.

## How
Added a dedicated effect (independent of dialog open state) that, once profiles load, guarantees a valid selection while preserving any still-valid choice:
`library profile → media-pref default → first profile`.

Applied to:
- `add-movie-dialog.tsx`
- `add-series-dialog.tsx`
- `person-discover-dialog.tsx` (previously had no fallback effect at all)

## Testing
- `tsc --noEmit` clean
- `vitest run` → 51/51 pass
- eslint: only pre-existing a11y label warnings on unrelated lines

Closes #21