### PR TITLE
feat(requests): per-user request quotas & limits (#14)

### DIFF
--- a/internal/requests/handlers.go
+++ b/internal/requests/handlers.go
@@ -24,6 +24,7 @@ func Router(svc *Service, adminOnly func(http.Handler) http.Handler) chi.Router 
 	// Any authenticated user.
 	r.Post("/", svc.handleCreate)
 	r.Get("/mine", svc.handleListMine)
+	r.Get("/quota", svc.handleQuotaStatus)
 
 	// Admin only.
 	r.Group(func(ar chi.Router) {
@@ -31,6 +32,8 @@ func Router(svc *Service, adminOnly func(http.Handler) http.Handler) chi.Router 
 		ar.Get("/", svc.handleListAll)
 		ar.Post("/{id}/approve", svc.handleApprove)
 		ar.Post("/{id}/reject", svc.handleReject)
+		ar.Get("/quota/config", svc.handleGetQuotaConfig)
+		ar.Put("/quota/config", svc.handleSetQuotaConfig)
 	})
 
 	return r
@@ -59,7 +62,7 @@ func (s *Service) handleCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	req, err := s.Create(r.Context(), userIDStr(id), id.Username, in)
+	req, err := s.Create(r.Context(), userIDStr(id), id.Username, id.HasRole("admin"), in)
 	switch {
 	case errors.Is(err, ErrDuplicate):
 		writeError(w, http.StatusConflict, err.Error())
@@ -67,11 +70,55 @@ func (s *Service) handleCreate(w http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, ErrAlreadyAvailable):
 		writeError(w, http.StatusConflict, "this title is already in your library")
 		return
+	case errors.Is(err, ErrQuotaExceeded):
+		writeError(w, http.StatusTooManyRequests, "you have reached your request limit; try again later")
+		return
 	case err != nil:
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusCreated, req)
+}
+
+func (s *Service) handleQuotaStatus(w http.ResponseWriter, r *http.Request) {
+	id := auth.IdentityFrom(r.Context())
+	if id == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	status, err := s.QuotaStatus(r.Context(), userIDStr(id), id.HasRole("admin"))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+func (s *Service) handleGetQuotaConfig(w http.ResponseWriter, r *http.Request) {
+	cfg, err := s.GetQuotaConfig(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+func (s *Service) handleSetQuotaConfig(w http.ResponseWriter, r *http.Request) {
+	var cfg QuotaConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	saved, err := s.SetQuotaConfig(r.Context(), cfg)
+	switch {
+	case errors.Is(err, ErrInvalidQuota):
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, saved)
 }
 
 func (s *Service) handleListMine(w http.ResponseWriter, r *http.Request) {

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 )
 
 // Fulfiller adds requested media to the library and triggers a grab. It is the
@@ -77,8 +78,9 @@ var ErrAlreadyAvailable = errors.New("requests: media already available")
 
 // Create validates and stores a new request on behalf of the given user. It
 // rejects unsupported media types, missing TMDB ids, already-available media,
-// and duplicate open requests.
-func (s *Service) Create(ctx context.Context, userID, username string, in CreateInput) (Request, error) {
+// and duplicate open requests. Non-admin users are subject to the configured
+// per-user quota; admins (isAdmin) bypass it.
+func (s *Service) Create(ctx context.Context, userID, username string, isAdmin bool, in CreateInput) (Request, error) {
 	if !validMediaType(in.MediaType) {
 		return Request{}, fmt.Errorf("requests: invalid media type %q", in.MediaType)
 	}
@@ -100,7 +102,7 @@ func (s *Service) Create(ctx context.Context, userID, username string, in Create
 		}
 	}
 
-	return s.store.Create(ctx, Request{
+	req := Request{
 		UserID:     userID,
 		Username:   username,
 		MediaType:  in.MediaType,
@@ -109,7 +111,36 @@ func (s *Service) Create(ctx context.Context, userID, username string, in Create
 		Year:       in.Year,
 		PosterPath: in.PosterPath,
 		Overview:   in.Overview,
-	})
+	}
+
+	// Enforce the per-user quota for non-admins when a limit is configured.
+	if !isAdmin {
+		cfg, err := s.store.GetQuotaConfig(ctx)
+		if err != nil {
+			return Request{}, fmt.Errorf("requests: loading quota: %w", err)
+		}
+		if limit := quotaLimitFor(cfg, in.MediaType); limit > 0 {
+			return s.store.CreateWithinQuota(ctx, req, limit, quotaSince(cfg))
+		}
+	}
+
+	return s.store.Create(ctx, req)
+}
+
+// quotaLimitFor returns the configured limit for a media type (0 = unlimited).
+func quotaLimitFor(cfg QuotaConfig, mt MediaType) int {
+	if mt == MediaMovie {
+		return cfg.MovieLimit
+	}
+	return cfg.SeriesLimit
+}
+
+// quotaSince returns the start of the rolling quota window (zero = all time).
+func quotaSince(cfg QuotaConfig) time.Time {
+	if cfg.WindowDays <= 0 {
+		return time.Time{}
+	}
+	return time.Now().UTC().AddDate(0, 0, -cfg.WindowDays)
 }
 
 func (s *Service) mediaExists(ctx context.Context, mt MediaType, tmdbID string) (string, error) {
@@ -127,6 +158,68 @@ func (s *Service) ListAll(ctx context.Context, status Status) ([]Request, error)
 // ListMine returns the given user's requests.
 func (s *Service) ListMine(ctx context.Context, userID string) ([]Request, error) {
 	return s.store.ListByUser(ctx, userID)
+}
+
+// GetQuotaConfig returns the global per-user request quota.
+func (s *Service) GetQuotaConfig(ctx context.Context) (QuotaConfig, error) {
+	return s.store.GetQuotaConfig(ctx)
+}
+
+// ErrInvalidQuota indicates a quota config failed validation.
+var ErrInvalidQuota = errors.New("requests: invalid quota configuration")
+
+// SetQuotaConfig validates and persists the global per-user request quota.
+// Limits must be non-negative; the window is clamped to [1, MaxWindowDays] and
+// defaults to DefaultWindowDays when limits are set without an explicit window.
+func (s *Service) SetQuotaConfig(ctx context.Context, c QuotaConfig) (QuotaConfig, error) {
+	if c.MovieLimit < 0 || c.SeriesLimit < 0 {
+		return QuotaConfig{}, fmt.Errorf("%w: limits must be non-negative", ErrInvalidQuota)
+	}
+	if c.WindowDays <= 0 {
+		c.WindowDays = DefaultWindowDays
+	}
+	if c.WindowDays > MaxWindowDays {
+		return QuotaConfig{}, fmt.Errorf("%w: window_days must be <= %d", ErrInvalidQuota, MaxWindowDays)
+	}
+	if err := s.store.SetQuotaConfig(ctx, c); err != nil {
+		return QuotaConfig{}, err
+	}
+	return c, nil
+}
+
+// QuotaStatus reports a user's current quota usage. Admins (isAdmin) are
+// exempt and reported as unlimited, though their usage is still counted for
+// informational display.
+func (s *Service) QuotaStatus(ctx context.Context, userID string, isAdmin bool) (QuotaStatus, error) {
+	cfg, err := s.store.GetQuotaConfig(ctx)
+	if err != nil {
+		return QuotaStatus{}, err
+	}
+	since := quotaSince(cfg)
+	movieUsed, err := s.store.CountUserRequests(ctx, userID, MediaMovie, since)
+	if err != nil {
+		return QuotaStatus{}, err
+	}
+	seriesUsed, err := s.store.CountUserRequests(ctx, userID, MediaSeries, since)
+	if err != nil {
+		return QuotaStatus{}, err
+	}
+	return QuotaStatus{
+		WindowDays: cfg.WindowDays,
+		Movie:      mediaQuota(cfg.MovieLimit, movieUsed, isAdmin),
+		Series:     mediaQuota(cfg.SeriesLimit, seriesUsed, isAdmin),
+	}, nil
+}
+
+func mediaQuota(limit, used int, isAdmin bool) MediaQuota {
+	if isAdmin || limit <= 0 {
+		return MediaQuota{Limit: limit, Used: used, Remaining: -1, Unlimited: true}
+	}
+	remaining := limit - used
+	if remaining < 0 {
+		remaining = 0
+	}
+	return MediaQuota{Limit: limit, Used: used, Remaining: remaining, Unlimited: false}
 }
 
 // Approve fulfills a pending request: it validates the admin-chosen target,

--- a/internal/requests/service_test.go
+++ b/internal/requests/service_test.go
@@ -90,7 +90,7 @@ func TestCreateAndListMine(t *testing.T) {
 	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
 	ctx := context.Background()
 
-	r, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603", Title: "The Matrix"})
+	r, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603", Title: "The Matrix"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -111,10 +111,10 @@ func TestCreateRejectsInvalid(t *testing.T) {
 	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
 	ctx := context.Background()
 
-	if _, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: "music", TMDBID: "1"}); err == nil {
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: "music", TMDBID: "1"}); err == nil {
 		t.Fatal("expected invalid media type error")
 	}
-	if _, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "  "}); err == nil {
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "  "}); err == nil {
 		t.Fatal("expected missing tmdb error")
 	}
 }
@@ -123,10 +123,10 @@ func TestCreateDuplicateOpen(t *testing.T) {
 	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
 	ctx := context.Background()
 
-	if _, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	_, err := svc.Create(ctx, "2", "bob", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	_, err := svc.Create(ctx, "2", "bob", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	if !errors.Is(err, ErrDuplicate) {
 		t.Fatalf("err = %v, want ErrDuplicate", err)
 	}
@@ -135,7 +135,7 @@ func TestCreateDuplicateOpen(t *testing.T) {
 func TestCreateAlreadyAvailable(t *testing.T) {
 	f := &fakeFulfiller{movieExists: map[string]string{"603": "movie-1"}}
 	svc := newSvc(t, f, okValidator{})
-	_, err := svc.Create(context.Background(), "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	_, err := svc.Create(context.Background(), "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	if !errors.Is(err, ErrAlreadyAvailable) {
 		t.Fatalf("err = %v, want ErrAlreadyAvailable", err)
 	}
@@ -146,7 +146,7 @@ func TestApproveHappyPath(t *testing.T) {
 	svc := newSvc(t, f, okValidator{})
 	ctx := context.Background()
 
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	out, err := svc.Approve(ctx, r.ID, "qp-1", "lib-1", "admin")
 	if err != nil {
 		t.Fatalf("Approve: %v", err)
@@ -162,7 +162,7 @@ func TestApproveHappyPath(t *testing.T) {
 func TestApproveValidatesTarget(t *testing.T) {
 	svc := newSvc(t, &fakeFulfiller{}, rejectValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	if _, err := svc.Approve(ctx, r.ID, "bad-qp", "bad-lib", "admin"); err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -183,7 +183,7 @@ func TestApproveFulfillFailureMarksFailed(t *testing.T) {
 	f := &fakeFulfiller{fulfillErr: errors.New("boom")}
 	svc := newSvc(t, f, okValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	if _, err := svc.Approve(ctx, r.ID, "qp", "lib", "admin"); err == nil {
 		t.Fatal("expected fulfillment error")
 	}
@@ -192,7 +192,7 @@ func TestApproveFulfillFailureMarksFailed(t *testing.T) {
 		t.Fatalf("status = %q, want failed", got.Status)
 	}
 	// A failed request is re-requestable.
-	if _, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
 		t.Fatalf("resubmit after failure: %v", err)
 	}
 }
@@ -201,7 +201,7 @@ func TestApproveAlreadyExistingShortCircuits(t *testing.T) {
 	f := &fakeFulfiller{}
 	svc := newSvc(t, f, okValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	// Media appears in the library between create and approve.
 	f.mu.Lock()
 	f.movieExists = map[string]string{"603": "movie-7"}
@@ -223,7 +223,7 @@ func TestApproveConcurrentClaimsOnce(t *testing.T) {
 	f := &fakeFulfiller{fulfilledMedia: "movie-1"}
 	svc := newSvc(t, f, okValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 
 	var wg sync.WaitGroup
 	var success int32
@@ -249,7 +249,7 @@ func TestRejectAfterApproveFails(t *testing.T) {
 	f := &fakeFulfiller{fulfilledMedia: "movie-1"}
 	svc := newSvc(t, f, okValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	if _, err := svc.Approve(ctx, r.ID, "qp", "lib", "admin"); err != nil {
 		t.Fatalf("Approve: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestRejectAfterApproveFails(t *testing.T) {
 func TestReject(t *testing.T) {
 	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
 	ctx := context.Background()
-	r, _ := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"})
+	r, _ := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"})
 	out, err := svc.Reject(ctx, r.ID, "not now", "admin")
 	if err != nil {
 		t.Fatalf("Reject: %v", err)
@@ -270,7 +270,123 @@ func TestReject(t *testing.T) {
 		t.Fatalf("out = %+v", out)
 	}
 	// Rejected request is re-requestable.
-	if _, err := svc.Create(ctx, "1", "alice", CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "603"}); err != nil {
 		t.Fatalf("resubmit after reject: %v", err)
+	}
+}
+
+func TestQuotaEnforcement(t *testing.T) {
+	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
+	ctx := context.Background()
+
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 2, SeriesLimit: 0, WindowDays: 7}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+
+	// Two distinct movie requests are allowed.
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "1"}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "2"}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	// Third exceeds the movie quota.
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "3"}); !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("third movie: expected ErrQuotaExceeded, got %v", err)
+	}
+	// Series is unlimited (limit 0) so it still works.
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaSeries, TMDBID: "10"}); err != nil {
+		t.Fatalf("series unlimited: %v", err)
+	}
+	// A different user has their own quota.
+	if _, err := svc.Create(ctx, "2", "bob", false, CreateInput{MediaType: MediaMovie, TMDBID: "4"}); err != nil {
+		t.Fatalf("other user: %v", err)
+	}
+}
+
+func TestQuotaAdminBypass(t *testing.T) {
+	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
+	ctx := context.Background()
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 1, WindowDays: 7}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+	for i, tmdb := range []string{"1", "2", "3"} {
+		if _, err := svc.Create(ctx, "9", "admin", true, CreateInput{MediaType: MediaMovie, TMDBID: tmdb}); err != nil {
+			t.Fatalf("admin create %d: %v", i, err)
+		}
+	}
+}
+
+func TestQuotaRejectedDoesNotCount(t *testing.T) {
+	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
+	ctx := context.Background()
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 1, WindowDays: 7}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+	r, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "1"})
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// At the limit now.
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "2"}); !errors.Is(err, ErrQuotaExceeded) {
+		t.Fatalf("expected quota exceeded, got %v", err)
+	}
+	// Rejecting the first frees the slot.
+	if _, err := svc.Reject(ctx, r.ID, "no", "admin"); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "2"}); err != nil {
+		t.Fatalf("after reject: %v", err)
+	}
+}
+
+func TestQuotaStatusReporting(t *testing.T) {
+	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
+	ctx := context.Background()
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 5, SeriesLimit: 0, WindowDays: 7}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+	if _, err := svc.Create(ctx, "1", "alice", false, CreateInput{MediaType: MediaMovie, TMDBID: "1"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	st, err := svc.QuotaStatus(ctx, "1", false)
+	if err != nil {
+		t.Fatalf("QuotaStatus: %v", err)
+	}
+	if st.WindowDays != 7 {
+		t.Fatalf("window = %d, want 7", st.WindowDays)
+	}
+	if st.Movie.Limit != 5 || st.Movie.Used != 1 || st.Movie.Remaining != 4 || st.Movie.Unlimited {
+		t.Fatalf("movie quota = %+v", st.Movie)
+	}
+	if !st.Series.Unlimited || st.Series.Remaining != -1 {
+		t.Fatalf("series quota = %+v", st.Series)
+	}
+	// Admin sees unlimited even with a configured limit.
+	adminSt, err := svc.QuotaStatus(ctx, "9", true)
+	if err != nil {
+		t.Fatalf("admin QuotaStatus: %v", err)
+	}
+	if !adminSt.Movie.Unlimited {
+		t.Fatalf("admin movie should be unlimited: %+v", adminSt.Movie)
+	}
+}
+
+func TestSetQuotaConfigValidation(t *testing.T) {
+	svc := newSvc(t, &fakeFulfiller{}, okValidator{})
+	ctx := context.Background()
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: -1}); !errors.Is(err, ErrInvalidQuota) {
+		t.Fatalf("negative limit: got %v", err)
+	}
+	if _, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 3, WindowDays: 99999}); !errors.Is(err, ErrInvalidQuota) {
+		t.Fatalf("huge window: got %v", err)
+	}
+	// Zero window defaults to DefaultWindowDays.
+	saved, err := svc.SetQuotaConfig(ctx, QuotaConfig{MovieLimit: 3, WindowDays: 0})
+	if err != nil {
+		t.Fatalf("default window: %v", err)
+	}
+	if saved.WindowDays != DefaultWindowDays {
+		t.Fatalf("window = %d, want %d", saved.WindowDays, DefaultWindowDays)
 	}
 }

--- a/internal/requests/store.go
+++ b/internal/requests/store.go
@@ -20,6 +20,10 @@ var ErrDuplicate = errors.New("requests: an open request already exists for this
 // request's status changed concurrently (e.g. approved while being rejected).
 var ErrConflict = errors.New("requests: request state changed concurrently")
 
+// ErrQuotaExceeded is returned when a user has reached their request limit for a
+// media type within the configured rolling window.
+var ErrQuotaExceeded = errors.New("requests: request quota exceeded")
+
 // Store persists media requests.
 type Store struct {
 	db *sql.DB
@@ -231,4 +235,127 @@ func affectedOne(res sql.Result, err error) error {
 		return ErrConflict
 	}
 	return nil
+}
+
+// statusPlaceholders renders the quota-counted statuses as a SQL list and args.
+func statusPlaceholders() (string, []any) {
+	parts := make([]string, len(quotaCountedStatuses))
+	args := make([]any, len(quotaCountedStatuses))
+	for i, st := range quotaCountedStatuses {
+		parts[i] = "?"
+		args[i] = string(st)
+	}
+	return strings.Join(parts, ", "), args
+}
+
+// GetQuotaConfig returns the global per-user request quota.
+func (s *Store) GetQuotaConfig(ctx context.Context) (QuotaConfig, error) {
+	var c QuotaConfig
+	err := s.db.QueryRowContext(ctx,
+		`SELECT movie_limit, series_limit, window_days FROM request_quota_config WHERE id = 1`,
+	).Scan(&c.MovieLimit, &c.SeriesLimit, &c.WindowDays)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Defensive: row should exist from migration; treat as unlimited.
+		return QuotaConfig{WindowDays: DefaultWindowDays}, nil
+	}
+	return c, err
+}
+
+// SetQuotaConfig persists the global per-user request quota.
+func (s *Store) SetQuotaConfig(ctx context.Context, c QuotaConfig) error {
+	now := time.Now().UTC().Format(tsLayout)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE request_quota_config
+		SET movie_limit = ?, series_limit = ?, window_days = ?, updated_at = ?
+		WHERE id = 1`,
+		c.MovieLimit, c.SeriesLimit, c.WindowDays, now)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		_, err = s.db.ExecContext(ctx, `
+			INSERT INTO request_quota_config (id, movie_limit, series_limit, window_days, updated_at)
+			VALUES (1, ?, ?, ?, ?)`,
+			c.MovieLimit, c.SeriesLimit, c.WindowDays, now)
+	}
+	return err
+}
+
+// CountUserRequests returns how many of a user's requests for the given media
+// type currently consume a quota slot within the rolling window. A zero `since`
+// counts across all time.
+func (s *Store) CountUserRequests(ctx context.Context, userID string, mt MediaType, since time.Time) (int, error) {
+	statusList, statusArgs := statusPlaceholders()
+	q := `SELECT COUNT(*) FROM media_requests
+		WHERE user_id = ? AND media_type = ? AND status IN (` + statusList + `)`
+	args := append([]any{userID, string(mt)}, statusArgs...)
+	if !since.IsZero() {
+		q += ` AND created_at >= ?`
+		args = append(args, since.UTC().Format(tsLayout))
+	}
+	var n int
+	err := s.db.QueryRowContext(ctx, q, args...).Scan(&n)
+	return n, err
+}
+
+// CreateWithinQuota atomically enforces a per-user quota and inserts a new
+// pending request. It serializes against concurrent inserts (BEGIN IMMEDIATE)
+// so a user cannot exceed `limit` by racing. It returns ErrQuotaExceeded when
+// the user already has `limit` counted requests of r.MediaType in the window.
+func (s *Store) CreateWithinQuota(ctx context.Context, r Request, limit int, since time.Time) (Request, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Request{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Acquire a write lock up front so the count below cannot be invalidated by
+	// a concurrent insert before we commit.
+	if _, err := tx.ExecContext(ctx, `UPDATE request_quota_config SET id = id WHERE id = 1`); err != nil {
+		return Request{}, err
+	}
+
+	statusList, statusArgs := statusPlaceholders()
+	countQ := `SELECT COUNT(*) FROM media_requests
+		WHERE user_id = ? AND media_type = ? AND status IN (` + statusList + `)`
+	countArgs := append([]any{r.UserID, string(r.MediaType)}, statusArgs...)
+	if !since.IsZero() {
+		countQ += ` AND created_at >= ?`
+		countArgs = append(countArgs, since.UTC().Format(tsLayout))
+	}
+	var used int
+	if err := tx.QueryRowContext(ctx, countQ, countArgs...).Scan(&used); err != nil {
+		return Request{}, err
+	}
+	if used >= limit {
+		return Request{}, ErrQuotaExceeded
+	}
+
+	r.ID = uuid.NewString()
+	now := time.Now().UTC()
+	r.CreatedAt = now
+	r.UpdatedAt = now
+	r.Status = StatusPending
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO media_requests
+			(id, user_id, username, media_type, tmdb_id, title, year, poster_path,
+			 overview, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
+		r.ID, r.UserID, r.Username, string(r.MediaType), r.TMDBID, r.Title, r.Year,
+		r.PosterPath, r.Overview, now.Format(tsLayout), now.Format(tsLayout),
+	)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Request{}, ErrDuplicate
+		}
+		return Request{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Request{}, err
+	}
+	return r, nil
 }

--- a/internal/requests/types.go
+++ b/internal/requests/types.go
@@ -70,3 +70,39 @@ type CreateInput struct {
 func validMediaType(t MediaType) bool {
 	return t == MediaMovie || t == MediaSeries
 }
+
+// quotaCountedStatuses are the request states that consume a user's quota slot.
+// rejected/failed are re-requestable and therefore do not count.
+var quotaCountedStatuses = []Status{StatusPending, StatusApproving, StatusApproved, StatusAvailable}
+
+// Quota configuration bounds.
+const (
+	// DefaultWindowDays is the rolling window used when limits are first set.
+	DefaultWindowDays = 7
+	// MaxWindowDays caps the rolling window to keep counts bounded.
+	MaxWindowDays = 3650
+)
+
+// QuotaConfig is the global, per-user request quota. A limit of 0 means
+// unlimited for that media type. WindowDays is the rolling window (in days)
+// over which counted requests accumulate.
+type QuotaConfig struct {
+	MovieLimit  int `json:"movie_limit"`
+	SeriesLimit int `json:"series_limit"`
+	WindowDays  int `json:"window_days"`
+}
+
+// MediaQuota is a single media type's quota usage for a user.
+type MediaQuota struct {
+	Limit     int  `json:"limit"`     // 0 = unlimited
+	Used      int  `json:"used"`      // requests counted in the window
+	Remaining int  `json:"remaining"` // -1 = unlimited
+	Unlimited bool `json:"unlimited"`
+}
+
+// QuotaStatus is a user's current quota usage across media types.
+type QuotaStatus struct {
+	WindowDays int        `json:"window_days"`
+	Movie      MediaQuota `json:"movie"`
+	Series     MediaQuota `json:"series"`
+}

--- a/internal/storage/migrations/sqlite/0061_request_quotas.sql
+++ b/internal/storage/migrations/sqlite/0061_request_quotas.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+
+-- request_quota_config holds the global, per-user media-request quota. A single
+-- row (id=1) stores the limits applied to each non-admin user within a rolling
+-- window. A limit of 0 means unlimited (the default, preserving prior
+-- behaviour). Admins are exempt from quotas.
+CREATE TABLE IF NOT EXISTS request_quota_config (
+    id           INTEGER PRIMARY KEY CHECK (id = 1),
+    movie_limit  INTEGER NOT NULL DEFAULT 0,
+    series_limit INTEGER NOT NULL DEFAULT 0,
+    window_days  INTEGER NOT NULL DEFAULT 7,
+    updated_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO request_quota_config (id, movie_limit, series_limit, window_days)
+VALUES (1, 0, 0, 7);
+
+-- Supports the per-user quota count (user_id + media_type + created_at), scoped
+-- to the request statuses that consume a quota slot.
+CREATE INDEX IF NOT EXISTS idx_media_requests_quota
+    ON media_requests (user_id, media_type, created_at)
+    WHERE status IN ('pending', 'approving', 'approved', 'available');
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_media_requests_quota;
+DROP TABLE IF EXISTS request_quota_config;

--- a/web/src/lib/requests-api.ts
+++ b/web/src/lib/requests-api.ts
@@ -144,12 +144,53 @@ export async function rejectRequest(
   });
 }
 
+// ---------- Quotas ----------
+
+export interface MediaQuota {
+  limit: number;
+  used: number;
+  remaining: number; // -1 = unlimited
+  unlimited: boolean;
+}
+
+export interface QuotaStatus {
+  window_days: number;
+  movie: MediaQuota;
+  series: MediaQuota;
+}
+
+export interface QuotaConfig {
+  movie_limit: number;
+  series_limit: number;
+  window_days: number;
+}
+
+export async function getQuotaStatus(
+  signal?: AbortSignal,
+): Promise<QuotaStatus> {
+  return request("GET", "/api/v1/requests/quota", undefined, signal);
+}
+
+export async function getQuotaConfig(
+  signal?: AbortSignal,
+): Promise<QuotaConfig> {
+  return request("GET", "/api/v1/requests/quota/config", undefined, signal);
+}
+
+export async function updateQuotaConfig(
+  cfg: QuotaConfig,
+): Promise<QuotaConfig> {
+  return request("PUT", "/api/v1/requests/quota/config", cfg);
+}
+
 // ---------- Query keys ----------
 
 export const requestKeys = {
   all: ["requests"] as const,
   mine: () => [...requestKeys.all, "mine"] as const,
   list: (status?: string) => [...requestKeys.all, "list", status ?? "all"] as const,
+  quota: () => [...requestKeys.all, "quota"] as const,
+  quotaConfig: () => [...requestKeys.all, "quota", "config"] as const,
 };
 
 // ---------- React Query hooks ----------
@@ -197,6 +238,30 @@ export function useRejectRequest() {
   return useMutation({
     mutationFn: ({ id, reason }: { id: string; reason: string }) =>
       rejectRequest(id, reason),
+    onSuccess: () => qc.invalidateQueries({ queryKey: requestKeys.all }),
+  });
+}
+
+export function useQuotaStatus(enabled = true) {
+  return useQuery<QuotaStatus, Error>({
+    queryKey: requestKeys.quota(),
+    queryFn: ({ signal }) => getQuotaStatus(signal),
+    enabled,
+  });
+}
+
+export function useQuotaConfig(enabled = true) {
+  return useQuery<QuotaConfig, Error>({
+    queryKey: requestKeys.quotaConfig(),
+    queryFn: ({ signal }) => getQuotaConfig(signal),
+    enabled,
+  });
+}
+
+export function useUpdateQuotaConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: updateQuotaConfig,
     onSuccess: () => qc.invalidateQueries({ queryKey: requestKeys.all }),
   });
 }

--- a/web/src/pages/requests.tsx
+++ b/web/src/pages/requests.tsx
@@ -8,7 +8,11 @@ import {
   useCreateRequest,
   useApproveRequest,
   useRejectRequest,
+  useQuotaStatus,
+  useQuotaConfig,
+  useUpdateQuotaConfig,
   type MediaRequest,
+  type MediaQuota,
   type RequestMediaType,
   type RequestStatus,
 } from "@/lib/requests-api";
@@ -33,7 +37,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Check, Loader2, Plus, Search, X, Inbox } from "lucide-react";
+import { Check, Loader2, Plus, Search, X, Inbox, Gauge } from "lucide-react";
+import { toast } from "sonner";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
 
@@ -574,6 +579,132 @@ function ManageRequests() {
   );
 }
 
+function QuotaPill({ label, q }: { label: string; q: MediaQuota }) {
+  if (q.unlimited) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-md border border-border/60 px-2.5 py-1 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">{label}</span> unlimited
+      </span>
+    );
+  }
+  const exhausted = q.remaining <= 0;
+  return (
+    <span
+      className={
+        "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs " +
+        (exhausted
+          ? "border-destructive/40 text-destructive"
+          : "border-border/60 text-muted-foreground")
+      }
+    >
+      <span className="font-medium text-foreground">{label}</span>
+      {q.used} of {q.limit} used
+    </span>
+  );
+}
+
+function QuotaBanner() {
+  const { data, isLoading } = useQuotaStatus();
+  if (isLoading || !data) return null;
+  if (data.movie.unlimited && data.series.unlimited) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2">
+      <Gauge className="h-4 w-4 text-muted-foreground" />
+      <QuotaPill label="Movies" q={data.movie} />
+      <QuotaPill label="TV" q={data.series} />
+      <span className="text-xs text-muted-foreground">
+        in the last {data.window_days} day{data.window_days === 1 ? "" : "s"}
+      </span>
+    </div>
+  );
+}
+
+function QuotaConfigCard() {
+  const { data, isLoading } = useQuotaConfig();
+  const update = useUpdateQuotaConfig();
+  const [movie, setMovie] = React.useState("");
+  const [series, setSeries] = React.useState("");
+  const [windowDays, setWindowDays] = React.useState("");
+
+  React.useEffect(() => {
+    if (data) {
+      setMovie(String(data.movie_limit));
+      setSeries(String(data.series_limit));
+      setWindowDays(String(data.window_days));
+    }
+  }, [data]);
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading quota…</p>;
+  }
+
+  const toInt = (s: string) => Math.max(0, Math.floor(Number(s) || 0));
+
+  function save(e: React.FormEvent) {
+    e.preventDefault();
+    update.mutate(
+      {
+        movie_limit: toInt(movie),
+        series_limit: toInt(series),
+        window_days: Math.max(1, toInt(windowDays) || 7),
+      },
+      {
+        onSuccess: () => toast.success("Request quota saved"),
+        onError: (err) =>
+          toast.error(err instanceof Error ? err.message : "Failed to save quota"),
+      },
+    );
+  }
+
+  return (
+    <form
+      onSubmit={save}
+      className="flex flex-col gap-4 rounded-lg border border-border/60 p-4 sm:flex-row sm:items-end"
+    >
+      <div className="flex-1 space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Movies per user
+        </label>
+        <Input
+          type="number"
+          min={0}
+          value={movie}
+          onChange={(e) => setMovie(e.target.value)}
+        />
+      </div>
+      <div className="flex-1 space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          TV shows per user
+        </label>
+        <Input
+          type="number"
+          min={0}
+          value={series}
+          onChange={(e) => setSeries(e.target.value)}
+        />
+      </div>
+      <div className="flex-1 space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">
+          Window (days)
+        </label>
+        <Input
+          type="number"
+          min={1}
+          value={windowDays}
+          onChange={(e) => setWindowDays(e.target.value)}
+        />
+      </div>
+      <Button type="submit" disabled={update.isPending}>
+        {update.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        Save
+      </Button>
+      <p className="text-xs text-muted-foreground sm:max-w-[12rem]">
+        0 = unlimited. Admins are exempt from quotas.
+      </p>
+    </form>
+  );
+}
+
 export function RequestsPage() {
   const { setHeader } = usePageHeader();
   const { user } = useAuth();
@@ -586,6 +717,7 @@ export function RequestsPage() {
         <h2 className="flex items-center gap-2 text-lg font-semibold">
           <Inbox className="h-5 w-5" /> Request media
         </h2>
+        <QuotaBanner />
         <SearchAndRequest />
       </section>
 
@@ -593,6 +725,17 @@ export function RequestsPage() {
         <h2 className="text-lg font-semibold">My requests</h2>
         <MyRequests />
       </section>
+
+      {isAdmin && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">Request quota</h2>
+          <p className="text-sm text-muted-foreground">
+            Limit how many requests each non-admin user can make in a rolling
+            window.
+          </p>
+          <QuotaConfigCard />
+        </section>
+      )}
 
       {isAdmin && (
         <section className="space-y-3">


### PR DESCRIPTION
Adds configurable per-user request quotas to the media-requests flow (part of #14 Phase 2).

## What
- **Global config, applied per non-admin user**: movie limit, series limit, rolling window (days). Limit of 0 = unlimited (preserves current behaviour). Admins are exempt.
- **Counted statuses**: pending/approving/approved/available. Rejected/failed are re-requestable and don't count.

## Backend
- Migration 0061: `request_quota_config` single-row table + partial index on `media_requests` for fast windowed counts.
- `CreateWithinQuota` uses `BEGIN IMMEDIATE` to lock the config row, count, and insert atomically (closes a TOCTOU race).
- `Create` now takes `isAdmin`; enforces quota for non-admins. `Get/SetQuotaConfig` with validation. `QuotaStatus` reporting.
- Routes: `GET /quota` (authed), `GET/PUT /quota/config` (admin). `ErrQuotaExceeded` -> 429.
- 5 new quota tests, all pass.

## Frontend
- Quota banner for users ("Movies: 2 of 5 used in the last 7 days").
- Admin quota config form. 429 surfaced inline on request submit.

## Tests
- `go test ./internal/requests/` green; frontend `tsc` + `build` green.