### PR TITLE
fix(series): re-link episode files after refresh

### DIFF
--- a/cmd/loom/wire_media.go
+++ b/cmd/loom/wire_media.go
@@ -70,6 +70,26 @@ func wireMedia(
 	seriesScannerSvc := buildSeriesScanner(seriesSvc, logger)
 	srv.SetSeriesScanner(seriesScannerSvc)
 
+	// After a refresh re-creates a series' episodes (new IDs), re-link on-disk
+	// files by triggering a per-series scan. Best-effort; never fails refresh.
+	// Use a detached, bounded context so a client disconnect mid-refresh can't
+	// leave the re-link half-applied (which would re-orphan episode files).
+	seriesSvc.SetPostRefreshHook(func(ctx context.Context, seriesID string) {
+		rescanCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+		defer cancel()
+		sr, err := seriesSvc.GetSeries(rescanCtx, seriesID)
+		if err != nil || sr.LibraryID == "" {
+			return
+		}
+		lib, err := libStore.Get(rescanCtx, sr.LibraryID)
+		if err != nil {
+			return
+		}
+		if _, err := seriesScannerSvc.RescanSeries(rescanCtx, seriesID, lib.Path); err != nil {
+			logger.Debug("post-refresh rescan failed", "series", seriesID, "error", err)
+		}
+	})
+
 	// Periodic library scan (every 6 hours)
 	periodicScanner := scheduler.NewPeriodicScanner(
 		seriesScannerSvc,

--- a/internal/series/episode_provider.go
+++ b/internal/series/episode_provider.go
@@ -38,3 +38,16 @@ type Option func(*service)
 func WithEpisodeProvider(p EpisodeProvider) Option {
 	return func(s *service) { s.episodeProvider = p }
 }
+
+// PostRefreshHook is invoked after a successful RefreshSeries. Because a refresh
+// deletes and re-creates a series' episodes (assigning new episode IDs), any
+// existing episode_file links are orphaned. The hook re-links on-disk files to
+// the freshly created episodes (typically by triggering a series scan). It is
+// best-effort: failures must not fail the refresh.
+type PostRefreshHook func(ctx context.Context, seriesID string)
+
+// WithPostRefreshHook configures a hook run after each successful refresh to
+// re-link on-disk episode files to the re-created episodes.
+func WithPostRefreshHook(fn PostRefreshHook) Option {
+	return func(s *service) { s.postRefreshHook = fn }
+}

--- a/internal/series/post_refresh_hook_test.go
+++ b/internal/series/post_refresh_hook_test.go
@@ -1,0 +1,40 @@
+package series
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPostRefreshHook_WiringViaOption(t *testing.T) {
+	called := false
+	var gotID string
+	hook := func(_ context.Context, seriesID string) {
+		called = true
+		gotID = seriesID
+	}
+
+	svc := NewService(newMockRepo(), "", WithPostRefreshHook(hook)).(*service)
+	if svc.postRefreshHook == nil {
+		t.Fatalf("WithPostRefreshHook did not set the hook")
+	}
+	svc.postRefreshHook(context.Background(), "abc")
+	if !called || gotID != "abc" {
+		t.Fatalf("hook not invoked correctly: called=%v id=%q", called, gotID)
+	}
+}
+
+func TestPostRefreshHook_WiringViaSetter(t *testing.T) {
+	called := false
+	svc := NewService(newMockRepo(), "").(*service)
+	if svc.postRefreshHook != nil {
+		t.Fatalf("expected no hook before setter")
+	}
+	svc.SetPostRefreshHook(func(_ context.Context, _ string) { called = true })
+	if svc.postRefreshHook == nil {
+		t.Fatalf("SetPostRefreshHook did not set the hook")
+	}
+	svc.postRefreshHook(context.Background(), "x")
+	if !called {
+		t.Fatalf("hook set via setter was not invoked")
+	}
+}

--- a/internal/series/service.go
+++ b/internal/series/service.go
@@ -23,6 +23,7 @@ type Service interface {
 	DeleteSeries(ctx context.Context, id string) error
 	SetMonitoringStatus(ctx context.Context, seriesID string, status MonitoringStatus) error
 	RefreshSeries(ctx context.Context, id string) error
+	SetPostRefreshHook(fn PostRefreshHook)
 
 	ListSeasons(ctx context.Context, seriesID string) ([]*Season, error)
 	ListEpisodes(ctx context.Context, seriesID string, seasonNum *int) ([]*Episode, error)
@@ -44,6 +45,15 @@ type service struct {
 	tmdbAPIKey      string
 	httpClient      *http.Client
 	episodeProvider EpisodeProvider
+	postRefreshHook PostRefreshHook
+}
+
+// SetPostRefreshHook installs the post-refresh re-link hook. It exists in
+// addition to WithPostRefreshHook because the hook (which drives the series
+// scanner) is only available after the scanner has been constructed from the
+// service, creating a late-binding dependency.
+func (s *service) SetPostRefreshHook(fn PostRefreshHook) {
+	s.postRefreshHook = fn
 }
 
 // NewService creates a new series Service. Optional behaviour (such as an
@@ -410,6 +420,13 @@ func (s *service) RefreshSeries(ctx context.Context, id string) error {
 
 	// Re-create credits
 	s.fetchAndStoreCredits(ctx, details, sr.ID)
+
+	// The delete+recreate above orphans any existing episode_file links (new
+	// episode IDs). Re-link on-disk files to the fresh episodes. Best-effort:
+	// a failure here must not fail the refresh.
+	if s.postRefreshHook != nil {
+		s.postRefreshHook(ctx, sr.ID)
+	}
 
 	return nil
 }


### PR DESCRIPTION
RefreshSeries deletes and re-creates a series' seasons/episodes (assigning new episode IDs) and removes `episode_files` rows. This orphans on-disk file links, so previously-downloaded episodes show as **missing** after any refresh — most visibly after anime multi-cour re-segmentation (#19).

## Fix
- Add an optional `PostRefreshHook` to the series service (`WithPostRefreshHook` option + late-binding `SetPostRefreshHook` setter).
- `RefreshSeries` invokes the hook after re-creating episodes/credits.
- Wired in `cmd/loom` to call the series scanner's `RescanSeries`, which walks the show folder and re-links `SxxExx` files to the freshly created episodes. This also picks up files that were previously **unmatched** (e.g. anime S2 files with no episode to match before re-segmentation).
- Best-effort: failures are logged at debug and never fail the refresh.
- Uses a detached, bounded context (`WithoutCancel` + 5m timeout) so a client disconnect mid-refresh can't leave the re-link half-applied.

## Tests
- Added hook wiring tests (option + setter). Full `RefreshSeries` integration isn't unit-testable here (hardcoded TMDB URL / network).

Follow-up (not in scope): serialize concurrent refreshes per series; add a unique index on `episode_files(file_path)`.