### PR TITLE
fix(ux): reset scroll on Settings section change to stop sub-nav shift

### DIFF
--- a/web/src/components/layout/settings-layout.tsx
+++ b/web/src/components/layout/settings-layout.tsx
@@ -204,6 +204,16 @@ export function SettingsLayout() {
     }
   }, [active, setHeader]);
 
+  // The settings layout stays mounted while sub-routes swap, so the window scroll
+  // position is otherwise preserved across navigation. Reset it to the top on each
+  // section change; without this, landing on a tall, async-loading panel (e.g.
+  // Libraries & Naming) while scrolled down causes the sticky sub-nav to visibly
+  // shift as the content clamps and then grows.
+  const activeTo = active?.to;
+  React.useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, [activeTo]);
+
   return (
     <div className="grid gap-6 lg:grid-cols-[15rem_1fr]">
       {/* Mobile section picker */}


### PR DESCRIPTION
Follow-up to #35 / #37.

## Problem
Opening the **Libraries & Naming** area shifted the Settings sub-nav down.

## Cause
The Settings layout now stays mounted while sub-routes swap (#37), so window scroll is preserved across navigation (no scroll restoration is configured). Landing on a tall, async-loading panel while scrolled down made the content clamp to a short loading state then grow — scroll anchoring moved the page and shifted the sticky sub-nav. Libraries & Naming is the worst case (3 async-loading panels).

## Fix
Reset window scroll to top whenever the active settings sub-route changes, so every panel loads from a stable position. Verified with a Playwright layout repro: sticky nav stays fixed throughout the async grow.

tsc + build + lint green.