### PR TITLE
feat(build): bundle TVDB key into image via ldflags injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ website/dist/
 
 # Local-only helm overrides (real ingress host, etc.)
 deploy/helm/values-homelab.local.yaml
+
+# Build-time secrets baked into the Docker image (TVDB key, etc.)
+deploy/.build-secrets.env

--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -24,6 +24,13 @@ import (
 // Override via LOOM_TMDB_API_KEY env var or config.
 const defaultTMDBKey = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI3NzU0NWI2ODU0ZjIzNGZjYjRhYzdlZTQzM2FjMTc4MyIsIm5iZiI6MTQyNDA4OTIyNi45ODgsInN1YiI6IjU0ZTFlMDhhOTI1MTQxMmM4ZTAwMTM2ZiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.sS6ImS7Y3HZKNLF6z8G_G8kVafIyYmZHKbOUtSydiMI"
 
+// defaultTVDBKey is an optional application-level TVDB v4 API key injected at
+// build time via -ldflags "-X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=...".
+// It is empty in source (this is a public repo); when a key is baked into the
+// image, anime season segmentation works out of the box without users needing
+// their own key. Override at runtime via LOOM_METADATA_TVDB_APIKEY.
+var defaultTVDBKey string
+
 // buildMoviesService constructs the movies.Service backed by the storage
 // engine in cfg and returns the wired service.
 func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus) (movies.Service, error) {
@@ -99,7 +106,12 @@ func buildSeriesService(db storage.DB) series.Service {
 	var opts []series.Option
 	// Optional TVDB episode provider: enables correct multi-cour anime season
 	// segmentation so releases numbered with the TVDB/scene S01/S02 split match.
-	if tvdbKey := os.Getenv("LOOM_METADATA_TVDB_APIKEY"); tvdbKey != "" {
+	// Key resolution: LOOM_METADATA_TVDB_APIKEY env > build-time bundled key.
+	tvdbKey := os.Getenv("LOOM_METADATA_TVDB_APIKEY")
+	if tvdbKey == "" {
+		tvdbKey = defaultTVDBKey
+	}
+	if tvdbKey != "" {
 		client := tvdb.NewClient(tvdb.Config{
 			APIKey: tvdbKey,
 			PIN:    os.Getenv("LOOM_METADATA_TVDB_PIN"),

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -21,13 +21,15 @@ COPY --from=web /web/dist ./web/dist
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG DATE
+ARG TVDB_APIKEY=""
 RUN CGO_ENABLED=0 go build \
     -trimpath \
     -tags embed \
     -ldflags "-s -w \
       -X github.com/ebenderooock/loom/internal/buildinfo.Version=${VERSION} \
       -X github.com/ebenderooock/loom/internal/buildinfo.Commit=${COMMIT} \
-      -X github.com/ebenderooock/loom/internal/buildinfo.Date=${DATE}" \
+      -X github.com/ebenderooock/loom/internal/buildinfo.Date=${DATE} \
+      -X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=${TVDB_APIKEY}" \
     -o /out/loom ./cmd/loom
 
 # ---------- runtime ----------

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -264,6 +264,13 @@ export LOOM_METADATA_TVDB_PIN=optional_pin               # optional
 export LOOM_METADATA_TVDB_SEASON_TYPE=official           # optional, default "official"
 ```
 
+Official release images ship with a **bundled TVDB key** injected at build time
+(`-ldflags "-X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=..."`), so
+anime segmentation works out of the box without users supplying their own key.
+`LOOM_METADATA_TVDB_APIKEY` still takes precedence when set, letting operators
+override the bundled key with their own. Builds from source have no bundled key
+and fall back to TMDB unless the env var is provided.
+
 - `LOOM_METADATA_TVDB_SEASON_TYPE` selects the TVDB season ordering:
   `default`, `official` (aired order, matches Sonarr's default), `dvd`,
   `absolute`, `alternate`, or `regional`.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,6 +47,15 @@ fi
 COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# Optional build-time secrets (gitignored). Provides TVDB_APIKEY so the bundled
+# TVDB key gets baked into the image — keeps it out of the public source tree.
+BUILD_SECRETS_FILE="$REPO_ROOT/deploy/.build-secrets.env"
+if [[ -f "$BUILD_SECRETS_FILE" ]]; then
+  info "Loading build secrets from $(basename "$BUILD_SECRETS_FILE")"
+  # shellcheck disable=SC1090
+  set -a; source "$BUILD_SECRETS_FILE"; set +a
+fi
+
 # ── 2. Build Docker image ───────────────────────────────────────────
 
 info "Building Docker image ${IMAGE}:${NEW_TAG} ..."
@@ -55,6 +64,7 @@ docker build \
   --build-arg VERSION="$NEW_TAG" \
   --build-arg COMMIT="$COMMIT" \
   --build-arg DATE="$DATE" \
+  --build-arg TVDB_APIKEY="${TVDB_APIKEY:-}" \
   -t "${IMAGE}:${NEW_TAG}" \
   -t "${IMAGE}:latest" \
   -f "$DOCKERFILE" \


### PR DESCRIPTION
## Summary

Follow-up to #24. Bakes an optional application-level **TVDB v4 API key** into
release images so anime season segmentation (issue #19) works out of the box
without users supplying their own key — mirroring the existing bundled TMDB key.

The key is **injected at docker build time** via
`-ldflags "-X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=..."` and is
**empty in source** (this is a public repo), so the key never enters the tree.

## Changes
- `cmd/loom`: build-injected `defaultTVDBKey` var; `buildSeriesService` prefers
  `LOOM_METADATA_TVDB_APIKEY` env, then the bundled key.
- `deploy/docker/Dockerfile`: `TVDB_APIKEY` build-arg wired into the `-X` ldflag.
- `scripts/deploy.sh`: sources gitignored `deploy/.build-secrets.env` and passes
  `--build-arg TVDB_APIKEY`.
- `docs/metadata.md`: documents the bundled key + env override precedence.

## Notes
- Builds from source (no build-arg) have no bundled key and fall back to TMDB.
- Operators can still override with their own key via the env var.
