### PR TITLE
feat(cleanup): downloads orphan cleanup tool (#5)

### DIFF
--- a/cmd/loom/cleanup.go
+++ b/cmd/loom/cleanup.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/appconfig"
+	"github.com/ebenderooock/loom/internal/cleanup"
+	"github.com/ebenderooock/loom/internal/downloads"
+	"github.com/ebenderooock/loom/internal/imports"
+	"github.com/ebenderooock/loom/internal/kernel/scheduler"
+	"github.com/ebenderooock/loom/internal/libraries"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+// cleanupJobName is the scheduler key for the periodic downloads-cleanup sweep.
+const cleanupJobName = "downloads-cleanup"
+
+// cleanupSchedule runs the sweep every 6 hours.
+const cleanupSchedule = "0 */6 * * *"
+
+// buildCleanupService wires the downloads-cleanup service. Its scan roots come
+// from each enabled download client's effective save folder; its tracked-path
+// set unions active downloads and recent import sources; and deletion routes
+// through the import recycle bin when configured.
+func buildCleanupService(
+	db storage.DB,
+	dlSvc *downloads.Service,
+	pipeline *imports.ImportPipeline,
+	libStore *libraries.Store,
+	appCfg *appconfig.Config,
+	logger *slog.Logger,
+) *cleanup.Service {
+	store := cleanup.NewStore(db.DB())
+	rb := imports.NewRecycleBin(appCfg)
+
+	roots := func(ctx context.Context) ([]cleanup.Root, error) {
+		defs, err := dlSvc.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		seen := make(map[string]bool)
+		var out []cleanup.Root
+		for _, d := range defs {
+			if !d.Enabled {
+				continue
+			}
+			root := d.SavePathDefault
+			// The built-in torrent engine knows its effective download dir,
+			// which may differ from the persisted save_path_default.
+			if c, ok := dlSvc.Registry().Get(d.ID); ok {
+				if tm, ok := c.(downloads.TorrentManager); ok {
+					if sp := tm.EngineSummary().SavePath; sp != "" {
+						root = sp
+					}
+				}
+			}
+			if root == "" || seen[root] {
+				continue
+			}
+			seen[root] = true
+			out = append(out, cleanup.Root{Path: root, ClientID: d.ID, ClientName: d.Name})
+		}
+		return out, nil
+	}
+
+	tracked := func(ctx context.Context) ([]string, error) {
+		// Active downloads are mandatory: without them we cannot safely
+		// classify orphans. If any client's status query failed the set is
+		// incomplete, so abort the scan/delete rather than risk treating a
+		// live download from an unreachable client as an orphan.
+		active, complete := dlSvc.TrackedDownloadPaths(ctx)
+		if !complete {
+			return nil, fmt.Errorf("download client status incomplete; skipping cleanup to avoid deleting live downloads")
+		}
+		paths := append([]string(nil), active...)
+		// Recent import source paths protect files mid-import or just imported.
+		if pipeline != nil {
+			if recs, err := pipeline.ListHistory(ctx, 1000, 0); err == nil {
+				for _, r := range recs {
+					if r != nil && r.SourcePath != "" {
+						paths = append(paths, r.SourcePath)
+					}
+				}
+			} else {
+				logger.Warn("cleanup: import history lookup failed", "err", err)
+			}
+		}
+		return paths, nil
+	}
+
+	// protected resolves media library roots. Any download root or orphan that
+	// overlaps one of these is never scanned or deleted. A lookup error aborts
+	// the operation so library content can never be misclassified.
+	protected := func(ctx context.Context) ([]string, error) {
+		if libStore == nil {
+			return nil, nil
+		}
+		libs, err := libStore.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var paths []string
+		for _, l := range libs {
+			if l.Path != "" {
+				paths = append(paths, l.Path)
+			}
+		}
+		return paths, nil
+	}
+
+	recycle := func(_ context.Context, path, _ string) error {
+		return cleanupRemove(rb, path)
+	}
+
+	return cleanup.NewService(cleanup.Options{
+		Store:     store,
+		Roots:     roots,
+		Tracked:   tracked,
+		Protected: protected,
+		Recycle:   recycle,
+		Logger:    logger,
+	})
+}
+
+// cleanupRemove recycles an orphan entry (file or directory) into the recycle
+// bin when one is configured, otherwise deletes it. It never silently falls
+// back to deletion when recycling is requested but fails — the error surfaces
+// so the user can investigate.
+func cleanupRemove(rb *imports.RecycleBin, path string) error {
+	if rb != nil && rb.Enabled && rb.Path != "" {
+		dest := filepath.Join(rb.Path, "downloads-cleanup",
+			fmt.Sprintf("%d_%s", time.Now().UnixNano(), filepath.Base(path)))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		return os.Rename(path, dest)
+	}
+	return os.RemoveAll(path)
+}
+
+// registerCleanupJob hooks the periodic scan + auto-delete sweep into the
+// scheduler.
+func registerCleanupJob(ctx context.Context, sched *scheduler.Scheduler, svc *cleanup.Service) error {
+	handler := func(ctx context.Context) error {
+		if _, err := svc.Scan(ctx); err != nil {
+			return err
+		}
+		if _, err := svc.AutoDelete(ctx); err != nil {
+			return err
+		}
+		return nil
+	}
+	return sched.Register(ctx, cleanupJobName, cleanupSchedule, handler, []byte(`{"builtin":true}`))
+}

--- a/cmd/loom/serve.go
+++ b/cmd/loom/serve.go
@@ -15,13 +15,13 @@ import (
 	"github.com/ebenderooock/loom/internal/auditlog"
 	"github.com/ebenderooock/loom/internal/backup"
 	"github.com/ebenderooock/loom/internal/customformats"
-	"github.com/ebenderooock/loom/internal/kernel/eventbus"
-	"github.com/ebenderooock/loom/internal/migrate"
-	"github.com/ebenderooock/loom/internal/rss"
 	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
 	"github.com/ebenderooock/loom/internal/kernel/logging"
 	"github.com/ebenderooock/loom/internal/kernel/scheduler"
 	"github.com/ebenderooock/loom/internal/kernel/telemetry"
+	"github.com/ebenderooock/loom/internal/migrate"
+	"github.com/ebenderooock/loom/internal/rss"
 	"github.com/ebenderooock/loom/internal/server"
 	"github.com/ebenderooock/loom/internal/storage"
 	"github.com/ebenderooock/loom/internal/systemlogs"
@@ -216,6 +216,13 @@ func cmdServe(ctx context.Context, args []string) error {
 	defer dlWiring.importPipeline.Stop()
 	defer dlWiring.monitorCancel()
 	defer dlWiring.orchestratorCancel()
+
+	// Wire downloads-cleanup (scan orphans in download folders + auto-delete).
+	cleanupSvc := buildCleanupService(db, downloadSvc, dlWiring.importPipeline, media.libStore, appCfg, logger)
+	srv.SetCleanup(cleanupSvc)
+	if err := registerCleanupJob(ctx, sched, cleanupSvc); err != nil {
+		return fmt.Errorf("register cleanup job: %w", err)
+	}
 
 	// Wire infrastructure services (connect, compat, notifications, rolling search, health)
 	infra, err := wireInfra(ctx, db, srv, indexerSvc, downloadSvc, moviesSvc, media, auditLogger, logger)

--- a/internal/cleanup/handlers.go
+++ b/internal/cleanup/handlers.go
@@ -1,0 +1,107 @@
+package cleanup
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Router returns a chi.Router exposing the cleanup endpoints. It is mounted
+// under /api/v1/cleanup by the server.
+func Router(svc *Service) chi.Router {
+	r := chi.NewRouter()
+	r.Get("/orphans", svc.handleListOrphans)
+	r.Post("/scan", svc.handleScan)
+	r.Get("/settings", svc.handleGetSettings)
+	r.Put("/settings", svc.handleSaveSettings)
+	r.Post("/orphans/{id}/approve", svc.handleApprove)
+	r.Post("/orphans/{id}/ignore", svc.handleIgnore)
+	return r
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    http.StatusText(status),
+			"message": msg,
+		},
+	})
+}
+
+func (s *Service) handleListOrphans(w http.ResponseWriter, r *http.Request) {
+	status := OrphanStatus(r.URL.Query().Get("status"))
+	if status == "" {
+		status = StatusPending
+	}
+	if status == "all" {
+		status = ""
+	}
+	orphans, err := s.store.List(r.Context(), status)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if orphans == nil {
+		orphans = []Orphan{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": orphans})
+}
+
+func (s *Service) handleScan(w http.ResponseWriter, r *http.Request) {
+	found, err := s.Scan(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"found": found})
+}
+
+func (s *Service) handleGetSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := s.store.GetSettings(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, settings)
+}
+
+func (s *Service) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
+	var settings Settings
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if err := s.store.SaveSettings(r.Context(), settings); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	saved, _ := s.store.GetSettings(r.Context())
+	writeJSON(w, http.StatusOK, saved)
+}
+
+func (s *Service) handleApprove(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.Approve(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+}
+
+func (s *Service) handleIgnore(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.Ignore(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"status": "ignored"})
+}

--- a/internal/cleanup/path_test.go
+++ b/internal/cleanup/path_test.go
@@ -1,0 +1,72 @@
+package cleanup
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestIsWithin(t *testing.T) {
+	sep := string(filepath.Separator)
+	base := sep + "downloads"
+	cases := []struct {
+		parent, child string
+		want          bool
+	}{
+		{base, base, true},
+		{base, filepath.Join(base, "Movie"), true},
+		{base, filepath.Join(base, "tv", "Show", "ep.mkv"), true},
+		{filepath.Join(base, "Movie"), filepath.Join(base, "Movie 2"), false}, // sibling, not prefix
+		{filepath.Join(base, "Movie"), base, false},                           // child is parent
+		{base, sep + "other", false},
+		{"", base, false},
+		{base, "", false},
+	}
+	for _, c := range cases {
+		if got := isWithin(c.parent, c.child); got != c.want {
+			t.Errorf("isWithin(%q,%q)=%v want %v", c.parent, c.child, got, c.want)
+		}
+	}
+}
+
+func TestIsProtected(t *testing.T) {
+	sep := string(filepath.Separator)
+	dl := sep + "downloads"
+	tracked := []string{
+		filepath.Join(dl, "tv", "Show S01", "ep01.mkv"), // active download content
+		filepath.Join(dl, "Movie (2024)"),               // active download (single dir)
+	}
+
+	cases := []struct {
+		name  string
+		entry string
+		want  bool
+	}{
+		// A category dir that CONTAINS a tracked download must be protected,
+		// even though the category dir itself is not a tracked path.
+		{"category dir holding tracked content", filepath.Join(dl, "tv"), true},
+		// The tracked download dir itself.
+		{"tracked movie dir", filepath.Join(dl, "Movie (2024)"), true},
+		// A file inside a tracked dir.
+		{"file under tracked movie", filepath.Join(dl, "Movie (2024)", "movie.mkv"), true},
+		// A genuine orphan: unrelated sibling.
+		{"unrelated orphan", filepath.Join(dl, "old-junk"), false},
+		// Sibling with shared prefix must NOT be protected.
+		{"prefix-sibling not protected", filepath.Join(dl, "Movie (2024) extras"), false},
+	}
+	for _, c := range cases {
+		if got := isProtected(c.entry, tracked); got != c.want {
+			t.Errorf("%s: isProtected(%q)=%v want %v", c.name, c.entry, got, c.want)
+		}
+	}
+}
+
+func TestUnderAnyRoot(t *testing.T) {
+	sep := string(filepath.Separator)
+	roots := []string{sep + "downloads", sep + "data" + sep + "torrents"}
+	if !underAnyRoot(filepath.Join(sep+"downloads", "x"), roots) {
+		t.Error("expected path under /downloads to be under a root")
+	}
+	if underAnyRoot(sep+"elsewhere"+sep+"x", roots) {
+		t.Error("did not expect /elsewhere/x to be under a root")
+	}
+}

--- a/internal/cleanup/scanner.go
+++ b/internal/cleanup/scanner.go
@@ -1,0 +1,317 @@
+package cleanup
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// RootsFunc resolves the current set of download folders to scan, one per
+// enabled download client.
+type RootsFunc func(ctx context.Context) ([]Root, error)
+
+// TrackedPathsFunc returns every on-disk path currently tracked by a download
+// client (active downloads) or an in-progress/recent import. Any orphan
+// candidate that equals, contains, or is contained by one of these is protected.
+type TrackedPathsFunc func(ctx context.Context) ([]string, error)
+
+// ProtectedPathsFunc returns paths that must never be scanned or deleted —
+// primarily media library roots. Any download root or orphan candidate that
+// overlaps one of these (equals, sits inside, or contains it) is excluded.
+type ProtectedPathsFunc func(ctx context.Context) ([]string, error)
+
+// RecycleFunc removes a single orphan entry (file or directory). Implementations
+// should prefer recoverable removal (recycle bin) over hard deletion.
+type RecycleFunc func(ctx context.Context, path, root string) error
+
+// Service coordinates scanning, review, and deletion of download orphans.
+type Service struct {
+	store     *Store
+	roots     RootsFunc
+	tracked   TrackedPathsFunc
+	protected ProtectedPathsFunc
+	recycle   RecycleFunc
+	logger    *slog.Logger
+	mu        sync.Mutex // serializes scans and deletes
+	skipNames map[string]bool
+}
+
+// Options configures a cleanup Service.
+type Options struct {
+	Store     *Store
+	Roots     RootsFunc
+	Tracked   TrackedPathsFunc
+	Protected ProtectedPathsFunc
+	Recycle   RecycleFunc
+	Logger    *slog.Logger
+}
+
+// NewService constructs a cleanup Service.
+func NewService(opts Options) *Service {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		store:     opts.Store,
+		roots:     opts.Roots,
+		tracked:   opts.Tracked,
+		protected: opts.Protected,
+		recycle:   opts.Recycle,
+		logger:    logger,
+		// Skip the import recycle/incomplete bookkeeping dirs and junk we
+		// should never flag or remove.
+		skipNames: map[string]bool{
+			".loom-cleanup": true,
+			".incomplete":   true,
+			"incomplete":    true,
+		},
+	}
+}
+
+// Store exposes the underlying store for read-only handlers.
+func (s *Service) Store() *Store { return s.store }
+
+// protectedPaths resolves the configured protected (e.g. media library) paths.
+// A resolution error is fatal to any destructive operation: callers must abort
+// rather than risk treating a library entry as an orphan.
+func (s *Service) protectedPaths(ctx context.Context) ([]string, error) {
+	if s.protected == nil {
+		return nil, nil
+	}
+	return s.protected(ctx)
+}
+
+// rootIsSafe reports whether a download root may be scanned/deleted within. A
+// root that overlaps any protected (library) path in either direction is unsafe
+// and is skipped entirely.
+func rootIsSafe(rootPath string, protected []string) bool {
+	return !isProtected(rootPath, protected)
+}
+
+// Scan walks every download root, classifies top-level entries, records new
+// orphans, and resolves entries that are no longer orphaned. It never deletes.
+func (s *Service) Scan(ctx context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.scanLocked(ctx)
+}
+
+func (s *Service) scanLocked(ctx context.Context) (int, error) {
+	roots, err := s.roots(ctx)
+	if err != nil {
+		return 0, err
+	}
+	tracked, err := s.tracked(ctx)
+	if err != nil {
+		// Without the tracked set we cannot safely classify anything.
+		return 0, err
+	}
+	protected, err := s.protectedPaths(ctx)
+	if err != nil {
+		// Without the library set we cannot guarantee we won't flag library
+		// content, so abort.
+		return 0, err
+	}
+
+	seen := make(map[string]bool)
+	found := 0
+	for _, root := range roots {
+		rootPath := normPath(root.Path)
+		if rootPath == "" {
+			continue
+		}
+		if !rootIsSafe(rootPath, protected) {
+			s.logger.Warn("cleanup: skipping download root that overlaps a media library", "root", rootPath)
+			continue
+		}
+		entries, err := os.ReadDir(rootPath)
+		if err != nil {
+			s.logger.Warn("cleanup: cannot read download root", "root", rootPath, "err", err)
+			continue
+		}
+		for _, e := range entries {
+			name := e.Name()
+			if s.skipNames[name] {
+				continue
+			}
+			full := filepath.Join(rootPath, name)
+			// Never follow symlinks — an orphan symlink could point into a
+			// media library. Skip them entirely so we never recurse or delete
+			// across the link.
+			info, err := os.Lstat(full)
+			if err != nil {
+				continue
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				continue
+			}
+			if isProtected(full, tracked) {
+				continue
+			}
+			seen[full] = true
+			found++
+			if err := s.store.Upsert(ctx, Orphan{
+				Path:      full,
+				ClientID:  root.ClientID,
+				Root:      rootPath,
+				SizeBytes: entrySize(full),
+			}); err != nil {
+				s.logger.Warn("cleanup: upsert orphan failed", "path", full, "err", err)
+			}
+		}
+	}
+
+	if err := s.store.ResolveStalePending(ctx, seen); err != nil {
+		s.logger.Warn("cleanup: resolving stale orphans failed", "err", err)
+	}
+	return found, nil
+}
+
+// AutoDelete recycles pending orphans older than the retention period, when
+// auto-delete is enabled. Each candidate is revalidated immediately before
+// removal. Returns the number of entries deleted.
+func (s *Service) AutoDelete(ctx context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	settings, err := s.store.GetSettings(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !settings.AutoDeleteEnabled {
+		return 0, nil
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(settings.RetentionDays) * 24 * time.Hour)
+
+	pending, err := s.store.List(ctx, StatusPending)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, o := range pending {
+		if o.FirstSeenAt.IsZero() || o.FirstSeenAt.After(cutoff) {
+			continue
+		}
+		ok, err := s.removeLocked(ctx, o)
+		if err != nil {
+			s.logger.Warn("cleanup: auto-delete failed", "path", o.Path, "err", err)
+			continue
+		}
+		if ok {
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// Approve immediately recycles a single orphan after revalidation.
+func (s *Service) Approve(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	o, err := s.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	_, err = s.removeLocked(ctx, o)
+	return err
+}
+
+// Ignore marks an orphan to be kept permanently.
+func (s *Service) Ignore(ctx context.Context, id string) error {
+	return s.store.MarkIgnored(ctx, id)
+}
+
+// removeLocked revalidates an orphan against the current download/import state
+// and roots, then recycles it. The caller must hold s.mu. It returns
+// (deleted, error); deleted is false when the orphan resolved itself.
+func (s *Service) removeLocked(ctx context.Context, o Orphan) (bool, error) {
+	roots, err := s.roots(ctx)
+	if err != nil {
+		return false, err
+	}
+	tracked, err := s.tracked(ctx)
+	if err != nil {
+		return false, err
+	}
+	protected, err := s.protectedPaths(ctx)
+	if err != nil {
+		return false, err
+	}
+	rootPaths := make([]string, 0, len(roots))
+	for _, r := range roots {
+		rootPaths = append(rootPaths, r.Path)
+	}
+
+	// Revalidate: still inside a download root, still untracked, still present,
+	// and not overlapping a protected media library.
+	if !underAnyRoot(o.Path, rootPaths) {
+		return false, s.store.Delete(ctx, o.ID)
+	}
+	if isProtected(o.Path, protected) {
+		// A library now overlaps this path — never delete; drop the record.
+		s.logger.Warn("cleanup: refusing to delete orphan overlapping a media library", "path", o.Path)
+		return false, s.store.Delete(ctx, o.ID)
+	}
+	if isProtected(o.Path, tracked) {
+		return false, s.store.Delete(ctx, o.ID)
+	}
+	info, err := os.Lstat(o.Path)
+	if os.IsNotExist(err) {
+		return false, s.store.Delete(ctx, o.ID)
+	}
+	if err != nil {
+		return false, s.store.MarkFailed(ctx, o.ID, err.Error())
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		// Should never reach here (scan skips symlinks) but guard anyway.
+		return false, s.store.Delete(ctx, o.ID)
+	}
+
+	if err := s.recycle(ctx, o.Path, o.Root); err != nil {
+		_ = s.store.MarkFailed(ctx, o.ID, err.Error())
+		return false, err
+	}
+	if err := s.store.MarkDeleted(ctx, o.ID); err != nil {
+		return true, err
+	}
+	s.logger.Info("cleanup: removed orphan", "path", o.Path, "size", o.SizeBytes)
+	return true, nil
+}
+
+// entrySize returns the total size of a file, or the recursive size of a
+// directory. It never follows symlinks and tolerates partial walk errors.
+func entrySize(path string) int64 {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return 0
+	}
+	if !info.IsDir() {
+		return info.Size()
+	}
+	var total int64
+	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !fi.IsDir() {
+			total += fi.Size()
+		}
+		return nil
+	})
+	return total
+}

--- a/internal/cleanup/scanner_test.go
+++ b/internal/cleanup/scanner_test.go
@@ -1,0 +1,411 @@
+package cleanup
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "loom.db")},
+	}
+	db, err := storage.Open(context.Background(), cfg,
+		slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return db.DB()
+}
+
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mkfile(t *testing.T, path string) {
+	t.Helper()
+	mkdir(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// buildScenario creates a download root with a protected category dir holding a
+// tracked download, plus a genuine orphan, and returns a wired Service.
+func buildScenario(t *testing.T) (*Service, string, string) {
+	t.Helper()
+	db := openTestDB(t)
+	store := NewStore(db)
+
+	root := t.TempDir()
+	// Tracked download nested under a category dir — the category dir must be
+	// protected because it contains tracked content.
+	trackedFile := filepath.Join(root, "tv", "Show S01", "ep01.mkv")
+	mkfile(t, trackedFile)
+	// A genuine orphan directory with junk.
+	orphanDir := filepath.Join(root, "old-release")
+	mkfile(t, filepath.Join(orphanDir, "junk.nfo"))
+
+	svc := NewService(Options{
+		Store: store,
+		Roots: func(context.Context) ([]Root, error) {
+			return []Root{{Path: root, ClientID: "c1", ClientName: "test"}}, nil
+		},
+		Tracked: func(context.Context) ([]string, error) {
+			return []string{filepath.Join(root, "tv", "Show S01")}, nil
+		},
+		Recycle: func(_ context.Context, path, _ string) error {
+			return os.RemoveAll(path)
+		},
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	return svc, orphanDir, filepath.Join(root, "tv")
+}
+
+func TestScanFlagsOnlyOrphans(t *testing.T) {
+	svc, orphanDir, categoryDir := buildScenario(t)
+	ctx := context.Background()
+
+	found, err := svc.Scan(ctx)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if found != 1 {
+		t.Fatalf("expected exactly 1 orphan, got %d", found)
+	}
+
+	pending, err := svc.store.List(ctx, StatusPending)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending row, got %d", len(pending))
+	}
+	if pending[0].Path != orphanDir {
+		t.Fatalf("orphan path = %q, want %q", pending[0].Path, orphanDir)
+	}
+	if pending[0].SizeBytes <= 0 {
+		t.Errorf("expected non-zero orphan size, got %d", pending[0].SizeBytes)
+	}
+
+	// The category dir holding tracked content must never be flagged.
+	if _, err := os.Stat(categoryDir); err != nil {
+		t.Fatalf("category dir should still exist: %v", err)
+	}
+}
+
+func TestScanIsIdempotent(t *testing.T) {
+	svc, _, _ := buildScenario(t)
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := svc.store.List(ctx, StatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("rescan should not duplicate rows, got %d", len(pending))
+	}
+}
+
+func TestApproveRecyclesOrphan(t *testing.T) {
+	svc, orphanDir, _ := buildScenario(t)
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := svc.store.List(ctx, StatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 orphan, got %d", len(pending))
+	}
+
+	if err := svc.Approve(ctx, pending[0].ID); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Fatalf("orphan dir should be removed, stat err=%v", err)
+	}
+	deleted, _ := svc.store.List(ctx, StatusDeleted)
+	if len(deleted) != 1 {
+		t.Fatalf("expected 1 deleted row, got %d", len(deleted))
+	}
+}
+
+func TestScanResolvesVanishedOrphan(t *testing.T) {
+	svc, orphanDir, _ := buildScenario(t)
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// Remove the orphan out-of-band, then rescan: the row should resolve away.
+	if err := os.RemoveAll(orphanDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := svc.store.List(ctx, StatusPending)
+	if len(pending) != 0 {
+		t.Fatalf("vanished orphan should be resolved, got %d pending", len(pending))
+	}
+}
+
+func TestApproveRevalidatesNowTracked(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	root := t.TempDir()
+	orphanDir := filepath.Join(root, "release")
+	mkfile(t, filepath.Join(orphanDir, "file.mkv"))
+
+	trackedNow := false
+	svc := NewService(Options{
+		Store: store,
+		Roots: func(context.Context) ([]Root, error) {
+			return []Root{{Path: root, ClientID: "c1"}}, nil
+		},
+		Tracked: func(context.Context) ([]string, error) {
+			if trackedNow {
+				return []string{orphanDir}, nil
+			}
+			return nil, nil
+		},
+		Recycle: func(_ context.Context, path, _ string) error { return os.RemoveAll(path) },
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := store.List(ctx, StatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 orphan, got %d", len(pending))
+	}
+
+	// It becomes tracked between scan and approval — must NOT be deleted.
+	trackedNow = true
+	if err := svc.Approve(ctx, pending[0].ID); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if _, err := os.Stat(orphanDir); err != nil {
+		t.Fatalf("now-tracked dir must not be deleted: %v", err)
+	}
+}
+
+func TestAutoDeleteRespectsRetention(t *testing.T) {
+	svc, orphanDir, _ := buildScenario(t)
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := svc.store.List(ctx, StatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 orphan, got %d", len(pending))
+	}
+
+	// Default retention is 7 days; a freshly-seen orphan must NOT auto-delete.
+	deleted, err := svc.AutoDelete(ctx)
+	if err != nil {
+		t.Fatalf("AutoDelete: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("fresh orphan should not auto-delete, deleted=%d", deleted)
+	}
+	if _, err := os.Stat(orphanDir); err != nil {
+		t.Fatalf("orphan should still exist: %v", err)
+	}
+
+	// Age the orphan past the retention window, then it should be removed.
+	if _, err := svc.store.db.ExecContext(ctx,
+		`UPDATE cleanup_orphans SET first_seen_at = ? WHERE id = ?`,
+		"2000-01-01T00:00:00Z", pending[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	deleted, err = svc.AutoDelete(ctx)
+	if err != nil {
+		t.Fatalf("AutoDelete: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("aged orphan should auto-delete, deleted=%d", deleted)
+	}
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Fatalf("aged orphan should be removed, stat err=%v", err)
+	}
+}
+
+func TestAutoDeleteDisabledIsNoop(t *testing.T) {
+	svc, orphanDir, _ := buildScenario(t)
+	ctx := context.Background()
+	if _, err := svc.Scan(ctx); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := svc.store.List(ctx, StatusPending)
+	if err := svc.store.SaveSettings(ctx, Settings{AutoDeleteEnabled: false, RetentionDays: 7}); err != nil {
+		t.Fatal(err)
+	}
+	// Age it, but auto-delete is off → must remain.
+	if _, err := svc.store.db.ExecContext(ctx,
+		`UPDATE cleanup_orphans SET first_seen_at = ? WHERE id = ?`,
+		"2000-01-01T00:00:00Z", pending[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := svc.AutoDelete(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != 0 {
+		t.Fatalf("auto-delete disabled should remove nothing, deleted=%d", deleted)
+	}
+	if _, err := os.Stat(orphanDir); err != nil {
+		t.Fatalf("orphan should still exist when auto-delete off: %v", err)
+	}
+}
+
+func TestSettingsRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	got, err := store.GetSettings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.AutoDeleteEnabled || got.RetentionDays != 7 {
+		t.Fatalf("default settings = %+v, want auto-delete on, 7 days", got)
+	}
+
+	if err := store.SaveSettings(ctx, Settings{AutoDeleteEnabled: false, RetentionDays: 14}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = store.GetSettings(ctx)
+	if got.AutoDeleteEnabled || got.RetentionDays != 14 {
+		t.Fatalf("saved settings = %+v, want auto-delete off, 14 days", got)
+	}
+}
+
+// TestScanSkipsLibraryOverlappingRoot ensures a download root that overlaps a
+// media library is never scanned, so library content is never flagged.
+func TestScanSkipsLibraryOverlappingRoot(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	// A real media file living directly under the root.
+	mkfile(t, filepath.Join(root, "Movie (2020)", "movie.mkv"))
+
+	svc := NewService(Options{
+		Store: store,
+		Roots: func(context.Context) ([]Root, error) {
+			return []Root{{Path: root, ClientID: "c1"}}, nil
+		},
+		Tracked:   func(context.Context) ([]string, error) { return nil, nil },
+		Protected: func(context.Context) ([]string, error) { return []string{root}, nil },
+		Recycle: func(_ context.Context, path, _ string) error {
+			return os.RemoveAll(path)
+		},
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	found, err := svc.Scan(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found != 0 {
+		t.Fatalf("scan must skip a library-overlapping root, found=%d", found)
+	}
+	pending, _ := store.List(ctx, StatusPending)
+	if len(pending) != 0 {
+		t.Fatalf("no orphans should be recorded for a library root, got %d", len(pending))
+	}
+}
+
+// TestApproveRefusesLibraryOverlap ensures that if a library comes to overlap a
+// previously-recorded orphan, approval refuses to delete it.
+func TestApproveRefusesLibraryOverlap(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	orphanDir := filepath.Join(root, "release")
+	mkfile(t, filepath.Join(orphanDir, "file.mkv"))
+
+	if err := store.Upsert(ctx, Orphan{Path: orphanDir, ClientID: "c1", Root: root, SizeBytes: 1}); err != nil {
+		t.Fatal(err)
+	}
+	pending, _ := store.List(ctx, StatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("setup: want 1 pending, got %d", len(pending))
+	}
+
+	svc := NewService(Options{
+		Store: store,
+		Roots: func(context.Context) ([]Root, error) {
+			return []Root{{Path: root, ClientID: "c1"}}, nil
+		},
+		Tracked: func(context.Context) ([]string, error) { return nil, nil },
+		// Library now overlaps the orphan path.
+		Protected: func(context.Context) ([]string, error) { return []string{orphanDir}, nil },
+		Recycle: func(_ context.Context, path, _ string) error {
+			return os.RemoveAll(path)
+		},
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if err := svc.Approve(ctx, pending[0].ID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if _, err := os.Stat(orphanDir); err != nil {
+		t.Fatalf("orphan overlapping a library must NOT be deleted: %v", err)
+	}
+}
+
+// TestTrackedErrorAbortsScan ensures an incomplete tracked set (e.g. a
+// download client that errored) aborts the scan rather than flagging live
+// downloads as orphans.
+func TestTrackedErrorAbortsScan(t *testing.T) {
+	db := openTestDB(t)
+	store := NewStore(db)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	mkfile(t, filepath.Join(root, "release", "file.mkv"))
+
+	svc := NewService(Options{
+		Store: store,
+		Roots: func(context.Context) ([]Root, error) {
+			return []Root{{Path: root, ClientID: "c1"}}, nil
+		},
+		Tracked: func(context.Context) ([]string, error) {
+			return nil, context.DeadlineExceeded
+		},
+		Recycle: func(_ context.Context, path, _ string) error { return os.RemoveAll(path) },
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	if _, err := svc.Scan(ctx); err == nil {
+		t.Fatal("scan must fail when the tracked set is unavailable")
+	}
+	pending, _ := store.List(ctx, StatusPending)
+	if len(pending) != 0 {
+		t.Fatalf("no orphans should be recorded when tracked set errored, got %d", len(pending))
+	}
+}

--- a/internal/cleanup/store.go
+++ b/internal/cleanup/store.go
@@ -1,0 +1,210 @@
+package cleanup
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store persists cleanup orphans and settings.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a cleanup store backed by the given database.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+const tsLayout = time.RFC3339
+
+// parseTS tolerates both RFC3339 (our writes) and SQLite's CURRENT_TIMESTAMP
+// "2006-01-02 15:04:05" form (seeded defaults).
+func parseTS(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// Upsert records (or refreshes) an orphan discovered during a scan. A newly
+// discovered path is inserted as pending; an existing row only has its
+// last_seen_at, size, root and client refreshed — its status and first_seen_at
+// are preserved so retention timing and ignore decisions survive rescans.
+func (s *Store) Upsert(ctx context.Context, o Orphan) error {
+	now := time.Now().UTC().Format(tsLayout)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cleanup_orphans
+			(id, path, client_id, root, size_bytes, status, first_seen_at, last_seen_at)
+		VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)
+		ON CONFLICT(path) DO UPDATE SET
+			client_id = excluded.client_id,
+			root = excluded.root,
+			size_bytes = excluded.size_bytes,
+			last_seen_at = excluded.last_seen_at`,
+		uuid.NewString(), o.Path, o.ClientID, o.Root, o.SizeBytes, now, now,
+	)
+	return err
+}
+
+// scanOrphan reads one row.
+func scanOrphan(rows interface {
+	Scan(...any) error
+}) (Orphan, error) {
+	var (
+		o           Orphan
+		status      string
+		first, last string
+		deleted     sql.NullString
+	)
+	if err := rows.Scan(&o.ID, &o.Path, &o.ClientID, &o.Root, &o.SizeBytes,
+		&status, &o.Error, &first, &last, &deleted); err != nil {
+		return Orphan{}, err
+	}
+	o.Status = OrphanStatus(status)
+	o.FirstSeenAt = parseTS(first)
+	o.LastSeenAt = parseTS(last)
+	if deleted.Valid && deleted.String != "" {
+		t := parseTS(deleted.String)
+		o.DeletedAt = &t
+	}
+	return o, nil
+}
+
+const selectCols = `id, path, client_id, root, size_bytes, status, error, first_seen_at, last_seen_at, deleted_at`
+
+// List returns orphans filtered by status. An empty status returns all rows.
+func (s *Store) List(ctx context.Context, status OrphanStatus) ([]Orphan, error) {
+	q := `SELECT ` + selectCols + ` FROM cleanup_orphans`
+	var args []any
+	if status != "" {
+		q += ` WHERE status = ?`
+		args = append(args, string(status))
+	}
+	q += ` ORDER BY first_seen_at ASC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Orphan
+	for rows.Next() {
+		o, err := scanOrphan(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+// Get returns a single orphan by id.
+func (s *Store) Get(ctx context.Context, id string) (Orphan, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+selectCols+` FROM cleanup_orphans WHERE id = ?`, id)
+	return scanOrphan(row)
+}
+
+// MarkDeleted flags an orphan as recycled.
+func (s *Store) MarkDeleted(ctx context.Context, id string) error {
+	now := time.Now().UTC().Format(tsLayout)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE cleanup_orphans SET status='deleted', error='', deleted_at=? WHERE id=?`,
+		now, id)
+	return err
+}
+
+// MarkFailed records a failed deletion attempt with the error message.
+func (s *Store) MarkFailed(ctx context.Context, id, msg string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE cleanup_orphans SET status='delete_failed', error=? WHERE id=?`, msg, id)
+	return err
+}
+
+// MarkIgnored flags an orphan to be kept and never auto-deleted or re-flagged.
+func (s *Store) MarkIgnored(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE cleanup_orphans SET status='ignored', error='' WHERE id=?`, id)
+	return err
+}
+
+// Delete removes a row entirely (used when an orphan resolves itself, e.g. it
+// vanished from disk or became tracked again).
+func (s *Store) Delete(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM cleanup_orphans WHERE id=?`, id)
+	return err
+}
+
+// ResolveStalePending deletes pending/delete_failed rows whose path was not
+// seen in the latest scan (gone from disk or now tracked). Ignored and deleted
+// rows are preserved. seenPaths is the set of paths observed this scan.
+func (s *Store) ResolveStalePending(ctx context.Context, seenPaths map[string]bool) error {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, path FROM cleanup_orphans WHERE status IN ('pending','delete_failed')`)
+	if err != nil {
+		return err
+	}
+	var stale []string
+	for rows.Next() {
+		var id, path string
+		if err := rows.Scan(&id, &path); err != nil {
+			rows.Close()
+			return err
+		}
+		if !seenPaths[path] {
+			stale = append(stale, id)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, id := range stale {
+		if _, err := s.db.ExecContext(ctx, `DELETE FROM cleanup_orphans WHERE id=?`, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetSettings returns the cleanup settings, falling back to defaults if the
+// row is somehow absent.
+func (s *Store) GetSettings(ctx context.Context) (Settings, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT auto_delete_enabled, retention_days FROM cleanup_settings WHERE id=1`)
+	var st Settings
+	if err := row.Scan(&st.AutoDeleteEnabled, &st.RetentionDays); err != nil {
+		if err == sql.ErrNoRows {
+			return Settings{AutoDeleteEnabled: true, RetentionDays: 7}, nil
+		}
+		return Settings{}, err
+	}
+	if st.RetentionDays < 1 {
+		st.RetentionDays = 1
+	}
+	return st, nil
+}
+
+// SaveSettings upserts the global cleanup settings.
+func (s *Store) SaveSettings(ctx context.Context, st Settings) error {
+	if st.RetentionDays < 1 {
+		st.RetentionDays = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cleanup_settings (id, auto_delete_enabled, retention_days, updated_at)
+		VALUES (1, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			auto_delete_enabled = excluded.auto_delete_enabled,
+			retention_days = excluded.retention_days,
+			updated_at = CURRENT_TIMESTAMP`,
+		st.AutoDeleteEnabled, st.RetentionDays,
+	)
+	return err
+}

--- a/internal/cleanup/types.go
+++ b/internal/cleanup/types.go
@@ -1,0 +1,117 @@
+// Package cleanup implements the Downloads Cleanup feature: it scans the
+// configured download save folders for "orphans" — files or folders no longer
+// tracked by any download client or in-progress import — and surfaces them for
+// review. When auto-delete is enabled, orphans are recycled after a configurable
+// retention period. The cleanup logic operates strictly on download folders and
+// never touches media libraries.
+package cleanup
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OrphanStatus is the lifecycle state of a tracked orphan.
+type OrphanStatus string
+
+const (
+	// StatusPending — discovered, awaiting review or retention expiry.
+	StatusPending OrphanStatus = "pending"
+	// StatusIgnored — user chose to keep it; never auto-deleted or re-flagged.
+	StatusIgnored OrphanStatus = "ignored"
+	// StatusDeleted — recycled/removed from disk.
+	StatusDeleted OrphanStatus = "deleted"
+	// StatusFailed — a removal attempt errored.
+	StatusFailed OrphanStatus = "delete_failed"
+)
+
+// Orphan is a single untracked entry inside a download folder.
+type Orphan struct {
+	ID          string       `json:"id"`
+	Path        string       `json:"path"`
+	ClientID    string       `json:"client_id"`
+	ClientName  string       `json:"client_name,omitempty"`
+	Root        string       `json:"root"`
+	SizeBytes   int64        `json:"size_bytes"`
+	Status      OrphanStatus `json:"status"`
+	Error       string       `json:"error,omitempty"`
+	FirstSeenAt time.Time    `json:"first_seen_at"`
+	LastSeenAt  time.Time    `json:"last_seen_at"`
+	DeletedAt   *time.Time   `json:"deleted_at,omitempty"`
+}
+
+// Settings is the global cleanup configuration.
+type Settings struct {
+	AutoDeleteEnabled bool `json:"auto_delete_enabled"`
+	RetentionDays     int  `json:"retention_days"`
+}
+
+// Root is a download folder to scan, tagged with the owning client for display.
+type Root struct {
+	Path       string
+	ClientID   string
+	ClientName string
+}
+
+// normPath cleans a path for stable comparison. It does not resolve symlinks;
+// symlinked entries are handled (skipped) by the scanner via Lstat.
+func normPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.Clean(p)
+}
+
+// isWithin reports whether child is the same path as, or nested under, parent.
+// Both inputs must be cleaned. It uses filepath.Rel rather than naive string
+// prefixing so that "/downloads/Movie" does not match "/downloads/Movie 2".
+func isWithin(parent, child string) bool {
+	if parent == "" || child == "" {
+		return false
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	if filepath.IsAbs(rel) {
+		return false
+	}
+	return true
+}
+
+// isProtected reports whether entry must be protected from deletion given the
+// set of tracked paths. An entry is protected when it equals, contains, or is
+// contained by any tracked path. The "contains" rule is critical: it prevents
+// deleting an intermediate/category directory (e.g. /downloads/tv) that holds a
+// tracked download somewhere beneath it.
+func isProtected(entry string, tracked []string) bool {
+	entry = normPath(entry)
+	for _, t := range tracked {
+		t = normPath(t)
+		if t == "" {
+			continue
+		}
+		if entry == t || isWithin(entry, t) || isWithin(t, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// underAnyRoot reports whether path sits inside (or equals) one of the roots.
+func underAnyRoot(path string, roots []string) bool {
+	path = normPath(path)
+	for _, r := range roots {
+		if isWithin(normPath(r), path) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/downloads/service.go
+++ b/internal/downloads/service.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/ebenderooock/loom/internal/workflows"
+	"github.com/go-chi/chi/v5"
 )
 
 // Clock is the small time abstraction the package uses so tests can
@@ -156,6 +156,26 @@ func (s *Service) ActiveDownloads(ctx context.Context) (map[string]workflows.Act
 		}
 	}
 	return result, nil
+}
+
+// TrackedDownloadPaths returns the content and save paths of every active
+// download across all enabled clients. The boolean reports whether the result
+// is complete: it is false when any client's status query failed. Callers that
+// make destructive decisions (e.g. downloads cleanup) must treat an incomplete
+// set as unsafe, since a temporarily unreachable client would otherwise make
+// its live downloads look like orphans.
+func (s *Service) TrackedDownloadPaths(ctx context.Context) (paths []string, complete bool) {
+	opts := s.FanOutOpts(nil)
+	status := s.registry.Status(ctx, nil, opts)
+	for _, item := range status.Items {
+		if item.ContentPath != "" {
+			paths = append(paths, item.ContentPath)
+		}
+		if item.SavePath != "" {
+			paths = append(paths, item.SavePath)
+		}
+	}
+	return paths, len(status.Errors) == 0
 }
 
 // HydrateAll reads every persisted client and registers a live

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ebenderooock/loom/internal/auth"
 	"github.com/ebenderooock/loom/internal/autosearch"
 	"github.com/ebenderooock/loom/internal/buildinfo"
+	"github.com/ebenderooock/loom/internal/cleanup"
 	"github.com/ebenderooock/loom/internal/commands"
 	"github.com/ebenderooock/loom/internal/compat/prowlarrv1"
 	"github.com/ebenderooock/loom/internal/compat/radarrv3"
@@ -97,6 +98,7 @@ type Server struct {
 	notifSvc          notifications.Service
 	connectSvc        connect.Service
 	reviewStore       *safety.ReviewStore
+	cleanupSvc        *cleanup.Service
 	importPipeline    *imports.ImportPipeline
 	langStore         *languages.Store
 	customFormatStore *customformats.Store
@@ -305,6 +307,15 @@ func (s *Server) SetPeriodicScanner(ps *scheduler.PeriodicScanner) {
 // SetImportPipeline installs the import pipeline and rebuilds the HTTP handler.
 func (s *Server) SetImportPipeline(p *imports.ImportPipeline) {
 	s.importPipeline = p
+	if s.httpSrv != nil {
+		s.httpSrv.Handler = s.newMux()
+	}
+}
+
+// SetCleanup installs the downloads-cleanup service and rebuilds the HTTP
+// handler so the /api/v1/cleanup routes are reachable.
+func (s *Server) SetCleanup(svc *cleanup.Service) {
+	s.cleanupSvc = svc
 	if s.httpSrv != nil {
 		s.httpSrv.Handler = s.newMux()
 	}
@@ -681,6 +692,11 @@ func (s *Server) newMux() http.Handler {
 
 		// Manual review routes (download safety)
 		r.Mount("/api/v1/reviews", safety.Router(s.reviewStore))
+
+		// Downloads cleanup routes
+		if s.cleanupSvc != nil {
+			r.Mount("/api/v1/cleanup", cleanup.Router(s.cleanupSvc))
+		}
 
 		// Rolling search routes
 		if s.rollingSearch != nil {

--- a/internal/storage/migrations/sqlite/0059_downloads_cleanup.sql
+++ b/internal/storage/migrations/sqlite/0059_downloads_cleanup.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+
+-- cleanup_orphans tracks files/folders found in download save folders that are
+-- no longer associated with any active download or in-progress import. They are
+-- surfaced for review and, when auto-delete is enabled, removed after a
+-- configurable retention period. Status transitions:
+--   pending       -> discovered, awaiting review or retention
+--   ignored       -> user kept it; never auto-deleted, never re-flagged
+--   deleted       -> removed (recycled) from disk
+--   delete_failed -> removal attempt errored; error captured for the user
+CREATE TABLE IF NOT EXISTS cleanup_orphans (
+    id            TEXT PRIMARY KEY,
+    path          TEXT NOT NULL UNIQUE,
+    client_id     TEXT NOT NULL DEFAULT '',
+    root          TEXT NOT NULL DEFAULT '',
+    size_bytes    INTEGER NOT NULL DEFAULT 0,
+    status        TEXT NOT NULL DEFAULT 'pending',
+    error         TEXT NOT NULL DEFAULT '',
+    first_seen_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at    TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_cleanup_orphans_status ON cleanup_orphans(status);
+
+-- cleanup_settings is a single-row table holding the global cleanup config.
+CREATE TABLE IF NOT EXISTS cleanup_settings (
+    id                  INTEGER PRIMARY KEY CHECK (id = 1),
+    auto_delete_enabled INTEGER NOT NULL DEFAULT 1,
+    retention_days      INTEGER NOT NULL DEFAULT 7,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO cleanup_settings (id, auto_delete_enabled, retention_days)
+VALUES (1, 1, 7)
+ON CONFLICT(id) DO NOTHING;
+
+-- +goose Down
+
+DROP TABLE IF EXISTS cleanup_orphans;
+DROP TABLE IF EXISTS cleanup_settings;

--- a/web/src/lib/cleanup-api.ts
+++ b/web/src/lib/cleanup-api.ts
@@ -1,0 +1,132 @@
+// Typed client + hooks for the Downloads Cleanup API
+// (internal/cleanup/handlers.go). Keep shapes in sync with internal/cleanup.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/fetch";
+
+export type OrphanStatus = "pending" | "ignored" | "deleted" | "delete_failed";
+
+export interface Orphan {
+  id: string;
+  path: string;
+  client_id: string;
+  client_name?: string;
+  root: string;
+  size_bytes: number;
+  status: OrphanStatus;
+  error?: string;
+  first_seen_at: string;
+  last_seen_at: string;
+  deleted_at?: string;
+}
+
+export interface CleanupSettings {
+  auto_delete_enabled: boolean;
+  retention_days: number;
+}
+
+async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await apiFetch(path, init);
+  const text = await res.text();
+  let parsed: unknown;
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+  if (!res.ok) {
+    const env = parsed as { error?: { message?: string } } | undefined;
+    throw new Error(env?.error?.message ?? `${method} ${path} failed (${res.status})`);
+  }
+  return parsed as T;
+}
+
+export async function listOrphans(status?: OrphanStatus | "all"): Promise<Orphan[]> {
+  const q = status ? `?status=${encodeURIComponent(status)}` : "";
+  const env = await req<{ data: Orphan[] }>("GET", `/api/v1/cleanup/orphans${q}`);
+  return env.data ?? [];
+}
+
+export async function scanCleanup(): Promise<{ found: number }> {
+  return req<{ found: number }>("POST", "/api/v1/cleanup/scan");
+}
+
+export async function getCleanupSettings(): Promise<CleanupSettings> {
+  return req<CleanupSettings>("GET", "/api/v1/cleanup/settings");
+}
+
+export async function saveCleanupSettings(s: CleanupSettings): Promise<CleanupSettings> {
+  return req<CleanupSettings>("PUT", "/api/v1/cleanup/settings", s);
+}
+
+export async function approveOrphan(id: string): Promise<void> {
+  await req<unknown>("POST", `/api/v1/cleanup/orphans/${encodeURIComponent(id)}/approve`);
+}
+
+export async function ignoreOrphan(id: string): Promise<void> {
+  await req<unknown>("POST", `/api/v1/cleanup/orphans/${encodeURIComponent(id)}/ignore`);
+}
+
+// ---------- Hooks ----------
+
+export const cleanupKeys = {
+  all: ["cleanup"] as const,
+  orphans: (status?: string) => [...cleanupKeys.all, "orphans", status ?? "pending"] as const,
+  settings: () => [...cleanupKeys.all, "settings"] as const,
+};
+
+export function useOrphans(status: OrphanStatus | "all" = "pending") {
+  return useQuery<Orphan[], Error>({
+    queryKey: cleanupKeys.orphans(status),
+    queryFn: () => listOrphans(status),
+  });
+}
+
+export function useCleanupSettings() {
+  return useQuery<CleanupSettings, Error>({
+    queryKey: cleanupKeys.settings(),
+    queryFn: getCleanupSettings,
+  });
+}
+
+export function useScanCleanup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: scanCleanup,
+    onSuccess: () => qc.invalidateQueries({ queryKey: cleanupKeys.all }),
+  });
+}
+
+export function useSaveCleanupSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: saveCleanupSettings,
+    onSuccess: (data) => {
+      qc.setQueryData(cleanupKeys.settings(), data);
+      qc.invalidateQueries({ queryKey: cleanupKeys.settings() });
+    },
+  });
+}
+
+export function useApproveOrphan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: approveOrphan,
+    onSuccess: () => qc.invalidateQueries({ queryKey: cleanupKeys.all }),
+  });
+}
+
+export function useIgnoreOrphan() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ignoreOrphan,
+    onSuccess: () => qc.invalidateQueries({ queryKey: cleanupKeys.all }),
+  });
+}

--- a/web/src/pages/downloads.tsx
+++ b/web/src/pages/downloads.tsx
@@ -19,6 +19,8 @@ import {
   Radio,
   Info,
   Gauge,
+  Trash2,
+  EyeOff,
 } from "lucide-react";
 import { apiFetch } from "@/lib/fetch";
 import { useSetPageHeader } from "@/hooks/use-page-header";
@@ -27,6 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
 import { ImportManager } from "@/components/imports/import-manager";
@@ -37,6 +40,15 @@ import {
   useTorrentPauseAll,
   useTorrentResumeAll,
 } from "@/lib/downloads-api";
+import {
+  useOrphans,
+  useCleanupSettings,
+  useScanCleanup,
+  useSaveCleanupSettings,
+  useApproveOrphan,
+  useIgnoreOrphan,
+  type Orphan,
+} from "@/lib/cleanup-api";
 import { toast } from "sonner";
 import {
   Sheet,
@@ -954,6 +966,214 @@ function TorrentEnginePanel() {
   );
 }
 
+// ─── Cleanup Tab ────────────────────────────────────────────────────────
+
+function relativeAge(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!then) return "—";
+  const days = Math.floor((Date.now() - then) / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "1 day ago";
+  return `${days} days ago`;
+}
+
+function OrphanRow({
+  orphan,
+  onApprove,
+  onIgnore,
+  busy,
+}: {
+  orphan: Orphan;
+  onApprove: (id: string) => void;
+  onIgnore: (id: string) => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3">
+      <div className="min-w-0">
+        <div className="truncate font-mono text-xs text-zinc-200">{orphan.path}</div>
+        <div className="mt-0.5 flex items-center gap-3 text-[11px] text-zinc-500">
+          <span className="tabular-nums">{formatBytes(orphan.size_bytes)}</span>
+          <span>first seen {relativeAge(orphan.first_seen_at)}</span>
+          {orphan.client_name && <span>{orphan.client_name}</span>}
+          {orphan.status === "delete_failed" && (
+            <span className="text-red-400">delete failed{orphan.error ? `: ${orphan.error}` : ""}</span>
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8"
+          disabled={busy}
+          onClick={() => onIgnore(orphan.id)}
+        >
+          <EyeOff className="h-3.5 w-3.5 mr-1.5" />
+          Keep
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 text-red-400 hover:text-red-300"
+          disabled={busy}
+          onClick={() => onApprove(orphan.id)}
+        >
+          <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CleanupTab() {
+  const { data: orphans, isLoading } = useOrphans("pending");
+  const { data: settings } = useCleanupSettings();
+  const scan = useScanCleanup();
+  const saveSettings = useSaveCleanupSettings();
+  const approve = useApproveOrphan();
+  const ignore = useIgnoreOrphan();
+
+  const [retention, setRetention] = React.useState("7");
+  const [autoDelete, setAutoDelete] = React.useState(true);
+  const [dirty, setDirty] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!settings || dirty) return;
+    setRetention(String(settings.retention_days));
+    setAutoDelete(settings.auto_delete_enabled);
+  }, [settings, dirty]);
+
+  const busy = approve.isPending || ignore.isPending;
+
+  const onApprove = (id: string) =>
+    approve.mutate(id, {
+      onSuccess: () => toast.success("Orphan deleted"),
+      onError: (e) => toast.error(e instanceof Error ? e.message : "Delete failed"),
+    });
+  const onIgnore = (id: string) =>
+    ignore.mutate(id, {
+      onSuccess: () => toast.success("Orphan kept"),
+      onError: (e) => toast.error(e instanceof Error ? e.message : "Failed"),
+    });
+
+  const saveCfg = () => {
+    const days = Math.max(1, parseInt(retention || "7", 10) || 7);
+    saveSettings.mutate(
+      { auto_delete_enabled: autoDelete, retention_days: days },
+      {
+        onSuccess: () => {
+          setDirty(false);
+          toast.success("Cleanup settings saved");
+        },
+        onError: (e) => toast.error(e instanceof Error ? e.message : "Save failed"),
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card className="bg-zinc-900/50 border-zinc-800">
+        <CardContent className="space-y-4 pt-5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Trash2 className="h-4 w-4 text-zinc-400" />
+              <span className="text-sm font-medium text-zinc-100">Cleanup settings</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 text-zinc-400 hover:text-zinc-200"
+              disabled={scan.isPending}
+              onClick={() =>
+                scan.mutate(undefined, {
+                  onSuccess: (r) => toast.success(`Scan complete — ${r.found} orphan(s)`),
+                  onError: (e) => toast.error(e instanceof Error ? e.message : "Scan failed"),
+                })
+              }
+            >
+              {scan.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              Scan now
+            </Button>
+          </div>
+
+          <p className="text-xs text-zinc-500">
+            Files in your download folders that are no longer tied to any active download or
+            import are listed below for review. Media libraries are never touched.
+          </p>
+
+          <div className="flex flex-wrap items-end gap-6 border-t border-zinc-800 pt-4">
+            <div className="flex items-center gap-2">
+              <Switch
+                id="cleanup-auto-delete"
+                checked={autoDelete}
+                onCheckedChange={(v) => {
+                  setAutoDelete(v);
+                  setDirty(true);
+                }}
+              />
+              <Label htmlFor="cleanup-auto-delete" className="text-xs text-zinc-300">
+                Auto-delete orphans
+              </Label>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="cleanup-retention" className="text-[11px] text-zinc-400">
+                Retention (days)
+              </Label>
+              <Input
+                id="cleanup-retention"
+                type="number"
+                min={1}
+                value={retention}
+                onChange={(e) => {
+                  setRetention(e.target.value);
+                  setDirty(true);
+                }}
+                className="h-8 w-28"
+              />
+            </div>
+            <Button size="sm" className="h-8" disabled={!dirty || saveSettings.isPending} onClick={saveCfg}>
+              {saveSettings.isPending ? <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" /> : null}
+              Save
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <Card className="bg-zinc-900/50 border-zinc-800">
+          <CardContent>
+            <LoadingState label="Scanning download folders…" />
+          </CardContent>
+        </Card>
+      ) : !orphans || orphans.length === 0 ? (
+        <Card className="bg-zinc-900/50 border-zinc-800 border-dashed">
+          <CardContent>
+            <EmptyState
+              icon={<Trash2 className="h-10 w-10" />}
+              title="No orphans found"
+              description="Everything in your download folders is accounted for. Run a scan to check again."
+            />
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="bg-zinc-900/50 border-zinc-800 overflow-hidden">
+          <div className="divide-y divide-zinc-800/50">
+            {orphans.map((o) => (
+              <OrphanRow key={o.id} orphan={o} onApprove={onApprove} onIgnore={onIgnore} busy={busy} />
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
 // ─── Downloads Page ─────────────────────────────────────────────────────
 
 export function DownloadsPage() {
@@ -971,6 +1191,10 @@ export function DownloadsPage() {
             <Import className="h-3.5 w-3.5" />
             Imports
           </TabsTrigger>
+          <TabsTrigger value="cleanup" className="flex items-center gap-1.5">
+            <Trash2 className="h-3.5 w-3.5" />
+            Cleanup
+          </TabsTrigger>
         </TabsList>
         <TabsContent value="active" className="space-y-4">
           <TorrentEnginePanel />
@@ -978,6 +1202,9 @@ export function DownloadsPage() {
         </TabsContent>
         <TabsContent value="imports">
           <ImportManager />
+        </TabsContent>
+        <TabsContent value="cleanup">
+          <CleanupTab />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
Closes #5.

Adds a **Downloads Cleanup** tool that scans configured download folders for orphaned files/folders no longer tracked by any download client or recent import, surfaces them for review, and optionally auto-deletes after a retention period (recoverable via the recycle bin). **Media libraries are never touched.**

### Backend
- Migration 0059: `cleanup_orphans` + `cleanup_settings` (auto-delete on, 7-day retention by default).
- `internal/cleanup` package: scanner, store, handlers (`/api/v1/cleanup`).
- Scheduler job (scan + auto-delete every 6h); manual `POST /scan` never auto-deletes.

### Safety guards
- Category-dir protection (entry equals/contains/contained-by a tracked path).
- **Media-library overlap guard** on roots at scan time and at delete-time revalidation.
- **Aborts** scan/delete when a download client's status query fails, so live downloads from a temporarily unreachable client are never flagged as orphans.
- Skips symlinks; serializes scan/delete via mutex; revalidates each orphan immediately before removal.

### Frontend
- New **Cleanup** tab on the Downloads page: pending-orphan list with Delete/Keep, Scan now, and auto-delete + retention settings.

### Tests
- `internal/cleanup` unit tests incl. library-overlap root skip, approve-refuses-library-overlap, and tracked-set-error-aborts-scan. All pass.