### PR TITLE
polish(ui): finish loading/empty-state sweep

### DIFF
--- a/web/src/pages/indexer-health.tsx
+++ b/web/src/pages/indexer-health.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { RotateCcw, ChevronDown, ChevronUp } from "lucide-react";
+import { RotateCcw, ChevronDown, ChevronUp, HeartPulse } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSetPageHeader } from "@/hooks/use-page-header";
 import { useApiClient } from "@/lib/api-client";
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 
 // ---------- Types ----------
 
@@ -263,16 +264,19 @@ export function IndexerHealthPage() {
       {!isLoading && !isError && (
         <>
           <SummaryBar items={items} />
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {items.map((item) => (
-              <HealthCard key={item.indexer_id} item={item} />
-            ))}
-            {items.length === 0 && (
-              <p className="col-span-full text-sm text-muted-foreground">
-                No indexer health data available yet.
-              </p>
-            )}
-          </div>
+          {items.length === 0 ? (
+            <EmptyState
+              icon={<HeartPulse />}
+              title="No indexer health data yet"
+              description="Health metrics appear here once your indexers have run some searches."
+            />
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {items.map((item) => (
+                <HealthCard key={item.indexer_id} item={item} />
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/web/src/pages/metadata.tsx
+++ b/web/src/pages/metadata.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Plus, RefreshCw, Play } from "lucide-react";
+import { Plus, RefreshCw, Play, SearchX } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
   Tabs,
   TabsContent,
@@ -125,9 +126,11 @@ function ResultsGrid({
 
   if (!results || results.length === 0) {
     return (
-      <div className="rounded-md border border-dashed border-border p-8 text-center text-muted-foreground">
-        No results. Try a different search.
-      </div>
+      <EmptyState
+        icon={<SearchX />}
+        title="No results"
+        description="Try a different search term or check your spelling."
+      />
     );
   }
 


### PR DESCRIPTION
Final pass of the UI loading/empty-state sweep.

Audited every remaining page. Most already had appropriate loading skeletons/spinners and empty states (movies & series even have filtered-empty states; the tracker was stale). The only genuine gaps were two pages using ad-hoc empty markup:

- **Indexer Health**: `No indexer health data available yet` plain text → shared `EmptyState` (HeartPulse icon + description).
- **Metadata**: `No results` dashed-border div → shared `EmptyState` (SearchX icon + description).

tsc + build green; changed files lint clean (metadata's remaining lint errors are pre-existing baseline).