### PR TITLE
feat(auth): admin user management UI + API (#14)

### DIFF
--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -27,6 +27,14 @@ func (s *Service) Mount(r chi.Router) {
 			r.Get("/apikeys", s.handleListAPIKeys)
 			r.Delete("/apikeys/{id}", s.handleRevokeAPIKey)
 		})
+		r.Group(func(r chi.Router) {
+			r.Use(s.RequireRole("admin"))
+			r.Get("/users", s.handleListUsers)
+			r.Post("/users", s.handleCreateUser)
+			r.Delete("/users/{id}", s.handleDeleteUser)
+			r.Patch("/users/{id}/role", s.handleUpdateUserRole)
+			r.Post("/users/{id}/password", s.handleResetUserPassword)
+		})
 	})
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ebenderooock/loom/internal/appconfig"
 	"github.com/ebenderooock/loom/internal/auth"
 	"github.com/ebenderooock/loom/internal/kernel/config"
 	"github.com/ebenderooock/loom/internal/storage"
@@ -57,6 +58,8 @@ func newTestService(t *testing.T) (*auth.Service, auth.Store, int64) {
 	svc, err := auth.NewService(auth.ServiceOptions{
 		Store:         store,
 		Logger:        quietLogger(),
+		AppConfig:     &appconfig.Config{},
+		AppConfigPath: filepath.Join(t.TempDir(), "config.json"),
 		SessionSecret: []byte("a-test-session-secret-32bytes!!!"),
 		SessionTTL:    time.Hour,
 		Proxy:         proxy,

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -123,9 +123,9 @@ func LoadOrCreateSessionSecret(ctx context.Context, store Store, configured stri
 func StoreFromDB(db storage.DB) (Store, error) {
 	switch db.Engine() {
 	case storage.EngineSQLite:
-		return SQLiteStore{Q: dbsqlite.New(db.DB())}, nil
+		return SQLiteStore{Q: dbsqlite.New(db.DB()), DB: db.DB()}, nil
 	case storage.EnginePostgres:
-		return PostgresStore{Q: dbpg.New(db.DB())}, nil
+		return PostgresStore{Q: dbpg.New(db.DB()), DB: db.DB()}, nil
 	default:
 		return nil, errors.New("auth: unknown storage engine")
 	}
@@ -158,6 +158,11 @@ func (s *Service) ReconcileAdmin(ctx context.Context) (User, error) {
 		if err := s.store.UpdateUserAdmin(ctx, adminID, s.appConfig.Admin.Username, s.appConfig.Admin.PasswordHash); err != nil {
 			return User{}, fmt.Errorf("auth: update admin user: %w", err)
 		}
+		// Force role back to admin: OIDC/proxy reconciliation could have
+		// demoted the protected admin while it was offline.
+		if err := s.store.UpdateUserRole(ctx, adminID, "admin"); err != nil {
+			return User{}, fmt.Errorf("auth: restore admin role: %w", err)
+		}
 		u, err := s.store.GetUserByID(ctx, adminID)
 		if err != nil {
 			return User{}, fmt.Errorf("auth: get admin user after update: %w", err)
@@ -178,6 +183,12 @@ func (s *Service) ReconcileAdmin(ctx context.Context) (User, error) {
 		}
 		if err := s.store.SetMeta(ctx, schemaMetaAdminUserID, fmt.Sprintf("%d", u.ID)); err != nil {
 			return User{}, fmt.Errorf("auth: save admin user id: %w", err)
+		}
+		if u.Role != "admin" {
+			if err := s.store.UpdateUserRole(ctx, u.ID, "admin"); err != nil {
+				return User{}, fmt.Errorf("auth: restore admin role: %w", err)
+			}
+			u.Role = "admin"
 		}
 		s.logger.Info("admin user tracked from existing user", "username", u.Username, "id", u.ID)
 		return u, nil

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -48,12 +48,24 @@ type CreateAPIKeyParams struct {
 	ExpiresAt *time.Time
 }
 
+// UserSummary is a read model for admin user listings, including timestamps.
+type UserSummary struct {
+	ID        int64     `json:"id"`
+	Username  string    `json:"username"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // Store is the storage seam consumed by the auth Service.
 type Store interface {
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	GetUserByUsername(ctx context.Context, username string) (User, error)
 	GetUserByID(ctx context.Context, id int64) (User, error)
 	CountUsers(ctx context.Context) (int64, error)
+	ListUsers(ctx context.Context) ([]UserSummary, error)
+	DeleteUser(ctx context.Context, id int64) error
+	UpdateUserRole(ctx context.Context, id int64, role string) error
 	UpdateUserPassword(ctx context.Context, id int64, hash string) error
 	UpdateUserAdmin(ctx context.Context, id int64, username, hash string) error
 	UpdateUserOIDC(ctx context.Context, id int64, email, role string) (User, error)
@@ -72,7 +84,10 @@ type Store interface {
 var ErrNoRows = sql.ErrNoRows
 
 // SQLiteStore adapts dbsqlite.Queries to Store.
-type SQLiteStore struct{ Q *dbsqlite.Queries }
+type SQLiteStore struct {
+	Q  *dbsqlite.Queries
+	DB *sql.DB
+}
 
 func nullStr(s string) sql.NullString {
 	if s == "" {
@@ -158,6 +173,20 @@ func (s SQLiteStore) UpdateUserPassword(ctx context.Context, id int64, hash stri
 	})
 }
 
+func (s SQLiteStore) ListUsers(ctx context.Context) ([]UserSummary, error) {
+	return listUsers(ctx, s.DB)
+}
+
+func (s SQLiteStore) DeleteUser(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM users WHERE id = ?`, id)
+	return err
+}
+
+func (s SQLiteStore) UpdateUserRole(ctx context.Context, id int64, role string) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE users SET role = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, role, id)
+	return err
+}
+
 func (s SQLiteStore) UpdateUserAdmin(ctx context.Context, id int64, username, hash string) error {
 	return s.Q.UpdateUserAdmin(ctx, dbsqlite.UpdateUserAdminParams{
 		ID:           id,
@@ -233,7 +262,10 @@ func (s SQLiteStore) SetMeta(ctx context.Context, key, value string) error {
 }
 
 // PostgresStore adapts dbpg.Queries to Store.
-type PostgresStore struct{ Q *dbpg.Queries }
+type PostgresStore struct {
+	Q  *dbpg.Queries
+	DB *sql.DB
+}
 
 func pgUser(u dbpg.User) User {
 	return User{
@@ -303,6 +335,20 @@ func (s PostgresStore) UpdateUserPassword(ctx context.Context, id int64, hash st
 		ID:           id,
 		PasswordHash: hash,
 	})
+}
+
+func (s PostgresStore) ListUsers(ctx context.Context) ([]UserSummary, error) {
+	return listUsers(ctx, s.DB)
+}
+
+func (s PostgresStore) DeleteUser(ctx context.Context, id int64) error {
+	_, err := s.DB.ExecContext(ctx, `DELETE FROM users WHERE id = $1`, id)
+	return err
+}
+
+func (s PostgresStore) UpdateUserRole(ctx context.Context, id int64, role string) error {
+	_, err := s.DB.ExecContext(ctx, `UPDATE users SET role = $1, updated_at = now() WHERE id = $2`, role, id)
+	return err
 }
 
 func (s PostgresStore) UpdateUserAdmin(ctx context.Context, id int64, username, hash string) error {
@@ -377,4 +423,55 @@ func (s PostgresStore) GetMeta(ctx context.Context, key string) (string, error) 
 
 func (s PostgresStore) SetMeta(ctx context.Context, key, value string) error {
 	return s.Q.SetSchemaMeta(ctx, dbpg.SetSchemaMetaParams{Key: key, Value: value})
+}
+
+// listUsers reads all users ordered by id. Shared by both engines since the
+// users table schema is identical; it tolerates both time.Time (postgres) and
+// string (sqlite CURRENT_TIMESTAMP) created_at representations.
+func listUsers(ctx context.Context, db *sql.DB) ([]UserSummary, error) {
+	rows, err := db.QueryContext(ctx, `SELECT id, username, email, role, created_at FROM users ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []UserSummary
+	for rows.Next() {
+		var (
+			u     UserSummary
+			email sql.NullString
+			ts    any
+		)
+		if err := rows.Scan(&u.ID, &u.Username, &email, &u.Role, &ts); err != nil {
+			return nil, err
+		}
+		u.Email = email.String
+		u.CreatedAt = parseCreatedAt(ts)
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+func parseCreatedAt(v any) time.Time {
+	switch t := v.(type) {
+	case time.Time:
+		return t
+	case []byte:
+		return parseCreatedAtStr(string(t))
+	case string:
+		return parseCreatedAtStr(t)
+	default:
+		return time.Time{}
+	}
+}
+
+func parseCreatedAtStr(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }

--- a/internal/auth/usermgmt.go
+++ b/internal/auth/usermgmt.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// User-management errors surfaced to admin handlers.
+var (
+	ErrUserExists      = errors.New("auth: username already exists")
+	ErrInvalidRole     = errors.New("auth: role must be 'admin' or 'user'")
+	ErrInvalidUsername = errors.New("auth: username is required")
+	ErrWeakPassword    = errors.New("auth: password must be at least 8 characters")
+	ErrProtectedUser   = errors.New("auth: the primary admin account cannot be modified or deleted")
+	ErrSelfModify      = errors.New("auth: you cannot delete or change the role of your own account")
+	ErrUserNotFound    = errors.New("auth: user not found")
+)
+
+const minPasswordLen = 8
+
+func validRole(role string) bool {
+	return role == "admin" || role == "user"
+}
+
+// isUniqueViolation reports whether err is a duplicate-key error from either
+// engine, used to map a racing concurrent create to ErrUserExists.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") || strings.Contains(msg, "duplicate key")
+}
+
+// primaryAdminID returns the config-managed admin user's DB id (0 if untracked).
+// It fails closed: a present-but-unparseable id is treated as an error so the
+// protected-admin guards never silently disable.
+func (s *Service) primaryAdminID(ctx context.Context) (int64, error) {
+	idStr, err := s.store.GetMeta(ctx, schemaMetaAdminUserID)
+	if err != nil {
+		return 0, err
+	}
+	if idStr == "" {
+		return 0, nil
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(idStr), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("auth: invalid admin user id in schema_meta: %w", err)
+	}
+	return id, nil
+}
+
+// ListUserAccounts returns all users for admin display.
+func (s *Service) ListUserAccounts(ctx context.Context) ([]UserSummary, error) {
+	return s.store.ListUsers(ctx)
+}
+
+// CreateUserAccount provisions a new DB-backed user with the given role.
+func (s *Service) CreateUserAccount(ctx context.Context, username, password, email, role string) (User, error) {
+	username = strings.TrimSpace(username)
+	email = strings.TrimSpace(email)
+	if role == "" {
+		role = "user"
+	}
+	if username == "" {
+		return User{}, ErrInvalidUsername
+	}
+	if !validRole(role) {
+		return User{}, ErrInvalidRole
+	}
+	if len(password) < minPasswordLen {
+		return User{}, ErrWeakPassword
+	}
+
+	if _, err := s.store.GetUserByUsername(ctx, username); err == nil {
+		return User{}, ErrUserExists
+	} else if !errors.Is(err, ErrNoRows) {
+		return User{}, err
+	}
+
+	hash, err := HashPassword(password)
+	if err != nil {
+		return User{}, err
+	}
+	u, err := s.store.CreateUser(ctx, CreateUserParams{
+		Username:     username,
+		PasswordHash: hash,
+		Email:        email,
+		Role:         role,
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return User{}, ErrUserExists
+		}
+		return User{}, err
+	}
+	s.logger.Info("user account created", "username", u.Username, "id", u.ID, "role", role)
+	return u, nil
+}
+
+// DeleteUserAccount removes a user, guarding the primary admin and self.
+func (s *Service) DeleteUserAccount(ctx context.Context, actorID, targetID int64) error {
+	if actorID == targetID {
+		return ErrSelfModify
+	}
+	adminID, err := s.primaryAdminID(ctx)
+	if err != nil {
+		return err
+	}
+	if adminID != 0 && targetID == adminID {
+		return ErrProtectedUser
+	}
+	if _, err := s.store.GetUserByID(ctx, targetID); err != nil {
+		if errors.Is(err, ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return err
+	}
+	if err := s.store.DeleteUser(ctx, targetID); err != nil {
+		return err
+	}
+	s.logger.Info("user account deleted", "id", targetID, "actor", actorID)
+	return nil
+}
+
+// SetUserRole changes a user's role, guarding the primary admin and self.
+func (s *Service) SetUserRole(ctx context.Context, actorID, targetID int64, role string) (User, error) {
+	if !validRole(role) {
+		return User{}, ErrInvalidRole
+	}
+	if actorID == targetID {
+		return User{}, ErrSelfModify
+	}
+	adminID, err := s.primaryAdminID(ctx)
+	if err != nil {
+		return User{}, err
+	}
+	if adminID != 0 && targetID == adminID {
+		return User{}, ErrProtectedUser
+	}
+	if _, err := s.store.GetUserByID(ctx, targetID); err != nil {
+		if errors.Is(err, ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, err
+	}
+	if err := s.store.UpdateUserRole(ctx, targetID, role); err != nil {
+		return User{}, err
+	}
+	u, err := s.store.GetUserByID(ctx, targetID)
+	if err != nil {
+		return User{}, err
+	}
+	s.logger.Info("user role changed", "id", targetID, "role", role, "actor", actorID)
+	return u, nil
+}
+
+// ResetUserPassword sets a new password for a user. The primary admin's
+// password is config-managed and cannot be reset here.
+func (s *Service) ResetUserPassword(ctx context.Context, targetID int64, password string) error {
+	if len(password) < minPasswordLen {
+		return ErrWeakPassword
+	}
+	adminID, err := s.primaryAdminID(ctx)
+	if err != nil {
+		return err
+	}
+	if adminID != 0 && targetID == adminID {
+		return ErrProtectedUser
+	}
+	if _, err := s.store.GetUserByID(ctx, targetID); err != nil {
+		if errors.Is(err, ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return err
+	}
+	hash, err := HashPassword(password)
+	if err != nil {
+		return err
+	}
+	if err := s.store.UpdateUserPassword(ctx, targetID, hash); err != nil {
+		return err
+	}
+	s.logger.Info("user password reset", "id", targetID)
+	return nil
+}

--- a/internal/auth/usermgmt_test.go
+++ b/internal/auth/usermgmt_test.go
@@ -1,0 +1,198 @@
+package auth_test
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/appconfig"
+	"github.com/ebenderooock/loom/internal/auth"
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+const adminMetaKey = "auth.admin_user_id"
+
+// newUserMgmtService builds a Service backed by a fresh sqlite DB plus a seeded
+// admin user that is registered as the protected primary admin.
+func newUserMgmtService(t *testing.T) (*auth.Service, auth.Store, int64) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "auth.db")},
+	}
+	db, err := storage.Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatalf("storage.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := auth.StoreFromDB(db)
+	if err != nil {
+		t.Fatalf("StoreFromDB: %v", err)
+	}
+	hash, err := auth.HashPassword("hunter2!!")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	admin, err := store.CreateUser(ctx, auth.CreateUserParams{
+		Username:     "admin",
+		PasswordHash: hash,
+		Email:        "admin@example.com",
+		Role:         "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	if err := store.SetMeta(ctx, adminMetaKey, strconv.FormatInt(admin.ID, 10)); err != nil {
+		t.Fatalf("set admin meta: %v", err)
+	}
+	svc, err := auth.NewService(auth.ServiceOptions{
+		Store:         store,
+		Logger:        quietLogger(),
+		AppConfig:     &appconfig.Config{},
+		AppConfigPath: filepath.Join(dir, "config.json"),
+		SessionSecret: []byte("a-test-session-secret-32bytes!!!"),
+		SessionTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, store, admin.ID
+}
+
+func TestCreateAndListUsers(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newUserMgmtService(t)
+
+	u, err := svc.CreateUserAccount(ctx, "bob", "password1", "bob@example.com", "user")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if u.Role != "user" || u.Username != "bob" {
+		t.Fatalf("unexpected user: %+v", u)
+	}
+
+	users, err := svc.ListUserAccounts(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	_ = adminID
+}
+
+func TestCreateUserValidation(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := newUserMgmtService(t)
+
+	if _, err := svc.CreateUserAccount(ctx, "", "password1", "", "user"); err != auth.ErrInvalidUsername {
+		t.Fatalf("empty username: got %v", err)
+	}
+	if _, err := svc.CreateUserAccount(ctx, "x", "short", "", "user"); err != auth.ErrWeakPassword {
+		t.Fatalf("weak password: got %v", err)
+	}
+	if _, err := svc.CreateUserAccount(ctx, "x", "password1", "", "superuser"); err != auth.ErrInvalidRole {
+		t.Fatalf("bad role: got %v", err)
+	}
+	// duplicate
+	if _, err := svc.CreateUserAccount(ctx, "dup", "password1", "", "user"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := svc.CreateUserAccount(ctx, "dup", "password1", "", "user"); err != auth.ErrUserExists {
+		t.Fatalf("duplicate: got %v", err)
+	}
+}
+
+func TestDeleteUserGuards(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newUserMgmtService(t)
+
+	bob, err := svc.CreateUserAccount(ctx, "bob", "password1", "", "user")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Cannot delete the protected primary admin.
+	if err := svc.DeleteUserAccount(ctx, bob.ID, adminID); err != auth.ErrProtectedUser {
+		t.Fatalf("delete admin: got %v", err)
+	}
+	// Cannot delete self.
+	if err := svc.DeleteUserAccount(ctx, bob.ID, bob.ID); err != auth.ErrSelfModify {
+		t.Fatalf("delete self: got %v", err)
+	}
+	// Not found.
+	if err := svc.DeleteUserAccount(ctx, adminID, 99999); err != auth.ErrUserNotFound {
+		t.Fatalf("delete missing: got %v", err)
+	}
+	// Happy path: admin deletes bob.
+	if err := svc.DeleteUserAccount(ctx, adminID, bob.ID); err != nil {
+		t.Fatalf("delete bob: %v", err)
+	}
+	users, _ := svc.ListUserAccounts(ctx)
+	if len(users) != 1 {
+		t.Fatalf("expected 1 user after delete, got %d", len(users))
+	}
+}
+
+func TestSetUserRoleGuards(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newUserMgmtService(t)
+
+	bob, err := svc.CreateUserAccount(ctx, "bob", "password1", "", "user")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := svc.SetUserRole(ctx, bob.ID, adminID, "user"); err != auth.ErrProtectedUser {
+		t.Fatalf("demote admin: got %v", err)
+	}
+	if _, err := svc.SetUserRole(ctx, bob.ID, bob.ID, "admin"); err != auth.ErrSelfModify {
+		t.Fatalf("self role: got %v", err)
+	}
+	if _, err := svc.SetUserRole(ctx, adminID, bob.ID, "wizard"); err != auth.ErrInvalidRole {
+		t.Fatalf("bad role: got %v", err)
+	}
+	u, err := svc.SetUserRole(ctx, adminID, bob.ID, "admin")
+	if err != nil {
+		t.Fatalf("promote bob: %v", err)
+	}
+	if u.Role != "admin" {
+		t.Fatalf("expected admin, got %s", u.Role)
+	}
+}
+
+func TestResetUserPassword(t *testing.T) {
+	ctx := context.Background()
+	svc, store, adminID := newUserMgmtService(t)
+
+	bob, err := svc.CreateUserAccount(ctx, "bob", "password1", "", "user")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if err := svc.ResetUserPassword(ctx, bob.ID, "short"); err != auth.ErrWeakPassword {
+		t.Fatalf("weak: got %v", err)
+	}
+	if err := svc.ResetUserPassword(ctx, adminID, "newpassword1"); err != auth.ErrProtectedUser {
+		t.Fatalf("reset admin: got %v", err)
+	}
+	if err := svc.ResetUserPassword(ctx, bob.ID, "newpassword1"); err != nil {
+		t.Fatalf("reset bob: %v", err)
+	}
+	updated, err := store.GetUserByID(ctx, bob.ID)
+	if err != nil {
+		t.Fatalf("get bob: %v", err)
+	}
+	ok, err := auth.VerifyPassword(updated.PasswordHash, "newpassword1")
+	if err != nil || !ok {
+		t.Fatalf("verify new password: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/auth/users_handlers.go
+++ b/internal/auth/users_handlers.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type userSummaryOut struct {
+	ID        int64  `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email,omitempty"`
+	Role      string `json:"role"`
+	Protected bool   `json:"protected"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+func (s *Service) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := s.ListUserAccounts(r.Context())
+	if err != nil {
+		writeAuthError(w, http.StatusInternalServerError, "list users")
+		return
+	}
+	adminID, _ := s.primaryAdminID(r.Context())
+	out := make([]userSummaryOut, len(users))
+	for i, u := range users {
+		o := userSummaryOut{
+			ID:        u.ID,
+			Username:  u.Username,
+			Email:     u.Email,
+			Role:      u.Role,
+			Protected: adminID != 0 && u.ID == adminID,
+		}
+		if !u.CreatedAt.IsZero() {
+			o.CreatedAt = u.CreatedAt.UTC().Format(time.RFC3339)
+		}
+		out[i] = o
+	}
+	writeJSONStatus(w, http.StatusOK, map[string]any{"users": out})
+}
+
+type createUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Email    string `json:"email"`
+	Role     string `json:"role"`
+}
+
+func (s *Service) handleCreateUser(w http.ResponseWriter, r *http.Request) {
+	var req createUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	u, err := s.CreateUserAccount(r.Context(), req.Username, req.Password, req.Email, req.Role)
+	if err != nil {
+		writeUserMgmtError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, map[string]any{"user": toUserOut(u)})
+}
+
+func (s *Service) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	id := IdentityFrom(r.Context())
+	if id == nil {
+		writeAuthError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	targetID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	if err := s.DeleteUserAccount(r.Context(), id.UserID, targetID); err != nil {
+		writeUserMgmtError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type updateRoleRequest struct {
+	Role string `json:"role"`
+}
+
+func (s *Service) handleUpdateUserRole(w http.ResponseWriter, r *http.Request) {
+	id := IdentityFrom(r.Context())
+	if id == nil {
+		writeAuthError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	targetID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	var req updateRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	u, err := s.SetUserRole(r.Context(), id.UserID, targetID, req.Role)
+	if err != nil {
+		writeUserMgmtError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusOK, map[string]any{"user": toUserOut(u)})
+}
+
+type resetPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+func (s *Service) handleResetUserPassword(w http.ResponseWriter, r *http.Request) {
+	targetID, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	var req resetPasswordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if err := s.ResetUserPassword(r.Context(), targetID, req.Password); err != nil {
+		writeUserMgmtError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeUserMgmtError maps service errors to appropriate HTTP status codes.
+func writeUserMgmtError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrUserExists):
+		writeAuthError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, ErrInvalidRole), errors.Is(err, ErrInvalidUsername), errors.Is(err, ErrWeakPassword):
+		writeAuthError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, ErrProtectedUser), errors.Is(err, ErrSelfModify):
+		writeAuthError(w, http.StatusForbidden, err.Error())
+	case errors.Is(err, ErrUserNotFound):
+		writeAuthError(w, http.StatusNotFound, err.Error())
+	default:
+		writeAuthError(w, http.StatusInternalServerError, "internal error")
+	}
+}

--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Compass,
   Inbox,
+  UsersRound,
   Download,
   Film,
   FolderOpen,
@@ -48,12 +49,14 @@ import {
 } from "@/components/command-palette";
 import { cn } from "@/lib/utils";
 import { PageHeaderProvider, usePageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
 
 interface NavItem {
   to: string;
   label: string;
   Icon: typeof LayoutDashboard;
   badge?: "review";
+  adminOnly?: boolean;
 }
 
 interface NavSection {
@@ -107,6 +110,7 @@ const NAV_SECTIONS: NavSection[] = [
     items: [
       { to: "/indexers/health", label: "Health", Icon: HeartPulse },
       { to: "/events", label: "Events", Icon: ScrollText },
+      { to: "/users", label: "Users", Icon: UsersRound, adminOnly: true },
       { to: "/settings", label: "Settings", Icon: Settings },
     ],
   },
@@ -138,6 +142,8 @@ function SidebarNav({
   const path = router.location.pathname;
   const reviewCount = useReviewCount();
   const searchLogEnabled = useFeatureEnabled("search_log");
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
 
   // Track which sections are expanded — all open by default
   const [openSections, setOpenSections] = React.useState<Record<string, boolean>>(() =>
@@ -194,6 +200,7 @@ function SidebarNav({
                 .filter(
                   ({ to }) => to !== "/search-queue" || searchLogEnabled,
                 )
+                .filter(({ adminOnly }) => !adminOnly || isAdmin)
                 .map(({ to, label, Icon, badge }) => {
                 const active =
                   to === "/" ? path === "/" : path === to || path.startsWith(`${to}/`);

--- a/web/src/lib/users-api.ts
+++ b/web/src/lib/users-api.ts
@@ -1,0 +1,155 @@
+// Typed fetch wrappers + react-query hooks for admin user management.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/fetch";
+
+export type UserRole = "admin" | "user";
+
+export interface ManagedUser {
+  id: number;
+  username: string;
+  email?: string;
+  role: UserRole;
+  protected: boolean;
+  created_at?: string;
+}
+
+export interface CreateUserInput {
+  username: string;
+  password: string;
+  email?: string;
+  role: UserRole;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  signal?: AbortSignal,
+): Promise<T> {
+  const init: RequestInit = { method, signal };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await apiFetch(path, init);
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  const text = await res.text();
+  let parsed: unknown;
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+  if (!res.ok) {
+    // Auth endpoints use {"error":"msg"}; others may use {error:{message}}.
+    const env = parsed as
+      | { error?: string | { message?: string } }
+      | undefined;
+    let message = `${method} ${path} failed: ${res.status} ${res.statusText}`;
+    if (typeof env?.error === "string") {
+      message = env.error;
+    } else if (env?.error?.message) {
+      message = env.error.message;
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parsed as T;
+}
+
+export async function listUsers(signal?: AbortSignal): Promise<ManagedUser[]> {
+  const data = await request<{ users: ManagedUser[] }>(
+    "GET",
+    "/api/v1/auth/users",
+    undefined,
+    signal,
+  );
+  return data?.users ?? [];
+}
+
+export async function createUser(body: CreateUserInput): Promise<ManagedUser> {
+  const data = await request<{ user: ManagedUser }>(
+    "POST",
+    "/api/v1/auth/users",
+    body,
+  );
+  return data.user;
+}
+
+export async function deleteUser(id: number): Promise<void> {
+  await request<void>("DELETE", `/api/v1/auth/users/${id}`);
+}
+
+export async function setUserRole(
+  id: number,
+  role: UserRole,
+): Promise<ManagedUser> {
+  const data = await request<{ user: ManagedUser }>(
+    "PATCH",
+    `/api/v1/auth/users/${id}/role`,
+    { role },
+  );
+  return data.user;
+}
+
+export async function resetUserPassword(
+  id: number,
+  password: string,
+): Promise<void> {
+  await request<void>("POST", `/api/v1/auth/users/${id}/password`, { password });
+}
+
+const USERS_KEY = ["auth", "users"] as const;
+
+export function useUsers() {
+  return useQuery({
+    queryKey: USERS_KEY,
+    queryFn: ({ signal }) => listUsers(signal),
+  });
+}
+
+export function useCreateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateUserInput) => createUser(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+  });
+}
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteUser(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+  });
+}
+
+export function useSetUserRole() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, role }: { id: number; role: UserRole }) =>
+      setUserRole(id, role),
+    onSuccess: () => qc.invalidateQueries({ queryKey: USERS_KEY }),
+  });
+}
+
+export function useResetUserPassword() {
+  return useMutation({
+    mutationFn: ({ id, password }: { id: number; password: string }) =>
+      resetUserPassword(id, password),
+  });
+}

--- a/web/src/pages/users.tsx
+++ b/web/src/pages/users.tsx
@@ -1,0 +1,444 @@
+import * as React from "react";
+import { usePageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
+import { toast } from "sonner";
+import {
+  useUsers,
+  useCreateUser,
+  useDeleteUser,
+  useSetUserRole,
+  useResetUserPassword,
+  ApiError,
+  type ManagedUser,
+  type UserRole,
+} from "@/lib/users-api";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Loader2, Plus, Trash2, KeyRound, Users, ShieldAlert } from "lucide-react";
+
+function errMessage(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return fallback;
+}
+
+function RoleBadge({ role }: { role: UserRole }) {
+  return (
+    <Badge
+      variant="outline"
+      className={
+        role === "admin"
+          ? "border-amber-500/40 text-amber-600 dark:text-amber-400"
+          : "text-muted-foreground"
+      }
+    >
+      {role}
+    </Badge>
+  );
+}
+
+function CreateUserCard() {
+  const create = useCreateUser();
+  const [username, setUsername] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [password, setPassword] = React.useState("");
+  const [role, setRole] = React.useState<UserRole>("user");
+
+  const canSubmit =
+    username.trim().length > 0 && password.length >= 8 && !create.isPending;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    create.mutate(
+      { username: username.trim(), email: email.trim() || undefined, password, role },
+      {
+        onSuccess: () => {
+          toast.success(`User "${username.trim()}" created`);
+          setUsername("");
+          setEmail("");
+          setPassword("");
+          setRole("user");
+        },
+        onError: (e) => toast.error(errMessage(e, "Failed to create user")),
+      },
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Plus className="h-4 w-4" /> Add user
+        </CardTitle>
+        <CardDescription>
+          Create a login that can sign in with username and password.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={submit}
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5 lg:items-end"
+        >
+          <div className="space-y-1">
+            <Label htmlFor="nu-username">Username</Label>
+            <Input
+              id="nu-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="nu-email">Email (optional)</Label>
+            <Input
+              id="nu-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="nu-password">Password</Label>
+            <Input
+              id="nu-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              placeholder="min 8 characters"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Role</Label>
+            <Select value={role} onValueChange={(v) => setRole(v as UserRole)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">user</SelectItem>
+                <SelectItem value="admin">admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button type="submit" disabled={!canSubmit}>
+            {create.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResetPasswordDialog({
+  user,
+  onClose,
+}: {
+  user: ManagedUser | null;
+  onClose: () => void;
+}) {
+  const reset = useResetUserPassword();
+  const [password, setPassword] = React.useState("");
+
+  React.useEffect(() => {
+    setPassword("");
+  }, [user]);
+
+  function submit() {
+    if (!user || password.length < 8) return;
+    reset.mutate(
+      { id: user.id, password },
+      {
+        onSuccess: () => {
+          toast.success(`Password reset for "${user.username}"`);
+          onClose();
+        },
+        onError: (e) => toast.error(errMessage(e, "Failed to reset password")),
+      },
+    );
+  }
+
+  return (
+    <Dialog open={!!user} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset password</DialogTitle>
+          <DialogDescription>
+            Set a new password for {user?.username}.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1">
+          <Label htmlFor="rp-password">New password</Label>
+          <Input
+            id="rp-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            placeholder="min 8 characters"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={password.length < 8 || reset.isPending}
+          >
+            {reset.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Reset password
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DeleteUserDialog({
+  user,
+  onClose,
+}: {
+  user: ManagedUser | null;
+  onClose: () => void;
+}) {
+  const del = useDeleteUser();
+
+  function submit() {
+    if (!user) return;
+    del.mutate(user.id, {
+      onSuccess: () => {
+        toast.success(`User "${user.username}" deleted`);
+        onClose();
+      },
+      onError: (e) => toast.error(errMessage(e, "Failed to delete user")),
+    });
+  }
+
+  return (
+    <Dialog open={!!user} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete user</DialogTitle>
+          <DialogDescription>
+            Permanently delete {user?.username}? This cannot be undone. Their API
+            keys will also be removed.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={submit}
+            disabled={del.isPending}
+          >
+            {del.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function UsersTable({ currentUserId }: { currentUserId: number }) {
+  const { data: users, isLoading } = useUsers();
+  const setRole = useSetUserRole();
+  const [resetTarget, setResetTarget] = React.useState<ManagedUser | null>(null);
+  const [deleteTarget, setDeleteTarget] = React.useState<ManagedUser | null>(
+    null,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 p-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading users…
+      </div>
+    );
+  }
+
+  const rows = users ?? [];
+
+  function changeRole(u: ManagedUser, role: UserRole) {
+    if (role === u.role) return;
+    setRole.mutate(
+      { id: u.id, role },
+      {
+        onSuccess: () => toast.success(`${u.username} is now ${role}`),
+        onError: (e) => toast.error(errMessage(e, "Failed to change role")),
+      },
+    );
+  }
+
+  return (
+    <>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Username</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((u) => {
+              const isSelf = u.id === currentUserId;
+              const locked = u.protected || isSelf;
+              return (
+                <TableRow key={u.id}>
+                  <TableCell className="font-medium">
+                    <span className="flex items-center gap-2">
+                      {u.username}
+                      {u.protected && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          primary admin
+                        </Badge>
+                      )}
+                      {isSelf && !u.protected && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          you
+                        </Badge>
+                      )}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {u.email || "—"}
+                  </TableCell>
+                  <TableCell>
+                    {locked ? (
+                      <RoleBadge role={u.role} />
+                    ) : (
+                      <Select
+                        value={u.role}
+                        onValueChange={(v) => changeRole(u, v as UserRole)}
+                      >
+                        <SelectTrigger className="h-8 w-28">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="user">user</SelectItem>
+                          <SelectItem value="admin">admin</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={u.protected}
+                        onClick={() => setResetTarget(u)}
+                      >
+                        <KeyRound className="mr-1 h-3.5 w-3.5" /> Password
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        disabled={locked}
+                        onClick={() => setDeleteTarget(u)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {rows.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="py-6 text-center text-sm text-muted-foreground"
+                >
+                  No users.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <ResetPasswordDialog
+        user={resetTarget}
+        onClose={() => setResetTarget(null)}
+      />
+      <DeleteUserDialog
+        user={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+      />
+    </>
+  );
+}
+
+export function UsersPage() {
+  const { setHeader } = usePageHeader();
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  React.useEffect(() => setHeader({ title: "Users" }), [setHeader]);
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-12 text-center text-muted-foreground">
+        <ShieldAlert className="h-8 w-8" />
+        <p>You need admin access to manage users.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <section className="space-y-1">
+        <h2 className="flex items-center gap-2 text-lg font-semibold">
+          <Users className="h-5 w-5" /> User accounts
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Create and manage logins. Non-admin users can submit requests; admins
+          can approve them and manage the system.
+        </p>
+      </section>
+
+      <CreateUserCard />
+
+      <UsersTable currentUserId={user?.id ?? -1} />
+    </div>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -282,6 +282,14 @@ const requestsRoute = createRoute({
   errorComponent: ErrorFallback,
 });
 
+const usersRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/users",
+  component: lazyRouteComponent(() => import("@/pages/users"), "UsersPage"),
+  pendingComponent: PageLoader,
+  errorComponent: ErrorFallback,
+});
+
 const eventsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/events",
@@ -334,6 +342,7 @@ const routeTree = rootRoute.addChildren([
   seriesRoute,
   discoverRoute,
   requestsRoute,
+  usersRoute,
   activityRoute,
   calendarRoute,
   indexerHealthRoute,


### PR DESCRIPTION
Adds an admin-only Users page + backend so admins can create non-admin logins for the media-requests flow (currently every account is the single config-managed admin).

## Backend (internal/auth)
- **Store**: `ListUsers`/`DeleteUser`/`UpdateUserRole` (raw SQL, sqlite+postgres); added `*sql.DB` to both stores; tolerant `created_at` scan.
- **Service** (`usermgmt.go`): list/create/delete/set-role/reset-password with role+password validation, dup-check, unique-violation→`ErrUserExists`.
- **Guards**: cannot delete or change-role of yourself or the protected primary admin; password reset blocks the (config-managed) primary admin; `primaryAdminID` fails closed on corrupt metadata.
- **Lost-admin prevention**: `ReconcileAdmin` now forces the primary admin's role back to `admin` on startup, self-healing any OIDC/proxy demotion.
- **Handlers**: admin-gated `/api/v1/auth/users` (GET/POST, DELETE/{id}, PATCH/{id}/role, POST/{id}/password) under `RequireRole("admin")`.
- **Tests**: create/list/validation/delete-guards/role-guards/password reset — all pass. Also repaired the pre-existing `middleware_test` harness (was missing `AppConfig`, failing on main).

## Frontend
- `users-api.ts` react-query hooks; `/users` admin page (create form, role badges, inline role change, password-reset + delete dialogs); `/users` route; admin-only nav entry under System.

No DB migration needed (users table already exists). DB-created users can log in via existing `handleLogin` (password + role from their row).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>