### PR TITLE
feat(downloads): built-in torrent engine management UI (#2)

### DIFF
--- a/internal/downloads/handlers.go
+++ b/internal/downloads/handlers.go
@@ -41,6 +41,11 @@ func (s *Service) Mount(r chi.Router) {
 			r.Post("/force-start", s.handleForceStart)
 			r.Post("/recheck", s.handleRecheck)
 			r.Post("/reannounce", s.handleReannounce)
+			// Built-in torrent engine management (no-op for other kinds).
+			r.Get("/torrent/status", s.handleTorrentStatus)
+			r.Post("/torrent/speed-limits", s.handleTorrentSpeedLimits)
+			r.Post("/torrent/pause-all", s.handleTorrentPauseAll)
+			r.Post("/torrent/resume-all", s.handleTorrentResumeAll)
 		})
 	})
 	// Aggregate activity endpoint across all download clients
@@ -899,4 +904,133 @@ func (s *Service) handleActivityDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, items[0])
+}
+
+// --- built-in torrent engine management ------------------------------
+
+// torrentManagerFor resolves the client by id and asserts it supports
+// torrent-engine management. It writes the appropriate error response and
+// returns ok=false when the client is missing or not a built-in torrent.
+func (s *Service) torrentManagerFor(w http.ResponseWriter, id string) (TorrentManager, bool) {
+	c, ok := s.registry.Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "download client not found")
+		return nil, false
+	}
+	mgr, ok := c.(TorrentManager)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "unsupported", "client is not a built-in torrent downloader")
+		return nil, false
+	}
+	return mgr, true
+}
+
+// handleTorrentStatus returns an aggregate snapshot of the built-in
+// torrent engine for the management UI.
+func (s *Service) handleTorrentStatus(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := s.torrentManagerFor(w, chi.URLParam(r, "id"))
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, mgr.EngineSummary())
+}
+
+type speedLimitsRequest struct {
+	// Bytes per second. 0 (or omitted) = unlimited. Negative is clamped to 0.
+	DownloadLimit int64 `json:"download_limit"`
+	UploadLimit   int64 `json:"upload_limit"`
+}
+
+// handleTorrentSpeedLimits applies global download/upload caps to the
+// running engine and persists them to the client config so they survive a
+// restart.
+func (s *Service) handleTorrentSpeedLimits(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	mgr, ok := s.torrentManagerFor(w, id)
+	if !ok {
+		return
+	}
+	var req speedLimitsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON body")
+		return
+	}
+	if req.DownloadLimit < 0 {
+		req.DownloadLimit = 0
+	}
+	if req.UploadLimit < 0 {
+		req.UploadLimit = 0
+	}
+
+	mgr.SetSpeedLimits(req.DownloadLimit, req.UploadLimit)
+
+	// Best-effort persistence: merge the new caps into the stored config
+	// blob so they are re-applied on a cold start. A failure here does not
+	// undo the live change.
+	if err := s.persistTorrentSpeedLimits(r.Context(), id, req.DownloadLimit, req.UploadLimit); err != nil {
+		s.logger.Warn("persisting torrent speed limits failed", "id", id, "err", err)
+	}
+
+	writeJSON(w, http.StatusOK, mgr.EngineSummary())
+}
+
+// persistTorrentSpeedLimits merges the speed caps into the client's stored
+// JSON config and patches the definition.
+func (s *Service) persistTorrentSpeedLimits(ctx context.Context, id string, down, up int64) error {
+	def, err := s.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	cfg := map[string]json.RawMessage{}
+	if len(def.Config) > 0 {
+		if err := json.Unmarshal(def.Config, &cfg); err != nil {
+			return err
+		}
+	}
+	cfg["download_speed_limit"], _ = json.Marshal(down)
+	cfg["upload_speed_limit"], _ = json.Marshal(up)
+	merged, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = s.Patch(ctx, Patch{ID: id, Config: merged})
+	return err
+}
+
+// handleTorrentPauseAll pauses every torrent in the built-in engine.
+func (s *Service) handleTorrentPauseAll(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, ok := s.registry.Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "download client not found")
+		return
+	}
+	if _, ok := c.(TorrentManager); !ok {
+		writeError(w, http.StatusBadRequest, "unsupported", "client is not a built-in torrent downloader")
+		return
+	}
+	if err := c.Pause(r.Context()); err != nil {
+		writeError(w, http.StatusBadGateway, "pause_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// handleTorrentResumeAll resumes every torrent in the built-in engine.
+func (s *Service) handleTorrentResumeAll(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	c, ok := s.registry.Get(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "download client not found")
+		return
+	}
+	if _, ok := c.(TorrentManager); !ok {
+		writeError(w, http.StatusBadRequest, "unsupported", "client is not a built-in torrent downloader")
+		return
+	}
+	if err := c.Resume(r.Context()); err != nil {
+		writeError(w, http.StatusBadGateway, "resume_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/downloads/torrent/client.go
+++ b/internal/downloads/torrent/client.go
@@ -63,6 +63,31 @@ func (c *Client) Detail(_ context.Context, id string) (any, error) {
 	return c.engine.Detail(id)
 }
 
+// EngineSummary implements downloads.TorrentManager.
+func (c *Client) EngineSummary() downloads.TorrentEngineSummary {
+	s := c.engine.Summary()
+	return downloads.TorrentEngineSummary{
+		TotalTorrents: s.TotalTorrents,
+		Downloading:   s.Downloading,
+		Seeding:       s.Seeding,
+		Paused:        s.Paused,
+		DownloadRate:  s.DownloadRate,
+		UploadRate:    s.UploadRate,
+		DownloadLimit: s.DownloadLimit,
+		UploadLimit:   s.UploadLimit,
+		ListenPort:    s.ListenPort,
+		DHT:           s.DHT,
+		PEX:           s.PEX,
+		UPnP:          s.UPnP,
+		SavePath:      s.SavePath,
+	}
+}
+
+// SetSpeedLimits implements downloads.TorrentManager.
+func (c *Client) SetSpeedLimits(downBytesPerSec, upBytesPerSec int64) {
+	c.engine.SetSpeedLimits(downBytesPerSec, upBytesPerSec)
+}
+
 // ID implements downloads.DownloadClient.
 func (c *Client) ID() string { return c.id }
 

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anacrolix/torrent"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/anacrolix/torrent/storage"
+	"golang.org/x/time/rate"
 )
 
 // metadataTimeout is how long we wait for a magnet's metadata to
@@ -52,17 +53,17 @@ type torrentMeta struct {
 
 // trackedTorrent pairs the anacrolix torrent handle with Loom metadata.
 type trackedTorrent struct {
-	t            *torrent.Torrent
-	title        string
-	category     string
-	savePath     string
-	addedAt      time.Time
-	seedStartAt  *time.Time
-	seedPolicy   SeedPolicy
-	paused       bool
-	movedToDest  bool  // true once files have been moved from IncompleteDir → DownloadDir
-	downloaded   int64 // snapshot for ratio calculation
-	uploaded     int64
+	t           *torrent.Torrent
+	title       string
+	category    string
+	savePath    string
+	addedAt     time.Time
+	seedStartAt *time.Time
+	seedPolicy  SeedPolicy
+	paused      bool
+	movedToDest bool  // true once files have been moved from IncompleteDir → DownloadDir
+	downloaded  int64 // snapshot for ratio calculation
+	uploaded    int64
 
 	// Speed tracking — computed from byte deltas between Status() calls.
 	lastSpeedSampleAt time.Time
@@ -82,6 +83,46 @@ type Engine struct {
 	items   map[string]*trackedTorrent // keyed by lowercase infohash hex
 	cancel  context.CancelFunc
 	dataDir string
+
+	// Live rate limiters shared with the anacrolix client config so the
+	// global download/upload caps can be changed at runtime.
+	downLimiter *rate.Limiter
+	upLimiter   *rate.Limiter
+}
+
+// rateLimiterBurst is the minimum token-bucket burst applied to a finite
+// rate limiter so individual piece requests are never starved.
+const rateLimiterBurst = 1 << 20 // 1 MiB
+
+// newRateLimiter builds a rate limiter for the given cap in bytes/sec.
+// A value <= 0 means unlimited.
+func newRateLimiter(bytesPerSec int64) *rate.Limiter {
+	if bytesPerSec <= 0 {
+		return rate.NewLimiter(rate.Inf, 0)
+	}
+	burst := bytesPerSec
+	if burst < rateLimiterBurst {
+		burst = rateLimiterBurst
+	}
+	return rate.NewLimiter(rate.Limit(bytesPerSec), int(burst))
+}
+
+// applyRateLimit updates a live limiter to the given cap in bytes/sec.
+func applyRateLimit(l *rate.Limiter, bytesPerSec int64) {
+	if l == nil {
+		return
+	}
+	if bytesPerSec <= 0 {
+		l.SetLimit(rate.Inf)
+		l.SetBurst(0)
+		return
+	}
+	burst := bytesPerSec
+	if burst < rateLimiterBurst {
+		burst = rateLimiterBurst
+	}
+	l.SetLimit(rate.Limit(bytesPerSec))
+	l.SetBurst(int(burst))
 }
 
 // NewEngine creates the anacrolix torrent client with the supplied
@@ -136,6 +177,13 @@ func NewEngine(cfg Config, logger *slog.Logger) (*Engine, error) {
 
 	tcfg.SetListenAddr(net.JoinHostPort("", fmt.Sprintf("%d", cfg.ListenPort)))
 
+	// Global speed caps. anacrolix throttles using these limiters; we keep
+	// references so the caps can be changed at runtime via SetSpeedLimits.
+	downLimiter := newRateLimiter(cfg.DownloadSpeedLimit)
+	upLimiter := newRateLimiter(cfg.UploadSpeedLimit)
+	tcfg.DownloadRateLimiter = downLimiter
+	tcfg.UploadRateLimiter = upLimiter
+
 	cl, err := torrent.NewClient(tcfg)
 	if err != nil {
 		_ = pc.Close()
@@ -148,14 +196,18 @@ func NewEngine(cfg Config, logger *slog.Logger) (*Engine, error) {
 		"dht", cfg.EnableDHT,
 		"pex", cfg.EnablePEX,
 		"upnp", cfg.EnableUPnP,
+		"download_limit", cfg.DownloadSpeedLimit,
+		"upload_limit", cfg.UploadSpeedLimit,
 	)
 
 	return &Engine{
-		client:  cl,
-		cfg:     cfg,
-		logger:  logger,
-		items:   make(map[string]*trackedTorrent),
-		dataDir: dataDir,
+		client:      cl,
+		cfg:         cfg,
+		logger:      logger,
+		items:       make(map[string]*trackedTorrent),
+		dataDir:     dataDir,
+		downLimiter: downLimiter,
+		upLimiter:   upLimiter,
 	}, nil
 }
 
@@ -346,6 +398,76 @@ func (e *Engine) Status(hashes ...string) []TorrentStatus {
 		out = append(out, e.buildStatus(tt))
 	}
 	return out
+}
+
+// EngineSummary aggregates the engine's live state for the management UI.
+type EngineSummary struct {
+	TotalTorrents int
+	Downloading   int
+	Seeding       int
+	Paused        int
+	DownloadRate  int64 // aggregate bytes/sec
+	UploadRate    int64 // aggregate bytes/sec
+	DownloadLimit int64 // bytes/sec, 0 = unlimited
+	UploadLimit   int64 // bytes/sec, 0 = unlimited
+	ListenPort    int
+	DHT           bool
+	PEX           bool
+	UPnP          bool
+	SavePath      string
+}
+
+// Summary returns an aggregate snapshot of the engine state.
+func (e *Engine) Summary() EngineSummary {
+	statuses := e.Status() // refreshes per-torrent rates; takes the lock itself
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	sum := EngineSummary{
+		TotalTorrents: len(statuses),
+		DownloadLimit: e.cfg.DownloadSpeedLimit,
+		UploadLimit:   e.cfg.UploadSpeedLimit,
+		ListenPort:    e.cfg.ListenPort,
+		DHT:           e.cfg.EnableDHT,
+		PEX:           e.cfg.EnablePEX,
+		UPnP:          e.cfg.EnableUPnP,
+		SavePath:      e.cfg.DownloadDir,
+	}
+	for _, s := range statuses {
+		sum.DownloadRate += s.DownloadRate
+		sum.UploadRate += s.UploadRate
+		switch s.Status {
+		case "paused":
+			sum.Paused++
+		case "seeding":
+			sum.Seeding++
+		default:
+			sum.Downloading++
+		}
+	}
+	return sum
+}
+
+// SetSpeedLimits updates the global download/upload caps (bytes/sec, 0 =
+// unlimited) on the running engine. The change takes effect immediately.
+func (e *Engine) SetSpeedLimits(downBytesPerSec, upBytesPerSec int64) {
+	if downBytesPerSec < 0 {
+		downBytesPerSec = 0
+	}
+	if upBytesPerSec < 0 {
+		upBytesPerSec = 0
+	}
+	e.mu.Lock()
+	e.cfg.DownloadSpeedLimit = downBytesPerSec
+	e.cfg.UploadSpeedLimit = upBytesPerSec
+	dl, ul := e.downLimiter, e.upLimiter
+	e.mu.Unlock()
+
+	applyRateLimit(dl, downBytesPerSec)
+	applyRateLimit(ul, upBytesPerSec)
+	e.logger.Info("engine speed limits updated",
+		"download_limit", downBytesPerSec, "upload_limit", upBytesPerSec)
 }
 
 // buildStatus creates a TorrentStatus snapshot from a trackedTorrent.

--- a/internal/downloads/torrent/ratelimit_test.go
+++ b/internal/downloads/torrent/ratelimit_test.go
@@ -1,0 +1,55 @@
+package torrent
+
+import (
+	"testing"
+
+	"golang.org/x/time/rate"
+)
+
+func TestNewRateLimiterUnlimited(t *testing.T) {
+	for _, v := range []int64{0, -1, -1024} {
+		l := newRateLimiter(v)
+		if l.Limit() != rate.Inf {
+			t.Fatalf("newRateLimiter(%d): expected Inf limit, got %v", v, l.Limit())
+		}
+	}
+}
+
+func TestNewRateLimiterFinite(t *testing.T) {
+	// Below the minimum burst: burst is clamped up to rateLimiterBurst.
+	l := newRateLimiter(1000)
+	if l.Limit() != rate.Limit(1000) {
+		t.Fatalf("expected limit 1000, got %v", l.Limit())
+	}
+	if l.Burst() != rateLimiterBurst {
+		t.Fatalf("expected burst %d, got %d", rateLimiterBurst, l.Burst())
+	}
+
+	// Above the minimum burst: burst equals the rate.
+	big := int64(4 << 20)
+	l = newRateLimiter(big)
+	if l.Burst() != int(big) {
+		t.Fatalf("expected burst %d, got %d", big, l.Burst())
+	}
+}
+
+func TestApplyRateLimit(t *testing.T) {
+	l := newRateLimiter(0) // start unlimited
+
+	applyRateLimit(l, 2000)
+	if l.Limit() != rate.Limit(2000) {
+		t.Fatalf("expected limit 2000, got %v", l.Limit())
+	}
+	if l.Burst() != rateLimiterBurst {
+		t.Fatalf("expected burst %d, got %d", rateLimiterBurst, l.Burst())
+	}
+
+	// Back to unlimited.
+	applyRateLimit(l, 0)
+	if l.Limit() != rate.Inf {
+		t.Fatalf("expected Inf limit after reset, got %v", l.Limit())
+	}
+
+	// Nil limiter must not panic.
+	applyRateLimit(nil, 1000)
+}

--- a/internal/downloads/types.go
+++ b/internal/downloads/types.go
@@ -16,13 +16,13 @@ type Kind string
 // Built-in kinds that ship with the downloads core. Real kinds land
 // in later phases and register themselves during their package init.
 const (
-	KindNull            Kind = "builtin/null"
-	KindBuiltinTorrent  Kind = "builtin/torrent"
-	KindQBittorrent     Kind = "qbittorrent"
-	KindTransmission    Kind = "transmission"
-	KindDeluge          Kind = "deluge"
-	KindSABnzbd         Kind = "sabnzbd"
-	KindNZBGet          Kind = "nzbget"
+	KindNull           Kind = "builtin/null"
+	KindBuiltinTorrent Kind = "builtin/torrent"
+	KindQBittorrent    Kind = "qbittorrent"
+	KindTransmission   Kind = "transmission"
+	KindDeluge         Kind = "deluge"
+	KindSABnzbd        Kind = "sabnzbd"
+	KindNZBGet         Kind = "nzbget"
 )
 
 // Protocol is the wire family the kind speaks. We model only torrent
@@ -117,7 +117,7 @@ type AddRequest struct {
 	// Media context — optional fields used to record grab linkage so the
 	// import pipeline can deterministically match completed downloads to
 	// the correct media item. Set by the interactive search dialog.
-	MediaType  string   `json:"media_type,omitempty"`  // "movie" or "episode"
+	MediaType  string   `json:"media_type,omitempty"` // "movie" or "episode"
 	SeriesID   string   `json:"series_id,omitempty"`
 	EpisodeIDs []string `json:"episode_ids,omitempty"`
 	MovieID    string   `json:"movie_id,omitempty"`
@@ -288,4 +288,33 @@ var ErrUnknownKind = errors.New("unknown download client kind")
 // (peers, files, trackers). The builtin/torrent kind implements this.
 type DetailProvider interface {
 	Detail(ctx context.Context, id string) (any, error)
+}
+
+// TorrentEngineSummary is an aggregate snapshot of the built-in torrent
+// engine, surfaced to the management UI.
+type TorrentEngineSummary struct {
+	TotalTorrents int    `json:"total_torrents"`
+	Downloading   int    `json:"downloading"`
+	Seeding       int    `json:"seeding"`
+	Paused        int    `json:"paused"`
+	DownloadRate  int64  `json:"download_rate"`  // aggregate bytes/sec
+	UploadRate    int64  `json:"upload_rate"`    // aggregate bytes/sec
+	DownloadLimit int64  `json:"download_limit"` // bytes/sec, 0 = unlimited
+	UploadLimit   int64  `json:"upload_limit"`   // bytes/sec, 0 = unlimited
+	ListenPort    int    `json:"listen_port"`
+	DHT           bool   `json:"dht"`
+	PEX           bool   `json:"pex"`
+	UPnP          bool   `json:"upnp"`
+	SavePath      string `json:"save_path"`
+}
+
+// TorrentManager is an optional interface implemented by the
+// builtin/torrent client to expose engine-level management: an aggregate
+// status summary and live global speed-limit control.
+type TorrentManager interface {
+	// EngineSummary returns an aggregate snapshot of the engine.
+	EngineSummary() TorrentEngineSummary
+	// SetSpeedLimits sets the global download/upload caps in bytes/sec.
+	// A value of 0 means unlimited. The change takes effect immediately.
+	SetSpeedLimits(downBytesPerSec, upBytesPerSec int64)
 }

--- a/web/src/lib/downloads-api.ts
+++ b/web/src/lib/downloads-api.ts
@@ -259,6 +259,61 @@ export async function grabRelease(
   );
 }
 
+// ---------- Built-in torrent engine management ----------
+
+export interface TorrentEngineSummary {
+  total_torrents: number;
+  downloading: number;
+  seeding: number;
+  paused: number;
+  download_rate: number; // aggregate bytes/sec
+  upload_rate: number; // aggregate bytes/sec
+  download_limit: number; // bytes/sec, 0 = unlimited
+  upload_limit: number; // bytes/sec, 0 = unlimited
+  listen_port: number;
+  dht: boolean;
+  pex: boolean;
+  upnp: boolean;
+  save_path: string;
+}
+
+export async function getTorrentStatus(
+  clientId: string,
+  signal?: AbortSignal,
+): Promise<TorrentEngineSummary> {
+  return request<TorrentEngineSummary>(
+    "GET",
+    `/api/v1/download-clients/${encodeURIComponent(clientId)}/torrent/status`,
+    undefined,
+    signal,
+  );
+}
+
+export async function setTorrentSpeedLimits(
+  clientId: string,
+  body: { download_limit: number; upload_limit: number },
+): Promise<TorrentEngineSummary> {
+  return request<TorrentEngineSummary>(
+    "POST",
+    `/api/v1/download-clients/${encodeURIComponent(clientId)}/torrent/speed-limits`,
+    body,
+  );
+}
+
+export async function torrentPauseAll(clientId: string): Promise<void> {
+  await request<void>(
+    "POST",
+    `/api/v1/download-clients/${encodeURIComponent(clientId)}/torrent/pause-all`,
+  );
+}
+
+export async function torrentResumeAll(clientId: string): Promise<void> {
+  await request<void>(
+    "POST",
+    `/api/v1/download-clients/${encodeURIComponent(clientId)}/torrent/resume-all`,
+  );
+}
+
 // ---------- React Query hooks ----------
 
 /**
@@ -350,6 +405,76 @@ export function useGrabRelease() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: downloadKeys.all });
       qc.invalidateQueries({ queryKey: ["movies"] });
+    },
+  });
+}
+
+// ---------- Built-in torrent engine hooks ----------
+
+export const torrentEngineKeys = {
+  status: (id: string) => [...downloadKeys.all, "torrent-status", id] as const,
+};
+
+/**
+ * Poll the built-in torrent engine status. Only enabled when a clientId is
+ * supplied for a builtin/torrent client.
+ */
+export function useTorrentStatus(
+  clientId: string | undefined,
+  options?: Omit<
+    UseQueryOptions<TorrentEngineSummary, Error>,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useQuery<TorrentEngineSummary, Error>({
+    queryKey: torrentEngineKeys.status(clientId ?? ""),
+    queryFn: ({ signal }) => getTorrentStatus(clientId as string, signal),
+    enabled: !!clientId,
+    refetchInterval: 5000,
+    ...options,
+  });
+}
+
+export function useSetTorrentSpeedLimits() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      download_limit,
+      upload_limit,
+    }: {
+      clientId: string;
+      download_limit: number;
+      upload_limit: number;
+    }) => setTorrentSpeedLimits(clientId, { download_limit, upload_limit }),
+    onSuccess: (data, { clientId }) => {
+      // Seed the status cache with the authoritative summary the server
+      // returned so the panel reflects the new limits immediately.
+      qc.setQueryData(torrentEngineKeys.status(clientId), data);
+      qc.invalidateQueries({ queryKey: torrentEngineKeys.status(clientId) });
+      qc.invalidateQueries({ queryKey: downloadKeys.all });
+    },
+  });
+}
+
+export function useTorrentPauseAll() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (clientId: string) => torrentPauseAll(clientId),
+    onSuccess: (_data, clientId) => {
+      qc.invalidateQueries({ queryKey: torrentEngineKeys.status(clientId) });
+      qc.invalidateQueries({ queryKey: downloadKeys.all });
+    },
+  });
+}
+
+export function useTorrentResumeAll() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (clientId: string) => torrentResumeAll(clientId),
+    onSuccess: (_data, clientId) => {
+      qc.invalidateQueries({ queryKey: torrentEngineKeys.status(clientId) });
+      qc.invalidateQueries({ queryKey: downloadKeys.all });
     },
   });
 }

--- a/web/src/pages/downloads.tsx
+++ b/web/src/pages/downloads.tsx
@@ -18,15 +18,25 @@ import {
   FileText,
   Radio,
   Info,
+  Gauge,
 } from "lucide-react";
 import { apiFetch } from "@/lib/fetch";
 import { useSetPageHeader } from "@/hooks/use-page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
 import { ImportManager } from "@/components/imports/import-manager";
+import {
+  useDownloads,
+  useTorrentStatus,
+  useSetTorrentSpeedLimits,
+  useTorrentPauseAll,
+  useTorrentResumeAll,
+} from "@/lib/downloads-api";
 import { toast } from "sonner";
 import {
   Sheet,
@@ -736,6 +746,214 @@ function ActiveDownloads() {
   );
 }
 
+// ─── Built-in Torrent Engine Panel ──────────────────────────────────────
+
+const MB = 1024 * 1024;
+
+function bytesToMbInput(bytes: number): string {
+  if (!bytes || bytes <= 0) return "0";
+  // Show up to 2 decimals, trimming trailing zeros.
+  return String(Math.round((bytes / MB) * 100) / 100);
+}
+
+function StatPill({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wide text-zinc-500">
+        {label}
+      </span>
+      <span className="text-sm font-medium text-zinc-100 tabular-nums">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function TorrentEnginePanel() {
+  const { data: clients } = useDownloads();
+  const torrentClient = React.useMemo(
+    () => clients?.find((c) => c.kind === "builtin/torrent" && c.enabled),
+    [clients],
+  );
+  const clientId = torrentClient?.id;
+
+  const { data: summary } = useTorrentStatus(clientId, {
+    // Keep showing the last value while the engine briefly errors.
+    retry: false,
+  });
+  const setLimits = useSetTorrentSpeedLimits();
+  const pauseAll = useTorrentPauseAll();
+  const resumeAll = useTorrentResumeAll();
+
+  const [downInput, setDownInput] = React.useState("0");
+  const [upInput, setUpInput] = React.useState("0");
+  const [dirty, setDirty] = React.useState(false);
+
+  // Sync editable inputs from the server value until the user edits them.
+  React.useEffect(() => {
+    if (!summary || dirty) return;
+    setDownInput(bytesToMbInput(summary.download_limit));
+    setUpInput(bytesToMbInput(summary.upload_limit));
+  }, [summary, dirty]);
+
+  if (!clientId) return null;
+
+  const applyLimits = () => {
+    const down = Math.max(0, Math.round(parseFloat(downInput || "0") * MB)) || 0;
+    const up = Math.max(0, Math.round(parseFloat(upInput || "0") * MB)) || 0;
+    setLimits.mutate(
+      { clientId, download_limit: down, upload_limit: up },
+      {
+        onSuccess: (data) => {
+          // Reflect the server's authoritative values, then unfreeze polling.
+          setDownInput(bytesToMbInput(data.download_limit));
+          setUpInput(bytesToMbInput(data.upload_limit));
+          setDirty(false);
+          toast.success("Speed limits updated");
+        },
+        onError: (e) => toast.error(e instanceof Error ? e.message : "Failed to update limits"),
+      },
+    );
+  };
+
+  return (
+    <Card className="bg-zinc-900/50 border-zinc-800">
+      <CardContent className="space-y-4 pt-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Gauge className="h-4 w-4 text-zinc-400" />
+            <span className="text-sm font-medium text-zinc-100">
+              Built-in Torrent Engine
+            </span>
+            <Badge variant="outline" className="text-[10px] text-zinc-400 border-zinc-700">
+              {torrentClient?.name}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              disabled={pauseAll.isPending}
+              onClick={() =>
+                pauseAll.mutate(clientId, {
+                  onSuccess: () => toast.success("All torrents paused"),
+                  onError: (e) => toast.error(e instanceof Error ? e.message : "Pause failed"),
+                })
+              }
+            >
+              <Pause className="h-3.5 w-3.5 mr-1.5" />
+              Pause all
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8"
+              disabled={resumeAll.isPending}
+              onClick={() =>
+                resumeAll.mutate(clientId, {
+                  onSuccess: () => toast.success("All torrents resumed"),
+                  onError: (e) => toast.error(e instanceof Error ? e.message : "Resume failed"),
+                })
+              }
+            >
+              <Play className="h-3.5 w-3.5 mr-1.5" />
+              Resume all
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4 lg:grid-cols-6">
+          <StatPill label="Torrents" value={summary?.total_torrents ?? "—"} />
+          <StatPill label="Downloading" value={summary?.downloading ?? "—"} />
+          <StatPill label="Seeding" value={summary?.seeding ?? "—"} />
+          <StatPill label="Paused" value={summary?.paused ?? "—"} />
+          <StatPill
+            label="Down rate"
+            value={
+              <span className="flex items-center gap-1 text-blue-400">
+                <ArrowDown className="h-3 w-3" />
+                {formatSpeed(summary?.download_rate ?? 0)}
+              </span>
+            }
+          />
+          <StatPill
+            label="Up rate"
+            value={
+              <span className="flex items-center gap-1 text-green-400">
+                <ArrowUp className="h-3 w-3" />
+                {formatSpeed(summary?.upload_rate ?? 0)}
+              </span>
+            }
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-zinc-500">
+          <span>
+            Port <span className="text-zinc-300 tabular-nums">{summary?.listen_port ?? "—"}</span>
+          </span>
+          <span className={summary?.dht ? "text-zinc-300" : "text-zinc-600"}>DHT</span>
+          <span className={summary?.pex ? "text-zinc-300" : "text-zinc-600"}>PEX</span>
+          <span className={summary?.upnp ? "text-zinc-300" : "text-zinc-600"}>UPnP</span>
+          {summary?.save_path && (
+            <span className="truncate">
+              Save path <span className="font-mono text-zinc-300">{summary.save_path}</span>
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-end gap-4 border-t border-zinc-800 pt-4">
+          <div className="space-y-1">
+            <Label htmlFor="torrent-down-limit" className="text-[11px] text-zinc-400">
+              Download limit (MB/s, 0 = unlimited)
+            </Label>
+            <Input
+              id="torrent-down-limit"
+              type="number"
+              min={0}
+              step="0.1"
+              value={downInput}
+              onChange={(e) => {
+                setDownInput(e.target.value);
+                setDirty(true);
+              }}
+              className="h-8 w-40"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="torrent-up-limit" className="text-[11px] text-zinc-400">
+              Upload limit (MB/s, 0 = unlimited)
+            </Label>
+            <Input
+              id="torrent-up-limit"
+              type="number"
+              min={0}
+              step="0.1"
+              value={upInput}
+              onChange={(e) => {
+                setUpInput(e.target.value);
+                setDirty(true);
+              }}
+              className="h-8 w-40"
+            />
+          </div>
+          <Button
+            size="sm"
+            className="h-8"
+            disabled={!dirty || setLimits.isPending}
+            onClick={applyLimits}
+          >
+            {setLimits.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            ) : null}
+            Apply limits
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── Downloads Page ─────────────────────────────────────────────────────
 
 export function DownloadsPage() {
@@ -754,7 +972,8 @@ export function DownloadsPage() {
             Imports
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="active">
+        <TabsContent value="active" className="space-y-4">
+          <TorrentEnginePanel />
           <ActiveDownloads />
         </TabsContent>
         <TabsContent value="imports">


### PR DESCRIPTION
Closes #2.

Adds engine-level management for the built-in anacrolix torrent client.

## Backend
- **Bug fix:** `NewEngine` never wired `DownloadRateLimiter`/`UploadRateLimiter`, so configured speed limits were silently ignored. Now wired with live limiter references.
- `Engine.Summary()` aggregate snapshot; `Engine.SetSpeedLimits()` live update (unlimited = `rate.Inf`).
- `TorrentManager` optional interface implemented by the `builtin/torrent` Client.
- 4 endpoints under `/api/v1/download-clients/{id}`: `torrent/status`, `torrent/speed-limits` (applies live + persists to config for cold start), `torrent/pause-all`, `torrent/resume-all`. Non-torrent clients get 400.
- Unit tests for the rate-limiter helpers.

## Frontend
- `TorrentEnginePanel` on the Downloads page: renders only when an enabled `builtin/torrent` client exists. Polls status (5s), shows counts/rates/port/DHT/PEX/UPnP/save path, editable MB/s limits (0 = unlimited, applied live + persisted), and Pause/Resume all.

## Verification
- `CGO_ENABLED=0 go build/vet/test ./internal/downloads/...` pass.
- Frontend `tsc -b` + `pnpm build` pass.

Note: CI has pre-existing macOS/Windows test-compile failures unrelated to this change.