### PR TITLE
fix(web): guard qualityProfiles[0] access in add dialogs

### DIFF
--- a/web/src/components/movies/add-movie-dialog.tsx
+++ b/web/src/components/movies/add-movie-dialog.tsx
@@ -76,7 +76,7 @@ export function AddMovieDialog({
     if (qualityProfiles.length === 0) return;
     setSelectedProfile((prev) => {
       if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
-      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0].id;
+      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0]?.id || "";
     });
   }, [qualityProfiles, libraries, mediaPrefs]);
 

--- a/web/src/components/person-discover-dialog.tsx
+++ b/web/src/components/person-discover-dialog.tsx
@@ -129,7 +129,7 @@ export function PersonDiscoverDialog({
     if (qualityProfiles.length === 0) return;
     setSelectedProfile((prev) => {
       if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
-      return libraries[0]?.quality_profile_id || qualityProfiles[0].id;
+      return libraries[0]?.quality_profile_id || qualityProfiles[0]?.id || "";
     });
   }, [qualityProfiles, libraries]);
 

--- a/web/src/components/series/add-series-dialog.tsx
+++ b/web/src/components/series/add-series-dialog.tsx
@@ -79,7 +79,7 @@ export function AddSeriesDialog({
     if (qualityProfiles.length === 0) return;
     setSelectedProfile((prev) => {
       if (prev && qualityProfiles.some((p) => p.id === prev)) return prev;
-      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0].id;
+      return libraries[0]?.quality_profile_id || mediaPrefs?.default_quality_profile_id || qualityProfiles[0]?.id || "";
     });
   }, [qualityProfiles, libraries, mediaPrefs]);
 


### PR DESCRIPTION
Fixes the Docker frontend build (`tsc -b`) which failed with TS2532 on the #22 quality-profile fallback code. Optional chaining + empty fallback; runtime behaviour unchanged (early length guard remains).