### PR TITLE
fix(build): use main.defaultTVDBKey for ldflags -X injection

### DIFF
--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -25,10 +25,10 @@ import (
 const defaultTMDBKey = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI3NzU0NWI2ODU0ZjIzNGZjYjRhYzdlZTQzM2FjMTc4MyIsIm5iZiI6MTQyNDA4OTIyNi45ODgsInN1YiI6IjU0ZTFlMDhhOTI1MTQxMmM4ZTAwMTM2ZiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.sS6ImS7Y3HZKNLF6z8G_G8kVafIyYmZHKbOUtSydiMI"
 
 // defaultTVDBKey is an optional application-level TVDB v4 API key injected at
-// build time via -ldflags "-X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=...".
-// It is empty in source (this is a public repo); when a key is baked into the
-// image, anime season segmentation works out of the box without users needing
-// their own key. Override at runtime via LOOM_METADATA_TVDB_APIKEY.
+// build time via -ldflags "-X main.defaultTVDBKey=...". It is empty in source
+// (this is a public repo); when a key is baked into the image, anime season
+// segmentation works out of the box without users needing their own key.
+// Override at runtime via LOOM_METADATA_TVDB_APIKEY.
 var defaultTVDBKey string
 
 // buildMoviesService constructs the movies.Service backed by the storage

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 go build \
       -X github.com/ebenderooock/loom/internal/buildinfo.Version=${VERSION} \
       -X github.com/ebenderooock/loom/internal/buildinfo.Commit=${COMMIT} \
       -X github.com/ebenderooock/loom/internal/buildinfo.Date=${DATE} \
-      -X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=${TVDB_APIKEY}" \
+      -X main.defaultTVDBKey=${TVDB_APIKEY}" \
     -o /out/loom ./cmd/loom
 
 # ---------- runtime ----------

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -265,8 +265,8 @@ export LOOM_METADATA_TVDB_SEASON_TYPE=official           # optional, default "of
 ```
 
 Official release images ship with a **bundled TVDB key** injected at build time
-(`-ldflags "-X github.com/ebenderooock/loom/cmd/loom.defaultTVDBKey=..."`), so
-anime segmentation works out of the box without users supplying their own key.
+(`-ldflags "-X main.defaultTVDBKey=..."`), so anime segmentation works out of
+the box without users supplying their own key.
 `LOOM_METADATA_TVDB_APIKEY` still takes precedence when set, letting operators
 override the bundled key with their own. Builds from source have no bundled key
 and fall back to TMDB unless the env var is provided.


### PR DESCRIPTION
The bundled TVDB key (#25) was injected via the full import path `-X .../cmd/loom.defaultTVDBKey`, which the Go linker silently ignores for a `package main` symbol. Result: the key stayed empty, the episode provider was nil, and anime refreshes fell back to TMDB (flat single season). Fixed to `-X main.defaultTVDBKey`. Verified that full-path -X into a main-package var is a no-op while `main.<name>` works.