### PR TITLE
fix(ux): stop Settings sub-nav from remounting on section change

### DIFF
--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -187,7 +187,12 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
   const [mobileOpen, setMobileOpen] = React.useState(false);
   const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPalette();
   const { header } = usePageHeader();
-  const routePath = useRouterState({ select: (s) => s.location.pathname });
+  // Animate (and remount) only when the top-level section changes, so that
+  // navigating between sub-pages within a section (e.g. Settings) swaps the
+  // content without remounting the section's own layout/sub-nav.
+  const sectionKey = useRouterState({
+    select: (s) => "/" + (s.location.pathname.split("/")[1] ?? ""),
+  });
 
   return (
     <div className="flex min-h-screen w-full bg-background text-foreground">
@@ -309,7 +314,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
         )}
 
         <main id="main" className="min-w-0 flex-1 overflow-x-hidden p-4 md:p-6">
-          <div key={routePath} className="page-enter">
+          <div key={sectionKey} className="page-enter">
             {children ?? <Outlet />}
           </div>
         </main>

--- a/web/src/components/layout/settings-layout.tsx
+++ b/web/src/components/layout/settings-layout.tsx
@@ -269,15 +269,17 @@ export function SettingsLayout() {
 
       {/* Content */}
       <div className="min-w-0">
-        {active?.kind === "panel" && (
-          <header className="mb-5">
-            <h1 className="text-xl font-semibold tracking-tight">{active.label}</h1>
-            {active.description && (
-              <p className="mt-1 text-sm text-muted-foreground">{active.description}</p>
-            )}
-          </header>
-        )}
-        <Outlet />
+        <div key={active?.to ?? path} className="page-enter">
+          {active?.kind === "panel" && (
+            <header className="mb-5">
+              <h1 className="text-xl font-semibold tracking-tight">{active.label}</h1>
+              {active.description && (
+                <p className="mt-1 text-sm text-muted-foreground">{active.description}</p>
+              )}
+            </header>
+          )}
+          <Outlet />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up to #35.

## Problem
Navigating between Settings areas made the sub-menu visibly refresh/jump instead of only swapping the content.

## Cause
`AppLayout` keyed its animated content wrapper on the **full pathname**, so every navigation remounted the entire route subtree — including a section's own layout + sub-nav.

## Fix
- Key the wrapper on the **top-level path segment** only, so navigating within a section (e.g. `/settings/*`) keeps the section layout and sub-nav mounted.
- Add a content-only fade inside `SettingsLayout` (keyed on the active sub-route) so the content still transitions smoothly while the menu stays put.

## Verification
tsc + build green; settings-layout lints clean; only pre-existing baseline a11y errors remain elsewhere.