### PR TITLE
fix(series): segment multi-cour anime seasons via TVDB episodes

### DIFF
--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ebenderooock/loom/internal/libraries"
 	"github.com/ebenderooock/loom/internal/metadata"
 	"github.com/ebenderooock/loom/internal/metadata/tmdb"
+	"github.com/ebenderooock/loom/internal/metadata/tvdb"
 	"github.com/ebenderooock/loom/internal/movies"
 	"github.com/ebenderooock/loom/internal/notifications"
 	"github.com/ebenderooock/loom/internal/organizer"
@@ -94,7 +95,26 @@ func buildSeriesService(db storage.DB) series.Service {
 		apiKey = defaultTMDBKey
 	}
 	repo := series.NewRepository(db.DB())
-	return series.NewService(repo, apiKey)
+
+	var opts []series.Option
+	// Optional TVDB episode provider: enables correct multi-cour anime season
+	// segmentation so releases numbered with the TVDB/scene S01/S02 split match.
+	if tvdbKey := os.Getenv("LOOM_METADATA_TVDB_APIKEY"); tvdbKey != "" {
+		client := tvdb.NewClient(tvdb.Config{
+			APIKey: tvdbKey,
+			PIN:    os.Getenv("LOOM_METADATA_TVDB_PIN"),
+		})
+		seasonType := os.Getenv("LOOM_METADATA_TVDB_SEASON_TYPE")
+		if seasonType == "" {
+			seasonType = "official"
+		}
+		opts = append(opts, series.WithEpisodeProvider(&tvdbEpisodeProvider{
+			client:     client,
+			seasonType: seasonType,
+		}))
+	}
+
+	return series.NewService(repo, apiKey, opts...)
 }
 
 // buildSeriesScanner constructs the series scanner backed by the series service.

--- a/cmd/loom/series_tvdb.go
+++ b/cmd/loom/series_tvdb.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/ebenderooock/loom/internal/metadata/tvdb"
+	"github.com/ebenderooock/loom/internal/series"
+)
+
+// tvdbEpisodeProvider adapts the TVDB client to series.EpisodeProvider so anime
+// series can be segmented using TVDB aired-order numbering.
+type tvdbEpisodeProvider struct {
+	client     *tvdb.Client
+	seasonType string
+}
+
+// ResolveSeriesID resolves a TVDB series ID from external IDs (preferring a
+// known TVDB id) or, failing that, a title + year search with a confident match.
+func (p *tvdbEpisodeProvider) ResolveSeriesID(ctx context.Context, title string, year int, externalIDs map[string]string) (int, error) {
+	results, err := p.client.FindSeries(ctx, title, externalIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	want := normalizeTitle(title)
+	best := 0
+	bestScore := 0
+	for _, r := range results {
+		if r == nil || r.TVDBID == nil {
+			continue
+		}
+		id, convErr := strconv.Atoi(*r.TVDBID)
+		if convErr != nil || id <= 0 {
+			continue
+		}
+		score := 0
+		if normalizeTitle(r.Title) == want {
+			score += 2
+		}
+		if year > 0 {
+			if ry := firstAirYear(r.FirstAirDate); ry == year {
+				score += 2
+			} else if ry != 0 {
+				// Year known but mismatched: penalize so we don't pick a
+				// different series with the same name.
+				score--
+			}
+		}
+		if score > bestScore {
+			bestScore = score
+			best = id
+		}
+	}
+
+	// Require a confident match (title or year agreement) to avoid mis-mapping.
+	if bestScore <= 0 {
+		return 0, nil
+	}
+	return best, nil
+}
+
+// SeriesEpisodes returns the series' episodes in the configured season type.
+func (p *tvdbEpisodeProvider) SeriesEpisodes(ctx context.Context, providerSeriesID int) ([]series.ProviderEpisode, error) {
+	recs, err := p.client.GetSeriesEpisodes(ctx, providerSeriesID, p.seasonType)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]series.ProviderEpisode, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, series.ProviderEpisode{
+			SeasonNumber:   r.SeasonNumber,
+			EpisodeNumber:  r.Number,
+			AbsoluteNumber: r.AbsoluteNumber,
+			Runtime:        r.Runtime,
+			Title:          r.Name,
+			Overview:       r.Overview,
+			AirDate:        r.Aired,
+			StillPath:      r.Image,
+		})
+	}
+	return out, nil
+}
+
+func normalizeTitle(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func firstAirYear(date string) int {
+	if len(date) < 4 {
+		return 0
+	}
+	y, err := strconv.Atoi(date[:4])
+	if err != nil {
+		return 0
+	}
+	return y
+}

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -242,6 +242,36 @@ export LOOM_METADATA_TVDB_PIN=optional_pin_for_higher_limits  # optional
 - Combined: higher hit rate for international/niche series
 - Fallback: if TVDB unavailable, service tries TMDB
 
+### Anime multi-cour season segmentation
+
+TMDB frequently collapses multi-cour anime (a show that airs in distinct
+broadcast runs, e.g. "Solo Leveling" Season 1 then Season 2) into a single
+TMDB-numbered season. Scene/torrent releases, however, follow the TVDB split
+and are numbered `S02Exx`. When Loom builds seasons from TMDB alone, the
+second cour is never created, so those releases never match.
+
+To fix this, the **series service** (`internal/series`) can fetch episode
+listings directly from TVDB for series whose type is `anime`. When a TVDB key
+is configured, adding or refreshing an anime series resolves its TVDB ID (via
+search when not already stored) and segments seasons/episodes using TVDB's
+ordering instead of TMDB's. Non-anime series, and all series when no TVDB key
+is set, continue to use TMDB.
+
+**Configuration** (reuses the TVDB provider credentials):
+```bash
+export LOOM_METADATA_TVDB_APIKEY=your_tvdb_api_key       # required to enable
+export LOOM_METADATA_TVDB_PIN=optional_pin               # optional
+export LOOM_METADATA_TVDB_SEASON_TYPE=official           # optional, default "official"
+```
+
+- `LOOM_METADATA_TVDB_SEASON_TYPE` selects the TVDB season ordering:
+  `default`, `official` (aired order, matches Sonarr's default), `dvd`,
+  `absolute`, `alternate`, or `regional`.
+- **Graceful fallback:** if `LOOM_METADATA_TVDB_APIKEY` is unset, the episode
+  provider is not wired and Loom builds seasons from TMDB exactly as before.
+- A series mis-typed as `standard` can be flipped to `anime` from the series
+  detail panel and then refreshed to re-segment its seasons.
+
 ## Integration Points
 
 ### Movies Module (Phase 5)

--- a/internal/metadata/tvdb/client.go
+++ b/internal/metadata/tvdb/client.go
@@ -110,6 +110,80 @@ func (c *Client) GetSeries(ctx context.Context, tvdbID int) (*metadata.SeriesMet
 	return MapSeriesToMetadata(data), nil
 }
 
+// GetSeriesEpisodes retrieves all episodes for a series in the given season type
+// (e.g. "official" for aired order, "absolute", "dvd"). It paginates the TVDB
+// endpoint until no further episodes are returned.
+func (c *Client) GetSeriesEpisodes(ctx context.Context, tvdbID int, seasonType string) ([]EpisodeBaseRecord, error) {
+	if seasonType == "" {
+		seasonType = "official"
+	}
+	if err := c.ensureToken(ctx); err != nil {
+		return nil, err
+	}
+
+	const maxPages = 200
+	var episodes []EpisodeBaseRecord
+
+	for page := 0; page < maxPages; page++ {
+		u, _ := url.Parse(fmt.Sprintf("%s/series/%d/episodes/%s", c.config.BaseURL, tvdbID, url.PathEscape(seasonType)))
+		q := u.Query()
+		q.Set("page", strconv.Itoa(page))
+		u.RawQuery = q.Encode()
+		reqURL := u.String()
+
+		resp, err := c.doRequest(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusUnauthorized {
+			resp.Body.Close()
+			c.tokenMutex.Lock()
+			c.token = ""
+			c.tokenMutex.Unlock()
+			if err := c.ensureToken(ctx); err != nil {
+				return nil, err
+			}
+			resp, err = c.doRequest(ctx, "GET", reqURL, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			resp.Body.Close()
+			return nil, NewNotFoundError(fmt.Sprintf("series %d not found", tvdbID))
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode >= 500 {
+				return nil, NewServerError(resp.StatusCode, string(body))
+			}
+			return nil, NewClientError(resp.StatusCode, string(body))
+		}
+
+		var er SeriesEpisodesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+			resp.Body.Close()
+			return nil, NewNetworkError(err)
+		}
+		resp.Body.Close()
+
+		if len(er.Data.Episodes) == 0 {
+			break
+		}
+		episodes = append(episodes, er.Data.Episodes...)
+
+		// Stop when the API reports no further page.
+		if er.Links.Next == "" {
+			break
+		}
+	}
+
+	return episodes, nil
+}
+
 // GetEpisode retrieves episode metadata by series TVDB ID and season/episode numbers.
 func (c *Client) GetEpisode(ctx context.Context, seriesTVDBID, season, episode int) (*metadata.EpisodeMetadata, error) {
 	// TVDB v4 requires episode ID, not season/episode numbers directly.

--- a/internal/metadata/tvdb/client_test.go
+++ b/internal/metadata/tvdb/client_test.go
@@ -556,3 +556,80 @@ func TestFindMovie_NotSupported(t *testing.T) {
 		t.Fatalf("expected error for FindMovie")
 	}
 }
+
+// TestGetSeriesEpisodes_Pagination verifies multi-page aggregation and that the
+// aired-order season split is preserved.
+func TestGetSeriesEpisodes_Pagination(t *testing.T) {
+page0 := SeriesEpisodesResponse{
+Data: SeriesEpisodesData{Episodes: []EpisodeBaseRecord{
+{ID: 1, SeasonNumber: 1, Number: 1, AbsoluteNumber: 1, Name: "S1E1"},
+{ID: 2, SeasonNumber: 1, Number: 2, AbsoluteNumber: 2, Name: "S1E2"},
+}},
+Links: PageLinks{Next: "page2"},
+}
+page1 := SeriesEpisodesResponse{
+Data: SeriesEpisodesData{Episodes: []EpisodeBaseRecord{
+{ID: 13, SeasonNumber: 2, Number: 1, AbsoluteNumber: 13, Name: "S2E1"},
+}},
+Links: PageLinks{Next: ""},
+}
+
+var hits int32
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Path == "/login" {
+json.NewEncoder(w).Encode(LoginResponse{Data: LoginData{Token: "t"}})
+return
+}
+if r.URL.Path != "/series/100/episodes/official" {
+http.Error(w, "not found", http.StatusNotFound)
+return
+}
+atomic.AddInt32(&hits, 1)
+w.Header().Set("Content-Type", "application/json")
+switch r.URL.Query().Get("page") {
+case "0":
+json.NewEncoder(w).Encode(page0)
+default:
+json.NewEncoder(w).Encode(page1)
+}
+}))
+defer server.Close()
+
+client := NewClient(Config{APIKey: "k", BaseURL: server.URL})
+eps, err := client.GetSeriesEpisodes(context.Background(), 100, "official")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(eps) != 3 {
+t.Fatalf("expected 3 episodes across pages, got %d", len(eps))
+}
+if eps[2].SeasonNumber != 2 || eps[2].Number != 1 {
+t.Fatalf("expected last episode to be S2E1, got S%dE%d", eps[2].SeasonNumber, eps[2].Number)
+}
+if atomic.LoadInt32(&hits) != 2 {
+t.Fatalf("expected 2 page requests, got %d", hits)
+}
+}
+
+// TestGetSeriesEpisodes_EmptyStops ensures the loop stops on an empty page.
+func TestGetSeriesEpisodes_EmptyStops(t *testing.T) {
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+if r.URL.Path == "/login" {
+json.NewEncoder(w).Encode(LoginResponse{Data: LoginData{Token: "t"}})
+return
+}
+// Always return empty episodes with a non-empty Next link; the empty
+// page must still terminate the loop.
+json.NewEncoder(w).Encode(SeriesEpisodesResponse{Links: PageLinks{Next: "more"}})
+}))
+defer server.Close()
+
+client := NewClient(Config{APIKey: "k", BaseURL: server.URL})
+eps, err := client.GetSeriesEpisodes(context.Background(), 7, "")
+if err != nil {
+t.Fatalf("unexpected error: %v", err)
+}
+if len(eps) != 0 {
+t.Fatalf("expected 0 episodes, got %d", len(eps))
+}
+}

--- a/internal/metadata/tvdb/types.go
+++ b/internal/metadata/tvdb/types.go
@@ -55,6 +55,40 @@ type RatingsInfo struct {
 	IMDB float64 `json:"imdb,omitempty"`
 }
 
+// SeriesEpisodesResponse is the JSON response from
+// GET /series/{id}/episodes/{season-type}.
+type SeriesEpisodesResponse struct {
+	Data  SeriesEpisodesData `json:"data"`
+	Links PageLinks          `json:"links"`
+}
+
+// SeriesEpisodesData holds the episodes payload of a series-episodes response.
+type SeriesEpisodesData struct {
+	Episodes []EpisodeBaseRecord `json:"episodes"`
+}
+
+// EpisodeBaseRecord is a TVDB v4 base episode record.
+type EpisodeBaseRecord struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	Overview       string `json:"overview"`
+	Image          string `json:"image"`
+	Aired          string `json:"aired"`
+	Runtime        int    `json:"runtime"`
+	SeasonNumber   int    `json:"seasonNumber"`
+	Number         int    `json:"number"`
+	AbsoluteNumber int    `json:"absoluteNumber"`
+}
+
+// PageLinks contains TVDB pagination links.
+type PageLinks struct {
+	Prev      string `json:"prev"`
+	Self      string `json:"self"`
+	Next      string `json:"next"`
+	TotalItems int   `json:"total_items"`
+	PageSize  int    `json:"page_size"`
+}
+
 // SearchResponse wraps search results from TVDB.
 type SearchResponse struct {
 	Data []SearchResult `json:"data"`

--- a/internal/series/anime_tvdb_test.go
+++ b/internal/series/anime_tvdb_test.go
@@ -1,0 +1,192 @@
+package series
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeEpisodeProvider is a test EpisodeProvider returning canned data.
+type fakeEpisodeProvider struct {
+	resolveID   int
+	resolveErr  error
+	episodes    []ProviderEpisode
+	episodesErr error
+
+	resolvedTitle string
+	resolvedYear  int
+}
+
+func (f *fakeEpisodeProvider) ResolveSeriesID(_ context.Context, title string, year int, _ map[string]string) (int, error) {
+	f.resolvedTitle = title
+	f.resolvedYear = year
+	return f.resolveID, f.resolveErr
+}
+
+func (f *fakeEpisodeProvider) SeriesEpisodes(_ context.Context, _ int) ([]ProviderEpisode, error) {
+	return f.episodes, f.episodesErr
+}
+
+// soloLevelingEpisodes mirrors the issue: TVDB splits into S1 (12) + S2 (13).
+func soloLevelingEpisodes() []ProviderEpisode {
+	var eps []ProviderEpisode
+	for i := 1; i <= 12; i++ {
+		eps = append(eps, ProviderEpisode{SeasonNumber: 1, EpisodeNumber: i, AbsoluteNumber: i})
+	}
+	for i := 1; i <= 13; i++ {
+		eps = append(eps, ProviderEpisode{SeasonNumber: 2, EpisodeNumber: i, AbsoluteNumber: 12 + i})
+	}
+	return eps
+}
+
+func TestBuildSeasonsAndEpisodes_MultiCour(t *testing.T) {
+	ts := time.Now()
+	seasons, episodes := buildSeasonsAndEpisodes("solo-leveling-2024", soloLevelingEpisodes(), ts)
+
+	if len(seasons) != 2 {
+		t.Fatalf("expected 2 seasons, got %d", len(seasons))
+	}
+	if seasons[0].SeasonNumber != 1 || seasons[0].EpisodeCount != 12 {
+		t.Fatalf("season 1 wrong: %+v", seasons[0])
+	}
+	if seasons[1].SeasonNumber != 2 || seasons[1].EpisodeCount != 13 {
+		t.Fatalf("season 2 wrong: %+v", seasons[1])
+	}
+	if len(episodes) != 25 {
+		t.Fatalf("expected 25 episodes, got %d", len(episodes))
+	}
+
+	// S02E01 must exist and belong to season 2 (this is what release matching needs).
+	want := "solo-leveling-2024-s02-e001"
+	var found *Episode
+	for _, e := range episodes {
+		if e.ID == want {
+			found = e
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected episode id %q (S02E01) to exist", want)
+	}
+	if found.SeasonID != "solo-leveling-2024-s02" || found.EpisodeNumber != 1 {
+		t.Fatalf("S02E01 mapped incorrectly: %+v", found)
+	}
+}
+
+func TestBuildSeasonsAndEpisodes_SkipsInvalidAndDuplicates(t *testing.T) {
+	ts := time.Now()
+	eps := []ProviderEpisode{
+		{SeasonNumber: 1, EpisodeNumber: 1},
+		{SeasonNumber: 1, EpisodeNumber: 1},  // duplicate
+		{SeasonNumber: 1, EpisodeNumber: 0},  // invalid episode
+		{SeasonNumber: -1, EpisodeNumber: 5}, // invalid season
+		{SeasonNumber: 0, EpisodeNumber: 1},  // specials kept
+	}
+	seasons, episodes := buildSeasonsAndEpisodes("show", eps, ts)
+	if len(episodes) != 2 {
+		t.Fatalf("expected 2 episodes (dedup + skip invalid), got %d", len(episodes))
+	}
+	if len(seasons) != 2 {
+		t.Fatalf("expected 2 seasons (1 and specials), got %d", len(seasons))
+	}
+	// Specials season title.
+	for _, se := range seasons {
+		if se.SeasonNumber == 0 && se.Title != "Specials" {
+			t.Fatalf("expected specials title, got %q", se.Title)
+		}
+	}
+}
+
+func TestPopulateProviderEpisodes_AnimeUsesTVDB(t *testing.T) {
+	repo := newMockRepo()
+	fp := &fakeEpisodeProvider{resolveID: 999, episodes: soloLevelingEpisodes()}
+	svc := NewService(repo, "", WithEpisodeProvider(fp)).(*service)
+
+	tvdbID := "" // none stored -> must resolve via provider
+	sr := &Series{ID: "solo-leveling-2024", Title: "Solo Leveling", Year: 2024, SeriesType: TypeAnime}
+	_ = tvdbID
+
+	ok, err := svc.populateProviderEpisodes(context.Background(), sr, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected episodes to be stored")
+	}
+	if got := len(repo.episodes["solo-leveling-2024"]); got != 25 {
+		t.Fatalf("expected 25 episodes stored, got %d", got)
+	}
+	if got := len(repo.seasons["solo-leveling-2024"]); got != 2 {
+		t.Fatalf("expected 2 seasons stored, got %d", got)
+	}
+	// Resolved TVDB ID must be written back for persistence.
+	if sr.TVDBID == nil || *sr.TVDBID != "999" {
+		t.Fatalf("expected resolved TVDB id 999 to be set, got %v", sr.TVDBID)
+	}
+	if fp.resolvedTitle != "Solo Leveling" || fp.resolvedYear != 2024 {
+		t.Fatalf("resolver received wrong args: %q %d", fp.resolvedTitle, fp.resolvedYear)
+	}
+}
+
+func TestPopulateProviderEpisodes_UnresolvedReturnsFalse(t *testing.T) {
+	repo := newMockRepo()
+	fp := &fakeEpisodeProvider{resolveID: 0} // cannot resolve
+	svc := NewService(repo, "", WithEpisodeProvider(fp)).(*service)
+
+	sr := &Series{ID: "x", Title: "Unknown", SeriesType: TypeAnime}
+	ok, err := svc.populateProviderEpisodes(context.Background(), sr, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when provider cannot resolve")
+	}
+	if len(repo.episodes["x"]) != 0 {
+		t.Fatalf("expected no episodes stored")
+	}
+}
+
+func TestPopulateProviderEpisodes_ProviderErrorPropagates(t *testing.T) {
+	repo := newMockRepo()
+	fp := &fakeEpisodeProvider{resolveID: 5, episodesErr: errors.New("boom")}
+	svc := NewService(repo, "", WithEpisodeProvider(fp)).(*service)
+
+	sr := &Series{ID: "x", Title: "Anime", SeriesType: TypeAnime, TVDBID: ptr("5")}
+	ok, err := svc.populateProviderEpisodes(context.Background(), sr, time.Now())
+	if err == nil {
+		t.Fatalf("expected error to propagate")
+	}
+	if ok {
+		t.Fatalf("expected ok=false on provider error")
+	}
+}
+
+func TestUseTVDBEpisodes(t *testing.T) {
+	svcNoProvider := NewService(newMockRepo(), "").(*service)
+	if svcNoProvider.useTVDBEpisodes(&Series{SeriesType: TypeAnime}) {
+		t.Fatalf("should be false without a provider")
+	}
+
+	svc := NewService(newMockRepo(), "", WithEpisodeProvider(&fakeEpisodeProvider{})).(*service)
+	if svc.useTVDBEpisodes(&Series{SeriesType: TypeStandard}) {
+		t.Fatalf("standard series must not use TVDB")
+	}
+	if !svc.useTVDBEpisodes(&Series{SeriesType: TypeAnime}) {
+		t.Fatalf("anime series with provider must use TVDB")
+	}
+}
+
+func TestResolveTVDBID_PrefersStored(t *testing.T) {
+	fp := &fakeEpisodeProvider{resolveID: 111}
+	svc := NewService(newMockRepo(), "", WithEpisodeProvider(fp)).(*service)
+	sr := &Series{ID: "x", Title: "T", TVDBID: ptr("42"), SeriesType: TypeAnime}
+	if got := svc.resolveTVDBID(context.Background(), sr); got != 42 {
+		t.Fatalf("expected stored id 42, got %d", got)
+	}
+	if fp.resolvedTitle != "" {
+		t.Fatalf("resolver should not be called when id is stored")
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/series/episode_provider.go
+++ b/internal/series/episode_provider.go
@@ -1,0 +1,40 @@
+package series
+
+import "context"
+
+// ProviderEpisode is a provider-agnostic episode record used to (re)segment a
+// series' seasons and episodes from an external episode source whose numbering
+// differs from TMDB (e.g. TVDB aired order for multi-cour anime).
+type ProviderEpisode struct {
+	SeasonNumber   int
+	EpisodeNumber  int
+	AbsoluteNumber int
+	Runtime        int
+	Title          string
+	Overview       string
+	AirDate        string
+	StillPath      string
+}
+
+// EpisodeProvider supplies season/episode structure for series whose numbering
+// differs between metadata sources. It is used for anime, where TMDB collapses
+// multiple cours into one season but releases use the TVDB/scene S01/S02 split.
+type EpisodeProvider interface {
+	// ResolveSeriesID resolves the provider's numeric series ID from the title,
+	// year and any known external IDs (e.g. "imdb", "tmdb"). It returns 0 when
+	// no confident match is found.
+	ResolveSeriesID(ctx context.Context, title string, year int, externalIDs map[string]string) (int, error)
+
+	// SeriesEpisodes returns all episodes for the provider series ID in aired
+	// (broadcast) order.
+	SeriesEpisodes(ctx context.Context, providerSeriesID int) ([]ProviderEpisode, error)
+}
+
+// Option configures the series service.
+type Option func(*service)
+
+// WithEpisodeProvider configures an external episode provider used to segment
+// anime series so their seasons match release numbering.
+func WithEpisodeProvider(p EpisodeProvider) Option {
+	return func(s *service) { s.episodeProvider = p }
+}

--- a/internal/series/repository.go
+++ b/internal/series/repository.go
@@ -135,11 +135,11 @@ func (r *sqlRepo) CreateSeries(ctx context.Context, s *Series) error {
 func (r *sqlRepo) UpdateSeries(ctx context.Context, s *Series) error {
 	genreBytes, _ := json.Marshal(s.Genres)
 	_, err := r.db.ExecContext(ctx,
-		`UPDATE series SET title = ?, year = ?, overview = ?, genres = ?, runtime = ?, rating = ?, backdrop_path = ?, poster_path = ?, network = ?, status = ?, series_type = ?, quality_profile_id = ?, library_id = ?, monitoring_status = ?, season_folder = ?, release_date = ?, updated_at = ?
+		`UPDATE series SET title = ?, year = ?, imdb_id = ?, tvdb_id = ?, overview = ?, genres = ?, runtime = ?, rating = ?, backdrop_path = ?, poster_path = ?, network = ?, status = ?, series_type = ?, metadata_provider = ?, quality_profile_id = ?, library_id = ?, monitoring_status = ?, season_folder = ?, release_date = ?, updated_at = ?
 		 WHERE id = ?`,
-		s.Title, s.Year, s.Overview, string(genreBytes), s.Runtime, s.Rating,
+		s.Title, s.Year, s.IMDBID, s.TVDBID, s.Overview, string(genreBytes), s.Runtime, s.Rating,
 		s.BackdropPath, s.PosterPath, s.Network,
-		string(s.Status), string(s.SeriesType),
+		string(s.Status), string(s.SeriesType), s.MetadataProvider,
 		s.QualityProfileID, s.LibraryID, string(s.MonitoringStatus),
 		s.SeasonFolder, s.ReleaseDate, s.UpdatedAt.Format(time.RFC3339), s.ID,
 	)

--- a/internal/series/service.go
+++ b/internal/series/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -39,18 +40,24 @@ type Service interface {
 }
 
 type service struct {
-	repo       Repository
-	tmdbAPIKey string
-	httpClient *http.Client
+	repo            Repository
+	tmdbAPIKey      string
+	httpClient      *http.Client
+	episodeProvider EpisodeProvider
 }
 
-// NewService creates a new series Service.
-func NewService(repo Repository, tmdbAPIKey string) Service {
-	return &service{
+// NewService creates a new series Service. Optional behaviour (such as an
+// external episode provider for anime segmentation) is supplied via options.
+func NewService(repo Repository, tmdbAPIKey string, opts ...Option) Service {
+	s := &service{
 		repo:       repo,
 		tmdbAPIKey: tmdbAPIKey,
 		httpClient: &http.Client{Timeout: 15 * time.Second},
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 func (s *service) ListSeries(ctx context.Context) ([]*Series, error) {
@@ -207,36 +214,23 @@ func (s *service) AddSeries(ctx context.Context, req *AddSeriesRequest) (*Series
 		return nil, fmt.Errorf("series: create: %w", err)
 	}
 
-	// Create seasons and episodes from TMDB data
-	if seasons, ok := details["seasons"].([]interface{}); ok {
-		for _, sRaw := range seasons {
-			sm, ok := sRaw.(map[string]interface{})
-			if !ok {
-				continue
+	// Create seasons and episodes. For anime, prefer the external episode
+	// provider (TVDB aired order) so multi-cour seasons match release numbering.
+	stored := false
+	if s.useTVDBEpisodes(sr) {
+		ok, err := s.populateProviderEpisodes(ctx, sr, nowt)
+		if err != nil {
+			slog.Default().Warn("series: anime episode fetch failed; falling back to TMDB", "series", sr.ID, "error", err)
+		} else if ok {
+			sr.MetadataProvider = "tvdb"
+			stored = true
+			if err := s.repo.UpdateSeries(ctx, sr); err != nil {
+				slog.Default().Warn("series: failed to persist provider metadata", "series", sr.ID, "error", err)
 			}
-
-			seasonNum := getInt(sm, "season_number")
-			seasonID := fmt.Sprintf("%s-s%02d", slug, seasonNum)
-
-			season := &Season{
-				ID:           seasonID,
-				SeriesID:     sr.ID,
-				SeasonNumber: seasonNum,
-				Title:        getString(sm, "name"),
-				Overview:     getString(sm, "overview"),
-				PosterPath:   getString(sm, "poster_path"),
-				Monitored:    true,
-				EpisodeCount: getInt(sm, "episode_count"),
-				CreatedAt:    nowt,
-				UpdatedAt:    nowt,
-			}
-			if err := s.repo.CreateSeason(ctx, season); err != nil {
-				continue
-			}
-
-			// Fetch individual season episodes from TMDB
-			s.fetchAndStoreEpisodes(ctx, req.TMDBID, seasonNum, sr.ID, seasonID, nowt)
 		}
+	}
+	if !stored {
+		s.createSeasonsFromTMDB(ctx, details, sr.ID, req.TMDBID, nowt)
 	}
 
 	// Save credits
@@ -366,11 +360,33 @@ func (s *service) RefreshSeries(ctx context.Context, id string) error {
 		}
 	}
 
+	// For anime, fetch the provider (TVDB) aired-order episodes BEFORE deleting
+	// existing data, so a provider failure never wipes the current structure.
+	var animeSeasons []*Season
+	var animeEpisodes []*Episode
+	animeOK := false
+	if s.useTVDBEpisodes(sr) {
+		if tvdbID := s.resolveTVDBID(ctx, sr); tvdbID != 0 {
+			eps, err := s.episodeProvider.SeriesEpisodes(ctx, tvdbID)
+			if err != nil {
+				slog.Default().Warn("series: anime refresh fetch failed; falling back to TMDB", "series", sr.ID, "error", err)
+			} else {
+				animeSeasons, animeEpisodes = buildSeasonsAndEpisodes(sr.ID, eps, nowt)
+				animeOK = len(animeEpisodes) > 0
+			}
+		}
+	}
+	if animeOK {
+		sr.MetadataProvider = "tvdb"
+	} else if sr.SeriesType != TypeAnime {
+		sr.MetadataProvider = "tmdb"
+	}
+
 	if err := s.repo.UpdateSeries(ctx, sr); err != nil {
 		return fmt.Errorf("series: update: %w", err)
 	}
 
-	// Delete existing children, then re-create from fresh TMDB data
+	// Delete existing children, then re-create from fresh data
 	if err := s.repo.DeleteEpisodesBySeriesID(ctx, sr.ID); err != nil {
 		return fmt.Errorf("series: delete episodes: %w", err)
 	}
@@ -381,35 +397,15 @@ func (s *service) RefreshSeries(ctx context.Context, id string) error {
 		return fmt.Errorf("series: delete credits: %w", err)
 	}
 
-	// Re-create seasons and episodes
-	if seasons, ok := details["seasons"].([]interface{}); ok {
-		for _, sRaw := range seasons {
-			sm, ok := sRaw.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			seasonNum := getInt(sm, "season_number")
-			seasonID := fmt.Sprintf("%s-s%02d", sr.ID, seasonNum)
-
-			season := &Season{
-				ID:           seasonID,
-				SeriesID:     sr.ID,
-				SeasonNumber: seasonNum,
-				Title:        getString(sm, "name"),
-				Overview:     getString(sm, "overview"),
-				PosterPath:   getString(sm, "poster_path"),
-				Monitored:    true,
-				EpisodeCount: getInt(sm, "episode_count"),
-				CreatedAt:    nowt,
-				UpdatedAt:    nowt,
-			}
-			if err := s.repo.CreateSeason(ctx, season); err != nil {
-				continue
-			}
-
-			s.fetchAndStoreEpisodes(ctx, *sr.TMDBID, seasonNum, sr.ID, seasonID, nowt)
+	if animeOK {
+		for _, se := range animeSeasons {
+			_ = s.repo.CreateSeason(ctx, se)
 		}
+		for _, e := range animeEpisodes {
+			_ = s.repo.CreateEpisode(ctx, e)
+		}
+	} else {
+		s.createSeasonsFromTMDB(ctx, details, sr.ID, *sr.TMDBID, nowt)
 	}
 
 	// Re-create credits
@@ -530,6 +526,166 @@ func (s *service) tmdbGet(ctx context.Context, rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("series: tmdb returned %d: %s", resp.StatusCode, string(body))
 	}
 	return body, nil
+}
+
+// useTVDBEpisodes reports whether the external episode provider should be used
+// to segment this series (anime only, and only when a provider is configured).
+func (s *service) useTVDBEpisodes(sr *Series) bool {
+	return sr != nil && sr.SeriesType == TypeAnime && s.episodeProvider != nil
+}
+
+// resolveTVDBID returns the numeric TVDB ID for a series, resolving it via the
+// episode provider when the series has none stored. A newly resolved ID is
+// written back onto sr so the caller can persist it. Returns 0 if unresolved.
+func (s *service) resolveTVDBID(ctx context.Context, sr *Series) int {
+	if sr.TVDBID != nil && *sr.TVDBID != "" {
+		if id, err := strconv.Atoi(*sr.TVDBID); err == nil && id > 0 {
+			return id
+		}
+	}
+	if s.episodeProvider == nil {
+		return 0
+	}
+	ext := map[string]string{}
+	if sr.IMDBID != nil && *sr.IMDBID != "" {
+		ext["imdb"] = *sr.IMDBID
+	}
+	if sr.TMDBID != nil && *sr.TMDBID != "" {
+		ext["tmdb"] = *sr.TMDBID
+	}
+	id, err := s.episodeProvider.ResolveSeriesID(ctx, sr.Title, sr.Year, ext)
+	if err != nil || id <= 0 {
+		if err != nil {
+			slog.Default().Warn("series: tvdb id resolution failed", "series", sr.ID, "error", err)
+		}
+		return 0
+	}
+	idStr := strconv.Itoa(id)
+	sr.TVDBID = &idStr
+	return id
+}
+
+// populateProviderEpisodes fetches aired-order episodes from the configured
+// provider and stores normalized seasons + episodes. It returns true when
+// episodes were stored. Callers must clear existing children beforehand.
+func (s *service) populateProviderEpisodes(ctx context.Context, sr *Series, ts time.Time) (bool, error) {
+	tvdbID := s.resolveTVDBID(ctx, sr)
+	if tvdbID == 0 {
+		return false, nil
+	}
+	eps, err := s.episodeProvider.SeriesEpisodes(ctx, tvdbID)
+	if err != nil {
+		return false, err
+	}
+	seasons, episodes := buildSeasonsAndEpisodes(sr.ID, eps, ts)
+	if len(episodes) == 0 {
+		return false, nil
+	}
+	for _, se := range seasons {
+		_ = s.repo.CreateSeason(ctx, se)
+	}
+	for _, e := range episodes {
+		_ = s.repo.CreateEpisode(ctx, e)
+	}
+	return true, nil
+}
+
+// createSeasonsFromTMDB creates the season rows from TMDB details and fetches
+// each season's episodes from TMDB.
+func (s *service) createSeasonsFromTMDB(ctx context.Context, details map[string]interface{}, seriesID, tmdbID string, ts time.Time) {
+	seasons, ok := details["seasons"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, sRaw := range seasons {
+		sm, ok := sRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		seasonNum := getInt(sm, "season_number")
+		seasonID := fmt.Sprintf("%s-s%02d", seriesID, seasonNum)
+		season := &Season{
+			ID:           seasonID,
+			SeriesID:     seriesID,
+			SeasonNumber: seasonNum,
+			Title:        getString(sm, "name"),
+			Overview:     getString(sm, "overview"),
+			PosterPath:   getString(sm, "poster_path"),
+			Monitored:    true,
+			EpisodeCount: getInt(sm, "episode_count"),
+			CreatedAt:    ts,
+			UpdatedAt:    ts,
+		}
+		if err := s.repo.CreateSeason(ctx, season); err != nil {
+			continue
+		}
+		s.fetchAndStoreEpisodes(ctx, tmdbID, seasonNum, seriesID, seasonID, ts)
+	}
+}
+
+// buildSeasonsAndEpisodes converts a provider's flat episode list into
+// normalized Season and Episode rows. Invalid entries (negative season or
+// non-positive episode numbers) are skipped and duplicate (season, episode)
+// pairs are dropped. Seasons are emitted in first-seen order.
+func buildSeasonsAndEpisodes(seriesID string, eps []ProviderEpisode, ts time.Time) ([]*Season, []*Episode) {
+	type seKey struct{ s, e int }
+	seen := make(map[seKey]bool)
+	counts := make(map[int]int)
+	var order []int
+	var episodes []*Episode
+
+	for _, ep := range eps {
+		if ep.SeasonNumber < 0 || ep.EpisodeNumber <= 0 {
+			continue
+		}
+		k := seKey{ep.SeasonNumber, ep.EpisodeNumber}
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		if _, ok := counts[ep.SeasonNumber]; !ok {
+			order = append(order, ep.SeasonNumber)
+		}
+		counts[ep.SeasonNumber]++
+		seasonID := fmt.Sprintf("%s-s%02d", seriesID, ep.SeasonNumber)
+		episodes = append(episodes, &Episode{
+			ID:            fmt.Sprintf("%s-e%03d", seasonID, ep.EpisodeNumber),
+			SeriesID:      seriesID,
+			SeasonID:      seasonID,
+			EpisodeNumber: ep.EpisodeNumber,
+			Title:         ep.Title,
+			Overview:      ep.Overview,
+			AirDate:       ep.AirDate,
+			Runtime:       ep.Runtime,
+			StillPath:     ep.StillPath,
+			Monitored:     true,
+			CreatedAt:     ts,
+			UpdatedAt:     ts,
+		})
+	}
+
+	var seasons []*Season
+	for _, sn := range order {
+		seasonID := fmt.Sprintf("%s-s%02d", seriesID, sn)
+		seasons = append(seasons, &Season{
+			ID:           seasonID,
+			SeriesID:     seriesID,
+			SeasonNumber: sn,
+			Title:        seasonTitle(sn),
+			Monitored:    true,
+			EpisodeCount: counts[sn],
+			CreatedAt:    ts,
+			UpdatedAt:    ts,
+		})
+	}
+	return seasons, episodes
+}
+
+func seasonTitle(n int) string {
+	if n == 0 {
+		return "Specials"
+	}
+	return fmt.Sprintf("Season %d", n)
 }
 
 func (s *service) fetchAndStoreEpisodes(ctx context.Context, tmdbID string, seasonNum int, seriesID, seasonID string, ts time.Time) {


### PR DESCRIPTION
## Summary

Fixes #19 — multi-cour anime collapsed into a single season (e.g. Solo Leveling
S2 not detected). TMDB numbers these shows as one season, but scene/torrent
releases follow the TVDB split (`S02Exx`), so the second cour was never created
and those releases never matched.

## What changed

- **TVDB client** (`internal/metadata/tvdb`): `GetSeriesEpisodes` paginates
  `/series/{id}/episodes/{season-type}` with 401 token-refresh retry; new
  episode/page response types.
- **Series service** (`internal/series`): new `EpisodeProvider` interface
  (`ResolveSeriesID` + `SeriesEpisodes`) wired via `WithEpisodeProvider`.
  `AddSeries`/`RefreshSeries` use TVDB episode data for `anime`-typed series
  (fetch-before-delete on refresh) and fall back to TMDB otherwise.
  `resolveTVDBID` searches and persists the TVDB ID when it is missing;
  `buildSeasonsAndEpisodes` dedupes and drops specials/invalid entries.
- **Repository**: `UpdateSeries` now persists `imdb_id`, `tvdb_id` and
  `metadata_provider` (previously silently dropped).
- **Wiring** (`cmd/loom`): enabled from `LOOM_METADATA_TVDB_APIKEY`
  (`LOOM_METADATA_TVDB_PIN`, `LOOM_METADATA_TVDB_SEASON_TYPE` default
  `official`). With no key configured, behaviour is unchanged (TMDB-only).
- **Docs**: anime segmentation + env vars documented in `docs/metadata.md`.

## Requirements / notes

- **Requires a TVDB v4 API key** to activate. Without it Loom gracefully
  builds seasons from TMDB exactly as before.
- Pairs with the editable Series Type change (PR #23 / issue #20): a series
  mis-typed as `standard` can be flipped to `anime` and refreshed to
  re-segment its seasons.
- Matching/import key purely on `(season, episode)`, so correct segmentation
  alone fixes the reported case. Absolute-episode-number release matching
  remains a possible non-blocking follow-up.

## Testing

- `go build ./internal/...`, `CGO_ENABLED=0 go build ./cmd/loom` — OK
- `go test ./internal/series/ ./internal/metadata/tvdb/` — green (new
  pagination + multi-cour grouping tests, incl. Solo Leveling S1=12/S2=13)
- `gofmt`/`go vet` clean on changed packages

Closes #19
