### PR TITLE
feat(discover): filtering by list/genre/year + sorting (#4)

### DIFF
--- a/internal/importlists/genres_test.go
+++ b/internal/importlists/genres_test.go
@@ -1,0 +1,39 @@
+package importlists
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEncodeDecodeGenres(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		enc  string
+		out  []string
+	}{
+		{"nil", nil, "", nil},
+		{"empty", []string{}, "", nil},
+		{"single", []string{"Action"}, "Action", []string{"Action"}},
+		{"multi", []string{"Action", "Sci-Fi & Fantasy"}, "Action|Sci-Fi & Fantasy", []string{"Action", "Sci-Fi & Fantasy"}},
+		{"trims blanks", []string{" Drama ", "", "  "}, "Drama", []string{"Drama"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := encodeGenres(c.in); got != c.enc {
+				t.Fatalf("encode: want %q got %q", c.enc, got)
+			}
+			if got := decodeGenres(c.enc); !reflect.DeepEqual(got, c.out) {
+				t.Fatalf("decode: want %v got %v", c.out, got)
+			}
+		})
+	}
+}
+
+func TestDecodeGenresTolerant(t *testing.T) {
+	got := decodeGenres("Action| |Comedy|")
+	want := []string{"Action", "Comedy"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %v got %v", want, got)
+	}
+}

--- a/internal/importlists/store.go
+++ b/internal/importlists/store.go
@@ -161,7 +161,7 @@ func (s *Store) UpdateLastSync(ctx context.Context, id string, t time.Time) erro
 func (s *Store) ListItems(ctx context.Context, listID string) ([]*ImportListItem, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, list_id, external_id, title, year, imdb_id, tmdb_id,
-		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview
+		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview, genres
 		FROM import_list_items WHERE list_id = ? ORDER BY title`, listID)
 	if err != nil {
 		return nil, err
@@ -189,18 +189,19 @@ func (s *Store) UpsertItem(ctx context.Context, item *ImportListItem) error {
 
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO import_list_items
-		(id, list_id, external_id, title, year, imdb_id, tmdb_id, tvdb_id, media_type, status, last_seen, created_at, poster_path, overview)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		(id, list_id, external_id, title, year, imdb_id, tmdb_id, tvdb_id, media_type, status, last_seen, created_at, poster_path, overview, genres)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			title = excluded.title, year = excluded.year,
 			imdb_id = excluded.imdb_id, tmdb_id = excluded.tmdb_id,
 			tvdb_id = excluded.tvdb_id, media_type = excluded.media_type,
 			status = excluded.status, last_seen = excluded.last_seen,
-			poster_path = excluded.poster_path, overview = excluded.overview`,
+			poster_path = excluded.poster_path, overview = excluded.overview,
+			genres = excluded.genres`,
 		item.ID, item.ListID, item.ExternalID, item.Title, item.Year,
 		nullStr(item.IMDbID), nullStr(item.TMDbID), nullStr(item.TVDbID),
 		nullStr(item.MediaType), item.Status, item.LastSeen, now,
-		item.PosterPath, item.Overview,
+		item.PosterPath, item.Overview, encodeGenres(item.Genres),
 	)
 	return err
 }
@@ -209,16 +210,16 @@ func (s *Store) UpsertItem(ctx context.Context, item *ImportListItem) error {
 func (s *Store) FindItemByExternalID(ctx context.Context, listID, externalID string) (*ImportListItem, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, list_id, external_id, title, year, imdb_id, tmdb_id,
-		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview
+		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview, genres
 		FROM import_list_items WHERE list_id = ? AND external_id = ?`, listID, externalID)
 
 	item := &ImportListItem{}
 	var year sql.NullInt64
-	var imdb, tmdb, tvdb, mediaType, poster, overview sql.NullString
+	var imdb, tmdb, tvdb, mediaType, poster, overview, genres sql.NullString
 	err := row.Scan(
 		&item.ID, &item.ListID, &item.ExternalID, &item.Title, &year,
 		&imdb, &tmdb, &tvdb, &mediaType, &item.Status, &item.LastSeen, &item.CreatedAt,
-		&poster, &overview,
+		&poster, &overview, &genres,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -236,6 +237,7 @@ func (s *Store) FindItemByExternalID(ctx context.Context, listID, externalID str
 	item.MediaType = mediaType.String
 	item.PosterPath = poster.String
 	item.Overview = overview.String
+	item.Genres = decodeGenres(genres.String)
 	return item, nil
 }
 
@@ -243,7 +245,7 @@ func (s *Store) FindItemByExternalID(ctx context.Context, listID, externalID str
 func (s *Store) GetItem(ctx context.Context, id string) (*ImportListItem, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, list_id, external_id, title, year, imdb_id, tmdb_id,
-		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview
+		       tvdb_id, media_type, status, last_seen, created_at, poster_path, overview, genres
 		FROM import_list_items WHERE id = ?`, id)
 	item, err := scanItem(row)
 	if err == sql.ErrNoRows {
@@ -268,7 +270,7 @@ func (s *Store) ListDiscoverItems(ctx context.Context, mediaType string) ([]*dis
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT i.id, i.list_id, i.external_id, i.title, i.year, i.imdb_id, i.tmdb_id,
 		       i.tvdb_id, i.media_type, i.status, i.last_seen, i.created_at,
-		       i.poster_path, i.overview, l.name, l.media_type
+		       i.poster_path, i.overview, i.genres, l.name, l.media_type
 		FROM import_list_items i
 		JOIN import_lists l ON i.list_id = l.id
 		WHERE l.mode = 'discover' AND l.enabled = 1 AND i.status != 'excluded'
@@ -283,12 +285,12 @@ func (s *Store) ListDiscoverItems(ctx context.Context, mediaType string) ([]*dis
 	for rows.Next() {
 		item := &ImportListItem{}
 		var year sql.NullInt64
-		var imdb, tmdb, tvdb, itemMedia, poster, overview sql.NullString
+		var imdb, tmdb, tvdb, itemMedia, poster, overview, genres sql.NullString
 		var listName, listMedia string
 		if err := rows.Scan(
 			&item.ID, &item.ListID, &item.ExternalID, &item.Title, &year,
 			&imdb, &tmdb, &tvdb, &itemMedia, &item.Status, &item.LastSeen, &item.CreatedAt,
-			&poster, &overview, &listName, &listMedia,
+			&poster, &overview, &genres, &listName, &listMedia,
 		); err != nil {
 			return nil, err
 		}
@@ -302,6 +304,7 @@ func (s *Store) ListDiscoverItems(ctx context.Context, mediaType string) ([]*dis
 		item.MediaType = itemMedia.String
 		item.PosterPath = poster.String
 		item.Overview = overview.String
+		item.Genres = decodeGenres(genres.String)
 		eff := item.MediaType
 		if eff == "" {
 			eff = listMedia
@@ -441,11 +444,11 @@ func scanList(row rowScanner) (*ImportList, error) {
 func scanItem(row rowScanner) (*ImportListItem, error) {
 	item := &ImportListItem{}
 	var year sql.NullInt64
-	var imdb, tmdb, tvdb, mediaType, poster, overview sql.NullString
+	var imdb, tmdb, tvdb, mediaType, poster, overview, genres sql.NullString
 	err := row.Scan(
 		&item.ID, &item.ListID, &item.ExternalID, &item.Title, &year,
 		&imdb, &tmdb, &tvdb, &mediaType, &item.Status, &item.LastSeen, &item.CreatedAt,
-		&poster, &overview,
+		&poster, &overview, &genres,
 	)
 	if err != nil {
 		return nil, err
@@ -460,7 +463,35 @@ func scanItem(row rowScanner) (*ImportListItem, error) {
 	item.MediaType = mediaType.String
 	item.PosterPath = poster.String
 	item.Overview = overview.String
+	item.Genres = decodeGenres(genres.String)
 	return item, nil
+}
+
+// encodeGenres serialises genre names as a pipe-separated string. Pipe is used
+// (rather than comma) because genre names may contain commas/ampersands.
+func encodeGenres(genres []string) string {
+	cleaned := make([]string, 0, len(genres))
+	for _, g := range genres {
+		if g = strings.TrimSpace(g); g != "" {
+			cleaned = append(cleaned, g)
+		}
+	}
+	return strings.Join(cleaned, "|")
+}
+
+// decodeGenres parses a pipe-separated genre string back into a slice.
+func decodeGenres(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, "|")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // normalizeMode coerces a stored mode string to a valid ListMode, defaulting to auto.

--- a/internal/importlists/sync.go
+++ b/internal/importlists/sync.go
@@ -251,10 +251,14 @@ func (m *SyncManager) SyncList(ctx context.Context, l *ImportList) error {
 	return nil
 }
 
-// enrichItem best-effort populates PosterPath/Overview from TMDB when missing.
-// Failures are logged and ignored so sync never breaks on metadata errors.
+// enrichItem best-effort populates PosterPath/Overview/Genres from TMDB when
+// missing. Failures are logged and ignored so sync never breaks on metadata errors.
 func (m *SyncManager) enrichItem(ctx context.Context, item *ImportListItem, l *ImportList) {
-	if m.tmdbClient == nil || item.PosterPath != "" {
+	if m.tmdbClient == nil {
+		return
+	}
+	// Fetch when any cacheable field is still missing.
+	if item.PosterPath != "" && len(item.Genres) > 0 {
 		return
 	}
 	if item.TMDbID == "" || item.TMDbID == "0" {
@@ -279,9 +283,14 @@ func (m *SyncManager) enrichItem(ctx context.Context, item *ImportListItem, l *I
 			m.logger.Debug("import-lists: tmdb tv enrich failed", "title", item.Title, "err", err)
 			return
 		}
-		item.PosterPath = meta.PosterPath
+		if item.PosterPath == "" {
+			item.PosterPath = meta.PosterPath
+		}
 		if item.Overview == "" {
 			item.Overview = meta.Overview
+		}
+		if len(item.Genres) == 0 {
+			item.Genres = meta.Genres
 		}
 		return
 	}
@@ -291,9 +300,14 @@ func (m *SyncManager) enrichItem(ctx context.Context, item *ImportListItem, l *I
 		m.logger.Debug("import-lists: tmdb movie enrich failed", "title", item.Title, "err", err)
 		return
 	}
-	item.PosterPath = meta.PosterPath
+	if item.PosterPath == "" {
+		item.PosterPath = meta.PosterPath
+	}
 	if item.Overview == "" {
 		item.Overview = meta.Overview
+	}
+	if len(item.Genres) == 0 {
+		item.Genres = meta.Genres
 	}
 }
 

--- a/internal/importlists/types.go
+++ b/internal/importlists/types.go
@@ -96,6 +96,7 @@ type ImportListItem struct {
 	Status     ItemStatus `json:"status"`
 	PosterPath string     `json:"poster_path,omitempty"`
 	Overview   string     `json:"overview,omitempty"`
+	Genres     []string   `json:"genres,omitempty"`
 	LastSeen   time.Time  `json:"last_seen"`
 	CreatedAt  time.Time  `json:"created_at"`
 }

--- a/internal/storage/migrations/sqlite/0058_import_list_items_genres.sql
+++ b/internal/storage/migrations/sqlite/0058_import_list_items_genres.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+-- Cache genres on discover items so the Discover grid can filter by genre
+-- without re-querying TMDB. Stored as a pipe-separated list of genre names.
+ALTER TABLE import_list_items ADD COLUMN genres TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+
+-- SQLite does not support DROP COLUMN in older versions; best-effort rollback.

--- a/web/src/lib/import-lists-api.ts
+++ b/web/src/lib/import-lists-api.ts
@@ -67,6 +67,7 @@ export interface ImportListItem {
 export interface DiscoverItem extends ImportListItem {
   list_name: string;
   in_library: boolean;
+  genres?: string[];
 }
 
 export interface ImportListExclusion {

--- a/web/src/pages/discover.tsx
+++ b/web/src/pages/discover.tsx
@@ -9,6 +9,13 @@ import { usePageHeader } from "@/hooks/use-page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Check, Loader2, Plus, Compass } from "lucide-react";
 import { CardGridSkeleton } from "@/components/ui/skeletons";
 
@@ -35,8 +42,58 @@ export function DiscoverPage() {
   );
 }
 
+type SortKey = "title-asc" | "title-desc" | "year-desc" | "year-asc";
+
+const ALL = "__all__";
+
 function DiscoverGrid({ mediaType }: { mediaType: MediaType }) {
   const { data: items, isLoading, isError, error } = useDiscover(mediaType);
+
+  const [listFilter, setListFilter] = React.useState(ALL);
+  const [genreFilter, setGenreFilter] = React.useState(ALL);
+  const [yearFilter, setYearFilter] = React.useState(ALL);
+  const [sort, setSort] = React.useState<SortKey>("title-asc");
+
+  // Derive available filter options from the loaded items.
+  const { lists, genres, years } = React.useMemo(() => {
+    const listSet = new Set<string>();
+    const genreSet = new Set<string>();
+    const yearSet = new Set<number>();
+    for (const it of items ?? []) {
+      if (it.list_name) listSet.add(it.list_name);
+      for (const g of it.genres ?? []) genreSet.add(g);
+      if (it.year) yearSet.add(it.year);
+    }
+    return {
+      lists: [...listSet].sort((a, b) => a.localeCompare(b)),
+      genres: [...genreSet].sort((a, b) => a.localeCompare(b)),
+      years: [...yearSet].sort((a, b) => b - a),
+    };
+  }, [items]);
+
+  const visible = React.useMemo(() => {
+    let out = [...(items ?? [])];
+    if (listFilter !== ALL) out = out.filter((it) => it.list_name === listFilter);
+    if (genreFilter !== ALL)
+      out = out.filter((it) => (it.genres ?? []).includes(genreFilter));
+    if (yearFilter !== ALL)
+      out = out.filter((it) => String(it.year ?? "") === yearFilter);
+
+    out.sort((a, b) => {
+      switch (sort) {
+        case "title-desc":
+          return b.title.localeCompare(a.title);
+        case "year-desc":
+          return (b.year ?? 0) - (a.year ?? 0) || a.title.localeCompare(b.title);
+        case "year-asc":
+          return (a.year ?? 0) - (b.year ?? 0) || a.title.localeCompare(b.title);
+        case "title-asc":
+        default:
+          return a.title.localeCompare(b.title);
+      }
+    });
+    return out;
+  }, [items, listFilter, genreFilter, yearFilter, sort]);
 
   if (isLoading) {
     return <CardGridSkeleton count={12} />;
@@ -63,11 +120,117 @@ function DiscoverGrid({ mediaType }: { mediaType: MediaType }) {
     );
   }
 
+  const hasFilters =
+    listFilter !== ALL || genreFilter !== ALL || yearFilter !== ALL;
+
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-      {items.map((item) => (
-        <DiscoverCard key={item.id} item={item} />
-      ))}
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {lists.length > 1 && (
+          <Select value={listFilter} onValueChange={setListFilter}>
+            <SelectTrigger className="h-9 w-[160px] text-xs">
+              <SelectValue placeholder="List" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL} className="text-xs">
+                All lists
+              </SelectItem>
+              {lists.map((l) => (
+                <SelectItem key={l} value={l} className="text-xs">
+                  {l}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {genres.length > 0 && (
+          <Select value={genreFilter} onValueChange={setGenreFilter}>
+            <SelectTrigger className="h-9 w-[150px] text-xs">
+              <SelectValue placeholder="Genre" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL} className="text-xs">
+                All genres
+              </SelectItem>
+              {genres.map((g) => (
+                <SelectItem key={g} value={g} className="text-xs">
+                  {g}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        {years.length > 0 && (
+          <Select value={yearFilter} onValueChange={setYearFilter}>
+            <SelectTrigger className="h-9 w-[120px] text-xs">
+              <SelectValue placeholder="Year" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL} className="text-xs">
+                All years
+              </SelectItem>
+              {years.map((y) => (
+                <SelectItem key={y} value={String(y)} className="text-xs">
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <Select value={sort} onValueChange={(v) => setSort(v as SortKey)}>
+          <SelectTrigger className="h-9 w-[150px] text-xs">
+            <SelectValue placeholder="Sort" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="title-asc" className="text-xs">
+              Title (A-Z)
+            </SelectItem>
+            <SelectItem value="title-desc" className="text-xs">
+              Title (Z-A)
+            </SelectItem>
+            <SelectItem value="year-desc" className="text-xs">
+              Year (newest)
+            </SelectItem>
+            <SelectItem value="year-asc" className="text-xs">
+              Year (oldest)
+            </SelectItem>
+          </SelectContent>
+        </Select>
+
+        {hasFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-9 text-xs"
+            onClick={() => {
+              setListFilter(ALL);
+              setGenreFilter(ALL);
+              setYearFilter(ALL);
+            }}
+          >
+            Clear filters
+          </Button>
+        )}
+
+        <span className="ml-auto text-xs text-muted-foreground">
+          {visible.length} of {items.length}
+        </span>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          No items match the selected filters.
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {visible.map((item) => (
+            <DiscoverCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #4

Discover now supports **filtering by source list, genre and year**, plus **sorting** by title or year.

## Backend
- Cache TMDB **genres** on discover items so the grid can filter without re-querying TMDB.
- New `genres` column (migration `0058_import_list_items_genres.sql`, SQLite), threaded through the item store: `UpsertItem`, `scanItem`, `ListItems`, `GetItem`, `FindItemByExternalID`, `ListDiscoverItems`.
- Stored as a pipe-separated list (pipe avoids commas/ampersands in genre names).
- `enrichItem` now also fetches metadata when genres are missing even if a poster is already cached, so existing items backfill genres on the next sync.

## Frontend
- A toolbar on each Discover grid derives the available **lists / genres / years** from the loaded items and filters + sorts **client-side** (data already present, no extra requests).
- Sort options: Title A–Z / Z–A, Year newest / oldest.
- Result count (`N of M`) and a **Clear filters** control. Filter selects only render when there's more than one option.

## Tests
- Added `encodeGenres`/`decodeGenres` unit tests. Frontend `tsc -b` + production build pass.

## Notes
- Existing discover items show genres only after their list re-syncs (enrichment runs during sync). New/updated items get them immediately.
- Postgres migrations aren't maintained at parity in this repo (SQLite is the active engine), so this adds a SQLite migration only, consistent with recent migrations.