### PR TITLE
feat(auth): self-service invite links

### DIFF
--- a/cmd/loom/auth.go
+++ b/cmd/loom/auth.go
@@ -47,5 +47,6 @@ func buildAuthService(ctx context.Context, cfg *config.Config, db storage.DB, ap
 		CookieSecure:  cfg.Auth.CookieSecure,
 		OIDC:          oidc,
 		Proxy:         proxyCfg,
+		Invites:       auth.NewInviteStore(db.DB()),
 	})
 }

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -20,6 +20,9 @@ func (s *Service) Mount(r chi.Router) {
 		r.Post("/logout", s.handleLogout)
 		r.Get("/oidc/login", s.handleOIDCLogin)
 		r.Get("/oidc/callback", s.handleOIDCCallback)
+		// Public invite redemption (token holder self-registers).
+		r.Get("/invites/redeem/{token}", s.handlePublicInvite)
+		r.Post("/invites/redeem/{token}/accept", s.handleAcceptInvite)
 		r.Group(func(r chi.Router) {
 			r.Use(s.RequireAuth)
 			r.Get("/me", s.handleMe)
@@ -34,6 +37,9 @@ func (s *Service) Mount(r chi.Router) {
 			r.Delete("/users/{id}", s.handleDeleteUser)
 			r.Patch("/users/{id}/role", s.handleUpdateUserRole)
 			r.Post("/users/{id}/password", s.handleResetUserPassword)
+			r.Post("/invites", s.handleCreateInvite)
+			r.Get("/invites", s.handleListInvites)
+			r.Delete("/invites/{id}", s.handleRevokeInvite)
 		})
 	})
 }

--- a/internal/auth/invites.go
+++ b/internal/auth/invites.go
@@ -1,0 +1,208 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Invite-related errors surfaced to handlers.
+var (
+	ErrInvitesDisabled = errors.New("auth: invites are not enabled")
+	ErrInviteInvalid   = errors.New("auth: invite is invalid, expired, or already used")
+)
+
+// Invite expiry bounds. Admin-supplied durations are clamped to this range so a
+// mistake can't create an immediately-expired or effectively-permanent link.
+const (
+	defaultInviteTTL = 7 * 24 * time.Hour
+	minInviteTTL     = time.Hour
+	maxInviteTTL     = 90 * 24 * time.Hour
+)
+
+// InviteStatus is the derived lifecycle state of an invite.
+type InviteStatus string
+
+const (
+	InvitePending InviteStatus = "pending"
+	InviteUsed    InviteStatus = "used"
+	InviteExpired InviteStatus = "expired"
+)
+
+// status derives an invite's lifecycle state at time now.
+func inviteStatus(inv Invite, now time.Time) InviteStatus {
+	switch {
+	case !inv.UsedAt.IsZero():
+		return InviteUsed
+	case !inv.ExpiresAt.IsZero() && !inv.ExpiresAt.After(now):
+		return InviteExpired
+	default:
+		return InvitePending
+	}
+}
+
+// generateInviteToken returns a URL-safe, high-entropy (256-bit) token.
+func generateInviteToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// CreateInvite provisions a single-use invite with a pre-assigned role. ttl is
+// clamped to [minInviteTTL, maxInviteTTL]; a non-positive ttl uses the default.
+func (s *Service) CreateInvite(ctx context.Context, actorID int64, email, role string, ttl time.Duration) (Invite, error) {
+	if s.invites == nil {
+		return Invite{}, ErrInvitesDisabled
+	}
+	email = strings.TrimSpace(email)
+	if role == "" {
+		role = "user"
+	}
+	if !validRole(role) {
+		return Invite{}, ErrInvalidRole
+	}
+	switch {
+	case ttl <= 0:
+		ttl = defaultInviteTTL
+	case ttl < minInviteTTL:
+		ttl = minInviteTTL
+	case ttl > maxInviteTTL:
+		ttl = maxInviteTTL
+	}
+	token, err := generateInviteToken()
+	if err != nil {
+		return Invite{}, err
+	}
+	now := time.Now().UTC()
+	inv := Invite{
+		ID:        uuid.NewString(),
+		Token:     token,
+		Email:     email,
+		Role:      role,
+		CreatedBy: actorID,
+		CreatedAt: now,
+		ExpiresAt: now.Add(ttl),
+	}
+	if err := s.invites.Create(ctx, inv); err != nil {
+		return Invite{}, err
+	}
+	s.logger.Info("invite created", "id", inv.ID, "role", role, "actor", actorID, "expires_at", inv.ExpiresAt)
+	return inv, nil
+}
+
+// ListInvites returns all invites for admin display.
+func (s *Service) ListInvites(ctx context.Context) ([]Invite, error) {
+	if s.invites == nil {
+		return nil, ErrInvitesDisabled
+	}
+	return s.invites.List(ctx)
+}
+
+// InviteStatusAt exposes the derived status helper to handlers.
+func (s *Service) InviteStatusAt(inv Invite, now time.Time) InviteStatus {
+	return inviteStatus(inv, now)
+}
+
+// RevokeInvite deletes an invite. Revoking an already-redeemed invite removes
+// only the audit row; the provisioned account is unaffected.
+func (s *Service) RevokeInvite(ctx context.Context, id string) error {
+	if s.invites == nil {
+		return ErrInvitesDisabled
+	}
+	ok, err := s.invites.Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrInviteNotFound
+	}
+	s.logger.Info("invite revoked", "id", id)
+	return nil
+}
+
+// LookupInvite returns the invite for token only if it is currently redeemable,
+// otherwise ErrInviteInvalid (callers must not distinguish the reason to avoid
+// leaking which tokens ever existed).
+func (s *Service) LookupInvite(ctx context.Context, token string) (Invite, error) {
+	if s.invites == nil {
+		return Invite{}, ErrInvitesDisabled
+	}
+	inv, err := s.invites.GetByToken(ctx, token)
+	if err != nil {
+		if errors.Is(err, ErrInviteNotFound) {
+			return Invite{}, ErrInviteInvalid
+		}
+		return Invite{}, err
+	}
+	if inviteStatus(inv, time.Now().UTC()) != InvitePending {
+		return Invite{}, ErrInviteInvalid
+	}
+	return inv, nil
+}
+
+// AcceptInvite redeems a pending invite, creating a new account with the
+// invite's pre-assigned role and email. The flow is: pre-validate the supplied
+// credentials (so a recoverable signup error doesn't burn the link), atomically
+// claim the invite (guarding against concurrent or expired redemption), create
+// the account, then either finalize the claim with the new user's id or release
+// the claim on failure so the link can be retried.
+func (s *Service) AcceptInvite(ctx context.Context, token, username, password string) (User, error) {
+	if s.invites == nil {
+		return User{}, ErrInvitesDisabled
+	}
+	username = strings.TrimSpace(username)
+	if username == "" {
+		return User{}, ErrInvalidUsername
+	}
+	if len(password) < minPasswordLen {
+		return User{}, ErrWeakPassword
+	}
+
+	inv, err := s.invites.GetByToken(ctx, token)
+	if err != nil {
+		if errors.Is(err, ErrInviteNotFound) {
+			return User{}, ErrInviteInvalid
+		}
+		return User{}, err
+	}
+	if inviteStatus(inv, time.Now().UTC()) != InvitePending {
+		return User{}, ErrInviteInvalid
+	}
+	// Reject an already-taken username before consuming the invite.
+	if _, err := s.store.GetUserByUsername(ctx, username); err == nil {
+		return User{}, ErrUserExists
+	} else if !errors.Is(err, ErrNoRows) {
+		return User{}, err
+	}
+
+	claimed, err := s.invites.Claim(ctx, token, time.Now().UTC())
+	if err != nil {
+		return User{}, err
+	}
+	if !claimed {
+		// Lost a race or it expired between the read and the claim.
+		return User{}, ErrInviteInvalid
+	}
+
+	u, err := s.CreateUserAccount(ctx, username, password, inv.Email, inv.Role)
+	if err != nil {
+		if relErr := s.invites.Release(ctx, token); relErr != nil {
+			s.logger.Error("failed to release invite after signup error", "token_id", inv.ID, "err", relErr)
+		}
+		return User{}, err
+	}
+	if finErr := s.invites.Finalize(ctx, token, u.ID); finErr != nil {
+		// The account exists and the invite is consumed; only the audit link is
+		// missing. Log rather than fail the redemption.
+		s.logger.Error("failed to finalize invite used_by", "token_id", inv.ID, "user_id", u.ID, "err", finErr)
+	}
+	s.logger.Info("invite redeemed", "id", inv.ID, "user_id", u.ID, "role", inv.Role)
+	return u, nil
+}

--- a/internal/auth/invites_handlers.go
+++ b/internal/auth/invites_handlers.go
@@ -1,0 +1,182 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type inviteOut struct {
+	ID         string `json:"id"`
+	Token      string `json:"token,omitempty"`
+	URL        string `json:"url,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Role       string `json:"role"`
+	Status     string `json:"status"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
+	UsedAt     string `json:"used_at,omitempty"`
+	UsedByName string `json:"used_by_name,omitempty"`
+}
+
+// toInviteOut renders an invite for the admin list. The raw token (and thus the
+// shareable URL) is only exposed while the invite is still pending so a consumed
+// or expired link can't be re-shared.
+func (s *Service) toInviteOut(inv Invite, r *http.Request, now time.Time) inviteOut {
+	status := inviteStatus(inv, now)
+	o := inviteOut{
+		ID:     inv.ID,
+		Email:  inv.Email,
+		Role:   inv.Role,
+		Status: string(status),
+	}
+	if !inv.CreatedAt.IsZero() {
+		o.CreatedAt = inv.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	if !inv.ExpiresAt.IsZero() {
+		o.ExpiresAt = inv.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	if !inv.UsedAt.IsZero() {
+		o.UsedAt = inv.UsedAt.UTC().Format(time.RFC3339)
+	}
+	o.UsedByName = inv.UsedByName
+	if status == InvitePending {
+		o.Token = inv.Token
+		o.URL = inviteURL(r, inv.Token)
+	}
+	return o
+}
+
+// inviteURL builds the public redemption link from the request's origin.
+func inviteURL(r *http.Request, token string) string {
+	scheme := "http"
+	if requestIsTLS(r) || r.Header.Get("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	}
+	host := r.Host
+	if fwd := r.Header.Get("X-Forwarded-Host"); fwd != "" {
+		host = fwd
+	}
+	return scheme + "://" + host + "/invite/" + token
+}
+
+type createInviteRequest struct {
+	Email          string `json:"email"`
+	Role           string `json:"role"`
+	ExpiresInHours int    `json:"expires_in_hours"`
+}
+
+func (s *Service) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	id := IdentityFrom(r.Context())
+	if id == nil {
+		writeAuthError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req createInviteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	var ttl time.Duration
+	if req.ExpiresInHours > 0 {
+		ttl = time.Duration(req.ExpiresInHours) * time.Hour
+	}
+	inv, err := s.CreateInvite(r.Context(), id.UserID, req.Email, req.Role, ttl)
+	if err != nil {
+		writeInviteError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, map[string]any{"invite": s.toInviteOut(inv, r, time.Now().UTC())})
+}
+
+func (s *Service) handleListInvites(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	invs, err := s.ListInvites(r.Context())
+	if err != nil {
+		writeInviteError(w, err)
+		return
+	}
+	now := time.Now().UTC()
+	out := make([]inviteOut, len(invs))
+	for i, inv := range invs {
+		out[i] = s.toInviteOut(inv, r, now)
+	}
+	writeJSONStatus(w, http.StatusOK, map[string]any{"invites": out})
+}
+
+func (s *Service) handleRevokeInvite(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.RevokeInvite(r.Context(), id); err != nil {
+		writeInviteError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type publicInviteOut struct {
+	Valid bool   `json:"valid"`
+	Email string `json:"email,omitempty"`
+	Role  string `json:"role,omitempty"`
+}
+
+func (s *Service) handlePublicInvite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	token := chi.URLParam(r, "token")
+	inv, err := s.LookupInvite(r.Context(), token)
+	if err != nil {
+		if errors.Is(err, ErrInviteInvalid) {
+			writeJSONStatus(w, http.StatusOK, publicInviteOut{Valid: false})
+			return
+		}
+		writeInviteError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusOK, publicInviteOut{Valid: true, Email: inv.Email, Role: inv.Role})
+}
+
+type acceptInviteRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func (s *Service) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	token := chi.URLParam(r, "token")
+	var req acceptInviteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAuthError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	u, err := s.AcceptInvite(r.Context(), token, req.Username, req.Password)
+	if err != nil {
+		writeInviteError(w, err)
+		return
+	}
+	if err := IssueSessionCookie(w, r, s.sessionSecret, u.ID, s.sessionTTL, s.cookieSecure); err != nil {
+		writeAuthError(w, http.StatusInternalServerError, "issue session")
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, toUserOut(u))
+}
+
+// writeInviteError maps invite/user-management errors to HTTP status codes.
+func writeInviteError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrInvitesDisabled):
+		writeAuthError(w, http.StatusServiceUnavailable, err.Error())
+	case errors.Is(err, ErrInviteInvalid):
+		writeAuthError(w, http.StatusGone, err.Error())
+	case errors.Is(err, ErrInviteNotFound):
+		writeAuthError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, ErrUserExists):
+		writeAuthError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, ErrInvalidRole), errors.Is(err, ErrInvalidUsername), errors.Is(err, ErrWeakPassword):
+		writeAuthError(w, http.StatusBadRequest, err.Error())
+	default:
+		writeAuthError(w, http.StatusInternalServerError, "invite operation failed")
+	}
+}

--- a/internal/auth/invites_store.go
+++ b/internal/auth/invites_store.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// ErrInviteNotFound is returned when an invite token does not exist.
+var ErrInviteNotFound = errors.New("auth: invite not found")
+
+// inviteTSLayout is the canonical timestamp format written by the invite store.
+const inviteTSLayout = time.RFC3339
+
+// parseInviteTS tolerates both RFC3339 (our writes) and SQLite's
+// CURRENT_TIMESTAMP form, mirroring the requests store.
+func parseInviteTS(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// Invite is a persisted, single-use account invitation.
+type Invite struct {
+	ID        string
+	Token     string
+	Email     string
+	Role      string
+	CreatedBy int64
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	UsedAt    time.Time
+	UsedBy    int64
+	// UsedByName is populated by list queries when the redeeming user still
+	// exists; it is empty for pending invites.
+	UsedByName string
+}
+
+// InviteStore persists account invites using a raw *sql.DB, mirroring the
+// lighter store pattern used by the requests package.
+type InviteStore struct {
+	db *sql.DB
+}
+
+// NewInviteStore creates an invite store backed by the given database.
+func NewInviteStore(db *sql.DB) *InviteStore {
+	return &InviteStore{db: db}
+}
+
+// Create persists a new invite.
+func (s *InviteStore) Create(ctx context.Context, inv Invite) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO user_invites (id, token, email, role, created_by, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		inv.ID, inv.Token, inv.Email, inv.Role, inv.CreatedBy,
+		inv.CreatedAt.UTC().Format(inviteTSLayout),
+		inv.ExpiresAt.UTC().Format(inviteTSLayout),
+	)
+	return err
+}
+
+const inviteSelectCols = `i.id, i.token, i.email, i.role, i.created_by,
+	i.created_at, i.expires_at, i.used_at, i.used_by,
+	COALESCE(u.username, '')`
+
+func scanInvite(row interface{ Scan(...any) error }) (Invite, error) {
+	var (
+		inv               Invite
+		created, expires  string
+		usedAt            sql.NullString
+		usedBy            sql.NullInt64
+		usedByName        string
+	)
+	if err := row.Scan(&inv.ID, &inv.Token, &inv.Email, &inv.Role, &inv.CreatedBy,
+		&created, &expires, &usedAt, &usedBy, &usedByName); err != nil {
+		return Invite{}, err
+	}
+	inv.CreatedAt = parseInviteTS(created)
+	inv.ExpiresAt = parseInviteTS(expires)
+	if usedAt.Valid {
+		inv.UsedAt = parseInviteTS(usedAt.String)
+	}
+	if usedBy.Valid {
+		inv.UsedBy = usedBy.Int64
+	}
+	inv.UsedByName = usedByName
+	return inv, nil
+}
+
+// GetByToken returns the invite for the given token, or ErrInviteNotFound.
+func (s *InviteStore) GetByToken(ctx context.Context, token string) (Invite, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+inviteSelectCols+`
+		FROM user_invites i LEFT JOIN users u ON u.id = i.used_by
+		WHERE i.token = ?`, token)
+	inv, err := scanInvite(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Invite{}, ErrInviteNotFound
+	}
+	return inv, err
+}
+
+// List returns all invites, newest first.
+func (s *InviteStore) List(ctx context.Context) ([]Invite, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+inviteSelectCols+`
+		FROM user_invites i LEFT JOIN users u ON u.id = i.used_by
+		ORDER BY i.created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Invite
+	for rows.Next() {
+		inv, err := scanInvite(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, inv)
+	}
+	return out, rows.Err()
+}
+
+// Delete removes an invite by id. It reports whether a row was removed.
+func (s *InviteStore) Delete(ctx context.Context, id string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM user_invites WHERE id = ?`, id)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// Claim atomically marks an unused, unexpired invite as consumed. It returns
+// true only if the invite was claimable at the instant of the update,
+// preventing a concurrent or expired redemption from succeeding. used_by is set
+// later by Finalize once the account it provisions has an id.
+func (s *InviteStore) Claim(ctx context.Context, token string, at time.Time) (bool, error) {
+	ts := at.UTC().Format(inviteTSLayout)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE user_invites SET used_at = ?
+		WHERE token = ? AND used_at IS NULL AND expires_at > ?`,
+		ts, token, ts,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+
+// Finalize records which user a claimed invite provisioned.
+func (s *InviteStore) Finalize(ctx context.Context, token string, usedBy int64) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE user_invites SET used_by = ? WHERE token = ?`, usedBy, token)
+	return err
+}
+
+// Release reverts a claim, making the invite redeemable again. Used to roll
+// back when account creation fails after a successful claim.
+func (s *InviteStore) Release(ctx context.Context, token string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE user_invites SET used_at = NULL, used_by = NULL WHERE token = ?`, token)
+	return err
+}

--- a/internal/auth/invites_test.go
+++ b/internal/auth/invites_test.go
@@ -1,0 +1,273 @@
+package auth_test
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/appconfig"
+	"github.com/ebenderooock/loom/internal/auth"
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+// newInviteService builds a Service with the invite store wired, returning the
+// service, the raw invite store (for inserting expired fixtures and inspecting
+// state), and the seeded primary admin id.
+func newInviteService(t *testing.T) (*auth.Service, *auth.InviteStore, int64) {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "auth.db")},
+	}
+	db, err := storage.Open(ctx, cfg, quietLogger())
+	if err != nil {
+		t.Fatalf("storage.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := auth.StoreFromDB(db)
+	if err != nil {
+		t.Fatalf("StoreFromDB: %v", err)
+	}
+	hash, err := auth.HashPassword("hunter2!!")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	admin, err := store.CreateUser(ctx, auth.CreateUserParams{
+		Username: "admin", PasswordHash: hash, Email: "admin@example.com", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	if err := store.SetMeta(ctx, adminMetaKey, strconv.FormatInt(admin.ID, 10)); err != nil {
+		t.Fatalf("set admin meta: %v", err)
+	}
+	invites := auth.NewInviteStore(db.DB())
+	svc, err := auth.NewService(auth.ServiceOptions{
+		Store:         store,
+		Logger:        quietLogger(),
+		AppConfig:     &appconfig.Config{},
+		AppConfigPath: filepath.Join(dir, "config.json"),
+		SessionSecret: []byte("a-test-session-secret-32bytes!!!"),
+		SessionTTL:    time.Hour,
+		Invites:       invites,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, invites, admin.ID
+}
+
+func TestCreateAndListInvites(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	inv, err := svc.CreateInvite(ctx, adminID, "friend@example.com", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if inv.Token == "" {
+		t.Fatal("expected a generated token")
+	}
+	if inv.Role != "user" || inv.Email != "friend@example.com" {
+		t.Fatalf("unexpected invite fields: %+v", inv)
+	}
+	if !inv.ExpiresAt.After(time.Now()) {
+		t.Fatal("expected a future expiry")
+	}
+
+	list, err := svc.ListInvites(ctx)
+	if err != nil {
+		t.Fatalf("ListInvites: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 invite, got %d", len(list))
+	}
+	if got := svc.InviteStatusAt(list[0], time.Now()); got != auth.InvitePending {
+		t.Fatalf("expected pending, got %s", got)
+	}
+}
+
+func TestCreateInviteClampsTTLAndValidatesRole(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	// Below the minimum is clamped up to at least an hour out.
+	inv, err := svc.CreateInvite(ctx, adminID, "", "", time.Minute)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if inv.Role != "user" {
+		t.Fatalf("expected default role user, got %s", inv.Role)
+	}
+	if time.Until(inv.ExpiresAt) < 59*time.Minute {
+		t.Fatalf("expected ttl clamped to >= 1h, got %s", time.Until(inv.ExpiresAt))
+	}
+
+	if _, err := svc.CreateInvite(ctx, adminID, "", "superuser", 0); err == nil {
+		t.Fatal("expected ErrInvalidRole for bad role")
+	}
+}
+
+func TestAcceptInviteHappyPath(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	inv, err := svc.CreateInvite(ctx, adminID, "friend@example.com", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	u, err := svc.AcceptInvite(ctx, inv.Token, "friend", "s3cretpw!")
+	if err != nil {
+		t.Fatalf("AcceptInvite: %v", err)
+	}
+	if u.Username != "friend" || u.Role != "user" || u.Email != "friend@example.com" {
+		t.Fatalf("unexpected created user: %+v", u)
+	}
+
+	// Single-use: a second redemption must fail and not create another account.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "friend2", "s3cretpw!"); err != auth.ErrInviteInvalid {
+		t.Fatalf("expected ErrInviteInvalid on reuse, got %v", err)
+	}
+
+	list, _ := svc.ListInvites(ctx)
+	if got := svc.InviteStatusAt(list[0], time.Now()); got != auth.InviteUsed {
+		t.Fatalf("expected used status, got %s", got)
+	}
+	if list[0].UsedByName != "friend" {
+		t.Fatalf("expected used_by_name 'friend', got %q", list[0].UsedByName)
+	}
+}
+
+func TestAcceptInviteExpired(t *testing.T) {
+	ctx := context.Background()
+	svc, store, adminID := newInviteService(t)
+
+	// Insert an already-expired invite directly.
+	past := time.Now().Add(-2 * time.Hour)
+	if err := store.Create(ctx, auth.Invite{
+		ID: "expired-1", Token: "expiredtoken", Role: "user",
+		CreatedBy: adminID, CreatedAt: past.Add(-time.Hour), ExpiresAt: past,
+	}); err != nil {
+		t.Fatalf("seed expired invite: %v", err)
+	}
+	if _, err := svc.LookupInvite(ctx, "expiredtoken"); err != auth.ErrInviteInvalid {
+		t.Fatalf("expected ErrInviteInvalid on lookup, got %v", err)
+	}
+	if _, err := svc.AcceptInvite(ctx, "expiredtoken", "late", "s3cretpw!"); err != auth.ErrInviteInvalid {
+		t.Fatalf("expected ErrInviteInvalid on accept, got %v", err)
+	}
+}
+
+func TestAcceptInviteValidationDoesNotBurnLink(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	inv, err := svc.CreateInvite(ctx, adminID, "", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	// Weak password is rejected before the invite is claimed.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "bob", "short"); err != auth.ErrWeakPassword {
+		t.Fatalf("expected ErrWeakPassword, got %v", err)
+	}
+	// Empty username likewise.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "  ", "s3cretpw!"); err != auth.ErrInvalidUsername {
+		t.Fatalf("expected ErrInvalidUsername, got %v", err)
+	}
+	// The invite is still redeemable.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "bob", "s3cretpw!"); err != nil {
+		t.Fatalf("expected redeemable invite after validation errors, got %v", err)
+	}
+}
+
+func TestAcceptInviteDuplicateUsernameReleasesLink(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	inv, err := svc.CreateInvite(ctx, adminID, "", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	// "admin" already exists.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "admin", "s3cretpw!"); err != auth.ErrUserExists {
+		t.Fatalf("expected ErrUserExists, got %v", err)
+	}
+	list, _ := svc.ListInvites(ctx)
+	if got := svc.InviteStatusAt(list[0], time.Now()); got != auth.InvitePending {
+		t.Fatalf("expected invite still pending after duplicate-username failure, got %s", got)
+	}
+	// And it can be redeemed with a fresh username.
+	if _, err := svc.AcceptInvite(ctx, inv.Token, "newperson", "s3cretpw!"); err != nil {
+		t.Fatalf("expected successful redemption, got %v", err)
+	}
+}
+
+func TestRevokeInvite(t *testing.T) {
+	ctx := context.Background()
+	svc, _, adminID := newInviteService(t)
+
+	inv, err := svc.CreateInvite(ctx, adminID, "", "user", 0)
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if err := svc.RevokeInvite(ctx, inv.ID); err != nil {
+		t.Fatalf("RevokeInvite: %v", err)
+	}
+	if _, err := svc.LookupInvite(ctx, inv.Token); err != auth.ErrInviteInvalid {
+		t.Fatalf("expected revoked invite to be invalid, got %v", err)
+	}
+	if err := svc.RevokeInvite(ctx, inv.ID); err != auth.ErrInviteNotFound {
+		t.Fatalf("expected ErrInviteNotFound on second revoke, got %v", err)
+	}
+}
+
+func TestInvitesDisabledWhenStoreNil(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	svc, err := auth.NewService(auth.ServiceOptions{
+		Store:         stubAuthStore(t, dir),
+		Logger:        quietLogger(),
+		AppConfig:     &appconfig.Config{},
+		AppConfigPath: filepath.Join(dir, "config.json"),
+		SessionSecret: []byte("a-test-session-secret-32bytes!!!"),
+		SessionTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if _, err := svc.CreateInvite(ctx, 1, "", "user", 0); err != auth.ErrInvitesDisabled {
+		t.Fatalf("expected ErrInvitesDisabled, got %v", err)
+	}
+	if _, err := svc.LookupInvite(ctx, "x"); err != auth.ErrInvitesDisabled {
+		t.Fatalf("expected ErrInvitesDisabled, got %v", err)
+	}
+}
+
+// stubAuthStore opens a migrated sqlite store for the invites-disabled test.
+func stubAuthStore(t *testing.T, dir string) auth.Store {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.Open(ctx, config.StorageConfig{
+		Engine: "sqlite", SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "stub.db")},
+	}, quietLogger())
+	if err != nil {
+		t.Fatalf("storage.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store, err := auth.StoreFromDB(db)
+	if err != nil {
+		t.Fatalf("StoreFromDB: %v", err)
+	}
+	return store
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -27,6 +27,9 @@ type ServiceOptions struct {
 	CookieSecure  bool
 	OIDC          *OIDC
 	Proxy         *ProxyAuth
+	// Invites is optional; when nil, invite endpoints report the feature as
+	// disabled. Production wires NewInviteStore(db.DB()).
+	Invites *InviteStore
 }
 
 // Service is the orchestrator: middleware, handlers, and CLI all use
@@ -41,6 +44,7 @@ type Service struct {
 	cookieSecure  bool
 	oidc          *OIDC
 	proxy         *ProxyAuth
+	invites       *InviteStore
 }
 
 // NewService validates options and returns the configured Service. The
@@ -74,6 +78,7 @@ func NewService(opts ServiceOptions) (*Service, error) {
 		cookieSecure:  opts.CookieSecure,
 		oidc:          opts.OIDC,
 		proxy:         opts.Proxy,
+		invites:       opts.Invites,
 	}, nil
 }
 

--- a/internal/storage/migrations/sqlite/0062_user_invites.sql
+++ b/internal/storage/migrations/sqlite/0062_user_invites.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+
+-- user_invites backs self-service onboarding: an admin generates a single-use
+-- invite link (token) with a pre-assigned role, and the recipient redeems it to
+-- create their own account. used_at/used_by record redemption for the audit
+-- trail; a NULL used_at means the invite is still claimable (subject to expiry).
+CREATE TABLE IF NOT EXISTS user_invites (
+    id         TEXT PRIMARY KEY,
+    token      TEXT NOT NULL UNIQUE,
+    email      TEXT NOT NULL DEFAULT '',
+    role       TEXT NOT NULL DEFAULT 'user',
+    created_by INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    used_at    TEXT,
+    used_by    INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_invites_token ON user_invites (token);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_user_invites_token;
+DROP TABLE IF EXISTS user_invites;

--- a/web/src/lib/invites-api.ts
+++ b/web/src/lib/invites-api.ts
@@ -1,0 +1,149 @@
+// Typed fetch wrappers + react-query hooks for account invites.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/fetch";
+import { ApiError, type UserRole } from "@/lib/users-api";
+
+export type InviteStatus = "pending" | "used" | "expired";
+
+export interface Invite {
+  id: string;
+  token?: string;
+  url?: string;
+  email?: string;
+  role: UserRole;
+  status: InviteStatus;
+  created_at?: string;
+  expires_at?: string;
+  used_at?: string;
+  used_by_name?: string;
+}
+
+export interface CreateInviteInput {
+  email?: string;
+  role: UserRole;
+  expires_in_hours?: number;
+}
+
+export interface PublicInvite {
+  valid: boolean;
+  email?: string;
+  role?: UserRole;
+}
+
+export interface AcceptInviteInput {
+  username: string;
+  password: string;
+}
+
+export interface AcceptedUser {
+  id: number;
+  username: string;
+  email?: string;
+  role: UserRole;
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  signal?: AbortSignal,
+): Promise<T> {
+  const init: RequestInit = { method, signal };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await apiFetch(path, init);
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  const text = await res.text();
+  let parsed: unknown;
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+  if (!res.ok) {
+    const env = parsed as
+      | { error?: string | { message?: string } }
+      | undefined;
+    let message = `${method} ${path} failed: ${res.status} ${res.statusText}`;
+    if (typeof env?.error === "string") {
+      message = env.error;
+    } else if (env?.error?.message) {
+      message = env.error.message;
+    }
+    throw new ApiError(res.status, message);
+  }
+  return parsed as T;
+}
+
+export async function listInvites(signal?: AbortSignal): Promise<Invite[]> {
+  const data = await request<{ invites: Invite[] }>(
+    "GET",
+    "/api/v1/auth/invites",
+    undefined,
+    signal,
+  );
+  return data?.invites ?? [];
+}
+
+export async function createInvite(body: CreateInviteInput): Promise<Invite> {
+  const data = await request<{ invite: Invite }>(
+    "POST",
+    "/api/v1/auth/invites",
+    body,
+  );
+  return data.invite;
+}
+
+export async function revokeInvite(id: string): Promise<void> {
+  await request<void>("DELETE", `/api/v1/auth/invites/${id}`);
+}
+
+export async function lookupInvite(token: string): Promise<PublicInvite> {
+  return request<PublicInvite>(
+    "GET",
+    `/api/v1/auth/invites/redeem/${encodeURIComponent(token)}`,
+  );
+}
+
+export async function acceptInvite(
+  token: string,
+  body: AcceptInviteInput,
+): Promise<AcceptedUser> {
+  return request<AcceptedUser>(
+    "POST",
+    `/api/v1/auth/invites/redeem/${encodeURIComponent(token)}/accept`,
+    body,
+  );
+}
+
+const INVITES_KEY = ["auth", "invites"] as const;
+
+export function useInvites() {
+  return useQuery({
+    queryKey: INVITES_KEY,
+    queryFn: ({ signal }) => listInvites(signal),
+  });
+}
+
+export function useCreateInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateInviteInput) => createInvite(body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: INVITES_KEY }),
+  });
+}
+
+export function useRevokeInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => revokeInvite(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: INVITES_KEY }),
+  });
+}

--- a/web/src/pages/invite.tsx
+++ b/web/src/pages/invite.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from "react";
+import { useParams } from "@tanstack/react-router";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { lookupInvite, acceptInvite } from "@/lib/invites-api";
+import { ApiError } from "@/lib/users-api";
+
+function ApiErrorMessage(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) return e.message;
+  if (e instanceof Error) return e.message;
+  return fallback;
+}
+
+type Phase = "checking" | "invalid" | "ready" | "submitting" | "done";
+
+export function InvitePage() {
+  const { token } = useParams({ strict: false }) as { token?: string };
+  const { isAuthenticated, user, logout } = useAuth();
+  const [phase, setPhase] = useState<Phase>("checking");
+  const [email, setEmail] = useState<string | undefined>();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (!token) {
+      setPhase("invalid");
+      return;
+    }
+    lookupInvite(token)
+      .then((res) => {
+        if (!active) return;
+        if (res.valid) {
+          setEmail(res.email);
+          setPhase("ready");
+        } else {
+          setPhase("invalid");
+        }
+      })
+      .catch(() => active && setPhase("invalid"));
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!username.trim()) {
+      setError("Choose a username");
+      return;
+    }
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters");
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match");
+      return;
+    }
+    setPhase("submitting");
+    try {
+      await acceptInvite(token as string, {
+        username: username.trim(),
+        password,
+      });
+      setPhase("done");
+      // Full reload so the auth provider re-checks and lands authenticated.
+      window.location.href = "/";
+    } catch (err) {
+      setError(ApiErrorMessage(err, "Could not create your account"));
+      setPhase("ready");
+    }
+  };
+
+  return (
+    <div className="w-full h-screen flex items-center justify-center bg-gradient-to-br from-purple-midnight via-neutral-dark to-teal-deep">
+      <div className="w-full max-w-md mx-auto px-4">
+        <div className="bg-neutral-card rounded-lg shadow-lg p-8 space-y-6">
+          <div className="text-center space-y-4">
+            <img
+              src="/loom-logo.png"
+              alt="Loom Logo"
+              className="h-16 mx-auto object-contain"
+            />
+            <div className="space-y-2">
+              <h1 className="text-3xl font-bold text-neutral-light">
+                Join Loom
+              </h1>
+              <p className="text-neutral-muted">
+                You&apos;ve been invited to create an account.
+              </p>
+            </div>
+          </div>
+
+          {isAuthenticated ? (
+            <div className="space-y-4">
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                  You&apos;re already signed in as{" "}
+                  <span className="font-medium">{user?.username}</span>.
+                  Accepting this invite creates a separate new account.
+                </AlertDescription>
+              </Alert>
+              <div className="flex flex-col gap-2">
+                <Button onClick={() => (window.location.href = "/")}>
+                  Continue to Loom
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={async () => {
+                    await logout();
+                    window.location.reload();
+                  }}
+                >
+                  Sign out to accept invite
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <>
+              {phase === "checking" && (
+                <div className="flex items-center justify-center gap-2 py-8 text-neutral-muted">
+                  <Loader2 className="h-5 w-5 animate-spin" /> Checking your invite…
+                </div>
+              )}
+
+              {phase === "invalid" && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    This invite link is invalid, has expired, or has already been
+                    used. Ask your administrator for a new one.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {(phase === "ready" || phase === "submitting") && (
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  {error && (
+                    <Alert variant="destructive">
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                  )}
+                  {email && (
+                    <p className="text-sm text-neutral-muted">
+                      Invited as <span className="font-medium">{email}</span>
+                    </p>
+                  )}
+                  <div className="space-y-1.5">
+                    <label htmlFor="invite-username" className="text-sm text-neutral-light">
+                      Username
+                    </label>
+                    <Input
+                      id="invite-username"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      autoComplete="username"
+                      disabled={phase === "submitting"}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <label htmlFor="invite-password" className="text-sm text-neutral-light">
+                      Password
+                    </label>
+                    <Input
+                      id="invite-password"
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      autoComplete="new-password"
+                      disabled={phase === "submitting"}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <label htmlFor="invite-confirm" className="text-sm text-neutral-light">
+                      Confirm password
+                    </label>
+                    <Input
+                      id="invite-confirm"
+                      type="password"
+                      value={confirm}
+                      onChange={(e) => setConfirm(e.target.value)}
+                      autoComplete="new-password"
+                      disabled={phase === "submitting"}
+                    />
+                  </div>
+                  <Button type="submit" className="w-full" disabled={phase === "submitting"}>
+                    {phase === "submitting" ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Creating account…
+                      </>
+                    ) : (
+                      "Create account"
+                    )}
+                  </Button>
+                </form>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/users.tsx
+++ b/web/src/pages/users.tsx
@@ -46,7 +46,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Loader2, Plus, Trash2, KeyRound, Users, ShieldAlert } from "lucide-react";
+import { Loader2, Plus, Trash2, KeyRound, Users, ShieldAlert, Link2, Copy, Mail } from "lucide-react";
+import {
+  useInvites,
+  useCreateInvite,
+  useRevokeInvite,
+  type Invite,
+} from "@/lib/invites-api";
 
 function errMessage(e: unknown, fallback: string): string {
   if (e instanceof ApiError) return e.message;
@@ -409,6 +415,210 @@ function UsersTable({ currentUserId }: { currentUserId: number }) {
   );
 }
 
+function inviteStatusVariant(status: Invite["status"]) {
+  if (status === "pending") return "default" as const;
+  if (status === "used") return "secondary" as const;
+  return "outline" as const;
+}
+
+const EXPIRY_OPTIONS: { label: string; hours: number }[] = [
+  { label: "1 day", hours: 24 },
+  { label: "3 days", hours: 72 },
+  { label: "7 days", hours: 168 },
+  { label: "30 days", hours: 720 },
+];
+
+function InvitesCard() {
+  const invites = useInvites();
+  const create = useCreateInvite();
+  const revoke = useRevokeInvite();
+  const [email, setEmail] = React.useState("");
+  const [role, setRole] = React.useState<UserRole>("user");
+  const [expiryHours, setExpiryHours] = React.useState("168");
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    create.mutate(
+      {
+        email: email.trim() || undefined,
+        role,
+        expires_in_hours: Number(expiryHours),
+      },
+      {
+        onSuccess: (inv) => {
+          setEmail("");
+          if (inv.url) {
+            void navigator.clipboard?.writeText(inv.url).then(
+              () => toast.success("Invite link created and copied to clipboard"),
+              () => toast.success("Invite link created"),
+            );
+          } else {
+            toast.success("Invite created");
+          }
+        },
+        onError: (err) => toast.error(errMessage(err, "Failed to create invite")),
+      },
+    );
+  }
+
+  function copyLink(inv: Invite) {
+    if (!inv.url) return;
+    void navigator.clipboard?.writeText(inv.url).then(
+      () => toast.success("Invite link copied"),
+      () => toast.error("Could not copy link"),
+    );
+  }
+
+  const rows = invites.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Link2 className="h-4 w-4" /> Invite links
+        </CardTitle>
+        <CardDescription>
+          Generate a shareable link so someone can self-register without you
+          setting a password. Links are single-use and expire.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <form
+          onSubmit={submit}
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:items-end"
+        >
+          <div className="space-y-1">
+            <Label htmlFor="inv-email">Email (optional)</Label>
+            <Input
+              id="inv-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="off"
+              placeholder="friend@example.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Role</Label>
+            <Select value={role} onValueChange={(v) => setRole(v as UserRole)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="user">user</SelectItem>
+                <SelectItem value="admin">admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>Expires in</Label>
+            <Select value={expiryHours} onValueChange={setExpiryHours}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {EXPIRY_OPTIONS.map((o) => (
+                  <SelectItem key={o.hours} value={String(o.hours)}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button type="submit" disabled={create.isPending}>
+            {create.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create invite
+          </Button>
+        </form>
+
+        {invites.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading invites…
+          </div>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No invites yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((inv) => (
+                <TableRow key={inv.id}>
+                  <TableCell className="flex items-center gap-1.5">
+                    {inv.email ? (
+                      <>
+                        <Mail className="h-3.5 w-3.5 text-muted-foreground" />
+                        {inv.email}
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <RoleBadge role={inv.role} />
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={inviteStatusVariant(inv.status)}>
+                      {inv.status}
+                      {inv.status === "used" && inv.used_by_name
+                        ? ` · ${inv.used_by_name}`
+                        : ""}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {inv.expires_at
+                      ? new Date(inv.expires_at).toLocaleString()
+                      : "—"}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center justify-end gap-2">
+                      {inv.status === "pending" && inv.url && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => copyLink(inv)}
+                        >
+                          <Copy className="mr-1.5 h-3.5 w-3.5" /> Copy link
+                        </Button>
+                      )}
+                      {inv.status === "pending" && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label="Revoke invite"
+                          disabled={revoke.isPending}
+                          onClick={() =>
+                            revoke.mutate(inv.id, {
+                              onSuccess: () => toast.success("Invite revoked"),
+                              onError: (err) =>
+                                toast.error(
+                                  errMessage(err, "Failed to revoke invite"),
+                                ),
+                            })
+                          }
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function UsersPage() {
   const { setHeader } = usePageHeader();
   const { user } = useAuth();
@@ -437,6 +647,8 @@ export function UsersPage() {
       </section>
 
       <CreateUserCard />
+
+      <InvitesCard />
 
       <UsersTable currentUserId={user?.id ?? -1} />
     </div>

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -5,6 +5,7 @@ import {
   createRouter,
   lazyRouteComponent,
   redirect,
+  Outlet,
 } from "@tanstack/react-router";
 import { AppLayout } from "@/components/layout/app-layout";
 import { SettingsLayout } from "@/components/layout/settings-layout";
@@ -37,6 +38,13 @@ function RootComponent() {
   }
 
   if (!isAuthenticated) {
+    // Public self-service invite acceptance lives outside the auth gate.
+    if (
+      typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/invite/")
+    ) {
+      return <Outlet />;
+    }
     return (
       <Suspense fallback={<PageLoader />}>
         <AuthPage />
@@ -352,9 +360,18 @@ const workflowDetailRedirectRoute = createRoute({
   },
 });
 
+const inviteRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/invite/$token",
+  component: lazyRouteComponent(() => import("@/pages/invite"), "InvitePage"),
+  pendingComponent: PageLoader,
+  errorComponent: ErrorFallback,
+});
+
 const routeTree = rootRoute.addChildren([
   setupRoute,
   indexRoute,
+  inviteRoute,
   libraryRoute,
   moviesRoute,
   seriesRoute,


### PR DESCRIPTION
Admins generate single-use, expiring invite links so friends/family can self-register without manual account creation. Accepting auto-logs-in the new user.

**Backend**: migration 0062 user_invites, InviteStore (atomic Claim/Finalize/Release for single-use), Service (CreateInvite ttl-clamp 1h..90d + 256-bit crypto token, LookupInvite no-leak, AcceptInvite pre-validate->claim->create->finalize/release, Revoke), admin + public handlers with Cache-Control: no-store, 8 tests.

**Frontend**: InvitesCard on Users page (create/copy-link/revoke), public /invite/$token accept page (router gate special-case for unauthenticated; warns already-signed-in users).

Refs #14.