### PR TITLE
Media-server analytics (#15)

### DIFF
--- a/cmd/loom/serve.go
+++ b/cmd/loom/serve.go
@@ -239,6 +239,10 @@ func cmdServe(ctx context.Context, args []string) error {
 	defer infra.rollingSearcher.Stop()
 	infra.healthMon.Start(ctx)
 	defer infra.healthMon.Stop()
+	if infra.analyticsPoller != nil {
+		infra.analyticsPoller.Start(ctx)
+		defer infra.analyticsPoller.Stop()
+	}
 	defer infra.auditSink.Close()
 	defer sysLogBatchWriter.Close()
 

--- a/cmd/loom/wire_infra.go
+++ b/cmd/loom/wire_infra.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"log/slog"
+	"time"
 
+	"github.com/ebenderooock/loom/internal/analytics"
 	"github.com/ebenderooock/loom/internal/auditlog"
 	"github.com/ebenderooock/loom/internal/compat/prowlarrv1"
 	"github.com/ebenderooock/loom/internal/compat/radarrv3"
@@ -11,6 +13,7 @@ import (
 	"github.com/ebenderooock/loom/internal/compat/syncprofiles"
 	"github.com/ebenderooock/loom/internal/connect"
 	"github.com/ebenderooock/loom/internal/downloads"
+	"github.com/ebenderooock/loom/internal/featureflags"
 	"github.com/ebenderooock/loom/internal/healthmonitor"
 	"github.com/ebenderooock/loom/internal/indexers"
 	"github.com/ebenderooock/loom/internal/libraries"
@@ -28,6 +31,7 @@ type infraWiring struct {
 	rollingSearcher *scheduler.RollingSearcher
 	healthMon       *healthmonitor.Monitor
 	auditSink       *auditlog.Sink
+	analyticsPoller *analytics.Poller
 }
 
 // wireInfra constructs infrastructure services (connect, compat shims,
@@ -47,6 +51,17 @@ func wireInfra(
 	// Connect (media server integrations)
 	connectSvc := connect.NewService(db.DB())
 	srv.SetConnect(connectSvc)
+
+	// Media analytics — live stream monitoring + watch history, sampled from
+	// enabled Plex/Emby/Jellyfin connections and gated by a feature flag.
+	analyticsSvc := analytics.NewService(analytics.NewStore(db.DB()), connectSvc, logger)
+	srv.SetAnalytics(analyticsSvc)
+	analyticsPoller := analytics.NewPoller(
+		analyticsSvc,
+		30*time.Second,
+		srv.Features().EnabledFunc(featureflags.KeyMediaAnalytics),
+		logger,
+	)
 
 	// Wire Trakt credentials into import list sync manager
 	media.importListSyncMgr.SetConnectService(connectSvc)
@@ -89,6 +104,7 @@ func wireInfra(
 		rollingSearcher: rollingSearcher,
 		healthMon:       healthMon,
 		auditSink:       auditSink,
+		analyticsPoller: analyticsPoller,
 	}, nil
 }
 

--- a/internal/analytics/handlers.go
+++ b/internal/analytics/handlers.go
@@ -1,0 +1,75 @@
+package analytics
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Router mounts the analytics endpoints. adminMW guards every route (analytics
+// expose other users' watch activity, so they are admin-only).
+func Router(svc *Service, adminMW func(http.Handler) http.Handler) chi.Router {
+	r := chi.NewRouter()
+	if adminMW != nil {
+		r.Use(adminMW)
+	}
+	r.Get("/streams", handleStreams(svc))
+	r.Get("/history", handleHistory(svc))
+	r.Get("/stats", handleStats(svc))
+	return r
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": map[string]any{
+		"code": http.StatusText(status), "message": msg,
+	}})
+}
+
+func handleStreams(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"streams": svc.ActiveStreams()})
+	}
+}
+
+func handleHistory(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f := HistoryFilter{User: r.URL.Query().Get("user")}
+		if v := r.URL.Query().Get("limit"); v != "" {
+			f.Limit, _ = strconv.Atoi(v)
+		}
+		if v := r.URL.Query().Get("offset"); v != "" {
+			f.Offset, _ = strconv.Atoi(v)
+		}
+		rows, err := svc.History(r.Context(), f)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"history": rows})
+	}
+}
+
+func handleStats(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		days := 30
+		if v := r.URL.Query().Get("days"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				days = n
+			}
+		}
+		stats, err := svc.Stats(r.Context(), days)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, stats)
+	}
+}

--- a/internal/analytics/poller.go
+++ b/internal/analytics/poller.go
@@ -1,0 +1,102 @@
+package analytics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Poller periodically samples active sessions. It is gated by an enabled
+// function (typically a feature flag) so admins can pause sampling without
+// losing existing history.
+type Poller struct {
+	svc      *Service
+	interval time.Duration
+	enabled  func() bool
+	logger   *slog.Logger
+
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	running  bool
+	sampling bool
+}
+
+// NewPoller creates an analytics poller. enabled may be nil (always on).
+func NewPoller(svc *Service, interval time.Duration, enabled func() bool, logger *slog.Logger) *Poller {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Poller{
+		svc:      svc,
+		interval: interval,
+		enabled:  enabled,
+		logger:   logger.With("module", "analytics-poller"),
+	}
+}
+
+// Start begins the polling loop after clearing startup orphans.
+func (p *Poller) Start(ctx context.Context) {
+	p.mu.Lock()
+	if p.running {
+		p.mu.Unlock()
+		return
+	}
+	childCtx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.running = true
+	p.mu.Unlock()
+
+	p.svc.ResetOrphans(childCtx)
+	go p.loop(childCtx)
+	p.logger.Info("analytics poller started", "interval", p.interval)
+}
+
+// Stop halts the polling loop.
+func (p *Poller) Stop() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cancel != nil {
+		p.cancel()
+	}
+	p.running = false
+}
+
+func (p *Poller) loop(ctx context.Context) {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.tick(ctx)
+		}
+	}
+}
+
+func (p *Poller) tick(ctx context.Context) {
+	if p.enabled != nil && !p.enabled() {
+		return
+	}
+	// Skip overlapping samples if the previous one is still running.
+	p.mu.Lock()
+	if p.sampling {
+		p.mu.Unlock()
+		p.logger.Debug("analytics: skipping tick, previous sample still running")
+		return
+	}
+	p.sampling = true
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.sampling = false
+		p.mu.Unlock()
+	}()
+
+	p.svc.Sample(ctx, p.interval)
+}

--- a/internal/analytics/service.go
+++ b/internal/analytics/service.go
@@ -1,0 +1,280 @@
+package analytics
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/connect"
+	"github.com/google/uuid"
+)
+
+// streamingProviders are the connection types that report playback sessions.
+var streamingProviders = map[connect.ProviderType]bool{
+	connect.ProviderPlex:     true,
+	connect.ProviderEmby:     true,
+	connect.ProviderJellyfin: true,
+}
+
+// ConnectionSource supplies the configured media-server connections.
+type ConnectionSource interface {
+	ListConnections(ctx context.Context) ([]*connect.Connection, error)
+}
+
+// SessionFetcher fetches active sessions for a single connection. It is a field
+// on the service so tests can substitute a fake.
+type SessionFetcher func(ctx context.Context, conn *connect.Connection) ([]connect.Session, error)
+
+// defaultFetcher uses the connect provider registry.
+func defaultFetcher(ctx context.Context, conn *connect.Connection) ([]connect.Session, error) {
+	p, err := connect.ProviderFor(conn.Provider)
+	if err != nil {
+		return nil, err
+	}
+	return p.ActiveSessions(ctx, conn.Settings)
+}
+
+// Service is the analytics business logic: it owns the live snapshot and the
+// persisted history store.
+type Service struct {
+	store   *Store
+	conns   ConnectionSource
+	fetch   SessionFetcher
+	logger  *slog.Logger
+	minPlay time.Duration // minimum watched time to count a play in stats
+
+	mu       sync.RWMutex
+	snapshot []LiveStream
+}
+
+// NewService creates an analytics service.
+func NewService(store *Store, conns ConnectionSource, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		store:    store,
+		conns:    conns,
+		fetch:    defaultFetcher,
+		logger:   logger.With("module", "analytics"),
+		minPlay:  60 * time.Second,
+		snapshot: []LiveStream{},
+	}
+}
+
+// ActiveStreams returns the most recent live-stream snapshot.
+func (s *Service) ActiveStreams() []LiveStream {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]LiveStream, len(s.snapshot))
+	copy(out, s.snapshot)
+	return out
+}
+
+// History returns persisted playback rows.
+func (s *Service) History(ctx context.Context, f HistoryFilter) ([]HistoryRecord, error) {
+	return s.store.ListHistory(ctx, f)
+}
+
+// Stats returns the analytics report for the given window in days.
+func (s *Service) Stats(ctx context.Context, windowDays int) (*Stats, error) {
+	if windowDays <= 0 {
+		windowDays = 30
+	}
+	since := time.Now().UTC().AddDate(0, 0, -windowDays)
+	return s.store.Stats(ctx, since, windowDays, s.minPlay.Milliseconds())
+}
+
+// ResetOrphans closes any open rows left over from a previous run. Call once at
+// startup before sampling begins.
+func (s *Service) ResetOrphans(ctx context.Context) {
+	n, err := s.store.CloseAllOpen(ctx, "startup_reap")
+	if err != nil {
+		s.logger.Warn("analytics: failed to close orphan rows", "error", err)
+		return
+	}
+	if n > 0 {
+		s.logger.Info("analytics: closed orphaned play rows on startup", "count", n)
+	}
+}
+
+// sessionKeyOf identifies an active session within a connection.
+type sessionKey struct {
+	session string
+	media   string
+}
+
+// Sample performs one polling cycle: fetch active sessions from each enabled
+// streaming connection, update the live snapshot, and persist history. Sampling
+// is isolated per connection so one unreachable server can't corrupt others'
+// history or hide their streams.
+func (s *Service) Sample(ctx context.Context, interval time.Duration) {
+	conns, err := s.conns.ListConnections(ctx)
+	if err != nil {
+		s.logger.Warn("analytics: list connections failed", "error", err)
+		return
+	}
+
+	type result struct {
+		conn     *connect.Connection
+		sessions []connect.Session
+		ok       bool
+	}
+
+	var targets []*connect.Connection
+	for _, c := range conns {
+		if c.Enabled && streamingProviders[c.Provider] {
+			targets = append(targets, c)
+		}
+	}
+
+	results := make([]result, len(targets))
+	var wg sync.WaitGroup
+	for i, c := range targets {
+		wg.Add(1)
+		go func(i int, c *connect.Connection) {
+			defer wg.Done()
+			cctx, cancel := context.WithTimeout(ctx, interval-time.Second)
+			defer cancel()
+			sessions, err := s.fetch(cctx, c)
+			if err != nil {
+				s.logger.Debug("analytics: sample connection failed", "connection", c.Name, "error", err)
+				results[i] = result{conn: c, ok: false}
+				return
+			}
+			results[i] = result{conn: c, sessions: sessions, ok: true}
+		}(i, c)
+	}
+	wg.Wait()
+
+	now := time.Now().UTC()
+	grace := 2 * interval
+
+	// Preserve previous snapshot entries for connections that failed this tick
+	// (mark stale by keeping them) and rebuild from successful ones.
+	prev := s.ActiveStreams()
+	prevByConn := map[string][]LiveStream{}
+	for _, ls := range prev {
+		prevByConn[ls.ConnectionID] = append(prevByConn[ls.ConnectionID], ls)
+	}
+
+	newSnapshot := []LiveStream{}
+	for _, res := range results {
+		if !res.ok {
+			// Keep last-known streams for this connection rather than dropping.
+			newSnapshot = append(newSnapshot, prevByConn[res.conn.ID]...)
+			continue
+		}
+		newSnapshot = append(newSnapshot, s.persistConnection(ctx, res.conn, res.sessions, now, grace)...)
+	}
+
+	s.mu.Lock()
+	s.snapshot = newSnapshot
+	s.mu.Unlock()
+}
+
+// persistConnection reconciles one connection's active sessions against its
+// open history rows and returns the live streams for the snapshot.
+func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, sessions []connect.Session, now time.Time, grace time.Duration) []LiveStream {
+	open, err := s.store.OpenRowsForConn(ctx, c.ID)
+	if err != nil {
+		s.logger.Warn("analytics: load open rows failed", "connection", c.Name, "error", err)
+	}
+	openByKey := map[sessionKey]*HistoryRecord{}
+	for i := range open {
+		k := sessionKey{session: open[i].SessionKey, media: open[i].MediaID}
+		openByKey[k] = &open[i]
+	}
+
+	active := map[sessionKey]bool{}
+	streams := make([]LiveStream, 0, len(sessions))
+
+	for _, sess := range sessions {
+		k := sessionKey{session: sess.SessionKey, media: sess.MediaID}
+		active[k] = true
+
+		if row, ok := openByKey[k]; ok {
+			// Accumulate watched time only while playing, capping the per-tick
+			// delta so a missed poll or a long gap can't inflate totals.
+			watched := row.WatchedMs
+			if sess.State == "playing" {
+				delta := now.Sub(row.LastSeenAt)
+				if delta < 0 {
+					delta = 0
+				}
+				if delta > grace {
+					delta = grace
+				}
+				watched += delta.Milliseconds()
+			}
+			if err := s.store.UpdateOpen(ctx, row.ID, now, sess.PositionMs, watched, sess.Transcode); err != nil {
+				s.logger.Warn("analytics: update row failed", "error", err)
+			} else {
+				row.WatchedMs = watched
+			}
+		} else {
+			rec := HistoryRecord{
+				ID:               uuid.NewString(),
+				ConnectionID:     c.ID,
+				Provider:         string(c.Provider),
+				SessionKey:       sess.SessionKey,
+				MediaID:          sess.MediaID,
+				User:             sess.User,
+				MediaType:        sess.MediaType,
+				Title:            sess.Title,
+				GrandparentTitle: sess.GrandparentTitle,
+				FullTitle:        sess.FullTitle,
+				Device:           sess.Device,
+				Transcode:        sess.Transcode,
+				StartedAt:        now,
+				LastSeenAt:       now,
+				LastPositionMs:   sess.PositionMs,
+				DurationMs:       sess.DurationMs,
+				WatchedMs:        0,
+			}
+			if err := s.store.InsertOpen(ctx, rec); err != nil {
+				s.logger.Warn("analytics: insert row failed", "error", err)
+			}
+		}
+
+		sess.ConnectionID = c.ID
+		sess.Provider = c.Provider
+		streams = append(streams, LiveStream{
+			Session:        sess,
+			ConnectionName: c.Name,
+			Progress:       progress(sess.PositionMs, sess.DurationMs),
+		})
+	}
+
+	// Reap: close open rows for this connection that are no longer active and
+	// whose last sighting is older than the grace window.
+	cutoff := now.Add(-grace)
+	for _, row := range open {
+		k := sessionKey{session: row.SessionKey, media: row.MediaID}
+		if active[k] {
+			continue
+		}
+		if row.LastSeenAt.Before(cutoff) {
+			if err := s.store.Close(ctx, row.ID, row.LastSeenAt, "disappeared"); err != nil {
+				s.logger.Warn("analytics: close row failed", "error", err)
+			}
+		}
+	}
+
+	return streams
+}
+
+func progress(pos, dur int64) float64 {
+	if dur <= 0 {
+		return 0
+	}
+	p := float64(pos) / float64(dur) * 100
+	if p < 0 {
+		return 0
+	}
+	if p > 100 {
+		return 100
+	}
+	return p
+}

--- a/internal/analytics/service_test.go
+++ b/internal/analytics/service_test.go
@@ -1,0 +1,258 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/connect"
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "loom.db")},
+	}
+	db, err := storage.Open(context.Background(), cfg,
+		slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return db.DB()
+}
+
+type fakeSource struct{ conns []*connect.Connection }
+
+func (f *fakeSource) ListConnections(_ context.Context) ([]*connect.Connection, error) {
+	return f.conns, nil
+}
+
+func quiet() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newSvc(t *testing.T, conns ...*connect.Connection) (*Service, *Store) {
+	t.Helper()
+	db := openTestDB(t)
+	store := NewStore(db)
+	svc := NewService(store, &fakeSource{conns: conns}, quiet())
+	return svc, store
+}
+
+func plexConn(id, name string) *connect.Connection {
+	return &connect.Connection{ID: id, Name: name, Provider: connect.ProviderPlex, Enabled: true}
+}
+
+func TestPersistContinuityAccumulatesWatched(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+
+	sess := connect.Session{SessionKey: "10", MediaID: "100", User: "alice", MediaType: "episode",
+		Title: "Ep", GrandparentTitle: "Show", FullTitle: "Show - S01E01 - Ep", State: "playing",
+		PositionMs: 1000, DurationMs: 600000}
+
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(30*time.Second), grace)
+
+	open, err := store.OpenRowsForConn(ctx, "c1")
+	if err != nil {
+		t.Fatalf("open rows: %v", err)
+	}
+	if len(open) != 1 {
+		t.Fatalf("expected 1 open row (continuous session), got %d", len(open))
+	}
+	if open[0].WatchedMs != 30000 {
+		t.Fatalf("expected 30000ms watched, got %d", open[0].WatchedMs)
+	}
+}
+
+func TestPersistCapsDeltaAtGrace(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
+
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	// A long gap (server unreachable): delta is 10m but must cap at grace (60s).
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(10*time.Minute), grace)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 1 || open[0].WatchedMs != 60000 {
+		t.Fatalf("expected watched capped at 60000ms, got %+v", open)
+	}
+}
+
+func TestPausedDoesNotAccumulate(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+	playing := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
+	paused := playing
+	paused.State = "paused"
+
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	svc.persistConnection(ctx, conn, []connect.Session{playing}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{paused}, t0.Add(30*time.Second), grace)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 1 || open[0].WatchedMs != 0 {
+		t.Fatalf("paused session should not accumulate watched time, got %+v", open)
+	}
+}
+
+func TestReapOnDisappear(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
+
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+
+	// Disappears; now is past lastSeen + grace, so it must be closed.
+	svc.persistConnection(ctx, conn, nil, t0.Add(2*grace+time.Second), grace)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 0 {
+		t.Fatalf("expected disappeared session to be reaped, %d still open", len(open))
+	}
+	hist, _ := store.ListHistory(ctx, HistoryFilter{})
+	if len(hist) != 1 || hist[0].EndedAt == nil {
+		t.Fatalf("expected 1 ended history row, got %+v", hist)
+	}
+}
+
+func TestReapWaitsForGrace(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
+
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	// Missed a single poll (30s) — within grace, must NOT reap.
+	svc.persistConnection(ctx, conn, nil, t0.Add(30*time.Second), grace)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 1 {
+		t.Fatalf("a single missed poll should not reap the session, %d open", len(open))
+	}
+}
+
+func TestDistinctMediaSameSessionKey(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	grace := 60 * time.Second
+	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+
+	a := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 1}
+	b := connect.Session{SessionKey: "10", MediaID: "200", State: "playing", DurationMs: 1}
+	svc.persistConnection(ctx, conn, []connect.Session{a, b}, t0, grace)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 2 {
+		t.Fatalf("same session key but different media must be 2 rows, got %d", len(open))
+	}
+}
+
+func TestResetOrphansClosesOpenRows(t *testing.T) {
+	svc, store := newSvc(t)
+	conn := plexConn("c1", "Plex")
+	ctx := context.Background()
+	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 1}
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, time.Now().UTC(), 60*time.Second)
+
+	svc.ResetOrphans(ctx)
+
+	open, _ := store.OpenRowsForConn(ctx, "c1")
+	if len(open) != 0 {
+		t.Fatalf("ResetOrphans should close all open rows, %d still open", len(open))
+	}
+}
+
+func TestStatsThresholdAndAggregates(t *testing.T) {
+	svc, store := newSvc(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// One qualifying play (>=60s) and one below threshold.
+	must := func(r HistoryRecord) {
+		if err := store.InsertOpen(ctx, r); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	must(HistoryRecord{ID: "a", ConnectionID: "c1", Provider: "plex", SessionKey: "1", MediaID: "m1",
+		User: "alice", MediaType: "movie", FullTitle: "Movie A", StartedAt: now, LastSeenAt: now, WatchedMs: 120000})
+	must(HistoryRecord{ID: "b", ConnectionID: "c1", Provider: "plex", SessionKey: "2", MediaID: "m2",
+		User: "bob", MediaType: "movie", FullTitle: "Movie B", StartedAt: now, LastSeenAt: now, WatchedMs: 5000})
+
+	stats, err := svc.Stats(ctx, 30)
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.Totals.Plays != 1 {
+		t.Fatalf("expected 1 play above threshold, got %d", stats.Totals.Plays)
+	}
+	if stats.Totals.UniqueUsers != 1 {
+		t.Fatalf("expected 1 unique user, got %d", stats.Totals.UniqueUsers)
+	}
+	if len(stats.TopUsers) != 1 || stats.TopUsers[0].User != "alice" {
+		t.Fatalf("expected alice as top user, got %+v", stats.TopUsers)
+	}
+	if len(stats.TopMedia) != 1 || stats.TopMedia[0].Title != "Movie A" {
+		t.Fatalf("expected Movie A as top media, got %+v", stats.TopMedia)
+	}
+}
+
+func TestSampleIsolatesFailedConnection(t *testing.T) {
+	connA := plexConn("a", "A")
+	connB := plexConn("b", "B")
+	svc, store := newSvc(t, connA, connB)
+	ctx := context.Background()
+
+	failB := false
+	svc.fetch = func(_ context.Context, c *connect.Connection) ([]connect.Session, error) {
+		if c.ID == "b" && failB {
+			return nil, context.DeadlineExceeded
+		}
+		return []connect.Session{{SessionKey: "1", MediaID: c.ID + "-m", State: "playing", DurationMs: 100, FullTitle: c.Name}}, nil
+	}
+
+	svc.Sample(ctx, 30*time.Second)
+	if len(svc.ActiveStreams()) != 2 {
+		t.Fatalf("expected 2 live streams after first sample, got %d", len(svc.ActiveStreams()))
+	}
+
+	// Now B fails: its stream must be retained (not dropped) and its open row
+	// must not be reaped.
+	failB = true
+	svc.Sample(ctx, 30*time.Second)
+	if len(svc.ActiveStreams()) != 2 {
+		t.Fatalf("failed connection's stream should be retained, got %d", len(svc.ActiveStreams()))
+	}
+	openB, _ := store.OpenRowsForConn(ctx, "b")
+	if len(openB) != 1 {
+		t.Fatalf("failed connection's history must not be reaped, %d open", len(openB))
+	}
+}

--- a/internal/analytics/store.go
+++ b/internal/analytics/store.go
@@ -1,0 +1,248 @@
+package analytics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const tsLayout = time.RFC3339
+
+// Store persists play history using raw SQL.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a play-history store.
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+func parseTS(s string) time.Time {
+	t, _ := time.Parse(tsLayout, s)
+	return t
+}
+
+// OpenRowsForConn returns all open (not-yet-ended) history rows for a
+// connection.
+func (s *Store) OpenRowsForConn(ctx context.Context, connID string) ([]HistoryRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, connection_id, provider, session_key, media_id, user, media_type,
+		       title, grandparent_title, full_title, device, transcode,
+		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms
+		FROM play_history
+		WHERE connection_id = ? AND ended_at IS NULL`, connID)
+	if err != nil {
+		return nil, fmt.Errorf("open rows: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HistoryRecord
+	for rows.Next() {
+		var r HistoryRecord
+		var started, lastSeen string
+		var transcode int
+		if err := rows.Scan(&r.ID, &r.ConnectionID, &r.Provider, &r.SessionKey, &r.MediaID,
+			&r.User, &r.MediaType, &r.Title, &r.GrandparentTitle, &r.FullTitle, &r.Device, &transcode,
+			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs); err != nil {
+			return nil, fmt.Errorf("scan open row: %w", err)
+		}
+		r.Transcode = transcode != 0
+		r.StartedAt = parseTS(started)
+		r.LastSeenAt = parseTS(lastSeen)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// InsertOpen inserts a new open playback row.
+func (s *Store) InsertOpen(ctx context.Context, r HistoryRecord) error {
+	transcode := 0
+	if r.Transcode {
+		transcode = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO play_history
+		(id, connection_id, provider, session_key, media_id, user, media_type,
+		 title, grandparent_title, full_title, device, transcode,
+		 started_at, last_seen_at, last_position_ms, duration_ms, watched_ms)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		r.ID, r.ConnectionID, r.Provider, r.SessionKey, r.MediaID, r.User, r.MediaType,
+		r.Title, r.GrandparentTitle, r.FullTitle, r.Device, transcode,
+		r.StartedAt.UTC().Format(tsLayout), r.LastSeenAt.UTC().Format(tsLayout),
+		r.LastPositionMs, r.DurationMs, r.WatchedMs)
+	if err != nil {
+		return fmt.Errorf("insert open: %w", err)
+	}
+	return nil
+}
+
+// UpdateOpen advances an open row with the latest sample.
+func (s *Store) UpdateOpen(ctx context.Context, id string, lastSeen time.Time, positionMs, watchedMs int64, transcode bool) error {
+	t := 0
+	if transcode {
+		t = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE play_history
+		SET last_seen_at = ?, last_position_ms = ?, watched_ms = ?, transcode = ?
+		WHERE id = ?`,
+		lastSeen.UTC().Format(tsLayout), positionMs, watchedMs, t, id)
+	if err != nil {
+		return fmt.Errorf("update open: %w", err)
+	}
+	return nil
+}
+
+// Close finalises an open row, setting ended_at and a reason.
+func (s *Store) Close(ctx context.Context, id string, endedAt time.Time, reason string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE play_history SET ended_at = ?, end_reason = ? WHERE id = ? AND ended_at IS NULL`,
+		endedAt.UTC().Format(tsLayout), reason, id)
+	if err != nil {
+		return fmt.Errorf("close row: %w", err)
+	}
+	return nil
+}
+
+// CloseAllOpen finalises every open row (used on startup to clear orphans).
+// Each row is ended at its own last_seen_at.
+func (s *Store) CloseAllOpen(ctx context.Context, reason string) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE play_history SET ended_at = last_seen_at, end_reason = ?
+		WHERE ended_at IS NULL`, reason)
+	if err != nil {
+		return 0, fmt.Errorf("close all open: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// ListHistory returns finished and in-progress rows, most recent first.
+func (s *Store) ListHistory(ctx context.Context, f HistoryFilter) ([]HistoryRecord, error) {
+	limit := f.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	query := `
+		SELECT id, connection_id, provider, session_key, media_id, user, media_type,
+		       title, grandparent_title, full_title, device, transcode,
+		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms, ended_at
+		FROM play_history`
+	args := []any{}
+	if f.User != "" {
+		query += ` WHERE user = ?`
+		args = append(args, f.User)
+	}
+	query += ` ORDER BY started_at DESC LIMIT ? OFFSET ?`
+	args = append(args, limit, f.Offset)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list history: %w", err)
+	}
+	defer rows.Close()
+
+	out := []HistoryRecord{}
+	for rows.Next() {
+		var r HistoryRecord
+		var started, lastSeen string
+		var ended sql.NullString
+		var transcode int
+		if err := rows.Scan(&r.ID, &r.ConnectionID, &r.Provider, &r.SessionKey, &r.MediaID,
+			&r.User, &r.MediaType, &r.Title, &r.GrandparentTitle, &r.FullTitle, &r.Device, &transcode,
+			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs, &ended); err != nil {
+			return nil, fmt.Errorf("scan history: %w", err)
+		}
+		r.Transcode = transcode != 0
+		r.StartedAt = parseTS(started)
+		r.LastSeenAt = parseTS(lastSeen)
+		if ended.Valid && ended.String != "" {
+			t := parseTS(ended.String)
+			r.EndedAt = &t
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// Stats computes the analytics report over the given window. Only plays with at
+// least minWatchedMs of observed playback count toward the aggregates, to keep
+// brief previews/accidental starts out of the reports.
+func (s *Store) Stats(ctx context.Context, since time.Time, windowDays int, minWatchedMs int64) (*Stats, error) {
+	sinceStr := since.UTC().Format(tsLayout)
+	st := &Stats{WindowDays: windowDays, TopUsers: []UserStat{}, TopMedia: []MediaStat{}, LeastMedia: []MediaStat{}, PlaysPerDay: []DayCount{}}
+
+	// Totals.
+	row := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COUNT(DISTINCT user), COALESCE(SUM(watched_ms),0)
+		FROM play_history WHERE started_at >= ? AND watched_ms >= ?`, sinceStr, minWatchedMs)
+	if err := row.Scan(&st.Totals.Plays, &st.Totals.UniqueUsers, &st.Totals.WatchedMs); err != nil {
+		return nil, fmt.Errorf("stats totals: %w", err)
+	}
+
+	// Top users.
+	uRows, err := s.db.QueryContext(ctx, `
+		SELECT user, COUNT(*) plays, COALESCE(SUM(watched_ms),0)
+		FROM play_history WHERE started_at >= ? AND watched_ms >= ? AND user <> ''
+		GROUP BY user ORDER BY plays DESC, watched_ms DESC LIMIT 10`, sinceStr, minWatchedMs)
+	if err != nil {
+		return nil, fmt.Errorf("stats users: %w", err)
+	}
+	defer uRows.Close()
+	for uRows.Next() {
+		var u UserStat
+		if err := uRows.Scan(&u.User, &u.Plays, &u.WatchedMs); err != nil {
+			return nil, fmt.Errorf("scan user stat: %w", err)
+		}
+		st.TopUsers = append(st.TopUsers, u)
+	}
+	if err := uRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Media aggregate (grouped by stable media id, falling back to title).
+	mediaQuery := func(order string) ([]MediaStat, error) {
+		rows, err := s.db.QueryContext(ctx, `
+			SELECT COALESCE(NULLIF(media_id,''), full_title) AS key,
+			       MAX(full_title), MAX(media_type), COUNT(*) plays, COALESCE(SUM(watched_ms),0)
+			FROM play_history WHERE started_at >= ? AND watched_ms >= ?
+			GROUP BY key ORDER BY plays `+order+`, watched_ms `+order+` LIMIT 10`, sinceStr, minWatchedMs)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		out := []MediaStat{}
+		for rows.Next() {
+			var m MediaStat
+			if err := rows.Scan(&m.MediaID, &m.Title, &m.MediaType, &m.Plays, &m.WatchedMs); err != nil {
+				return nil, err
+			}
+			out = append(out, m)
+		}
+		return out, rows.Err()
+	}
+	if st.TopMedia, err = mediaQuery("DESC"); err != nil {
+		return nil, fmt.Errorf("stats top media: %w", err)
+	}
+	if st.LeastMedia, err = mediaQuery("ASC"); err != nil {
+		return nil, fmt.Errorf("stats least media: %w", err)
+	}
+
+	// Plays per day.
+	dRows, err := s.db.QueryContext(ctx, `
+		SELECT date(started_at) d, COUNT(*)
+		FROM play_history WHERE started_at >= ? AND watched_ms >= ?
+		GROUP BY d ORDER BY d ASC`, sinceStr, minWatchedMs)
+	if err != nil {
+		return nil, fmt.Errorf("stats days: %w", err)
+	}
+	defer dRows.Close()
+	for dRows.Next() {
+		var d DayCount
+		if err := dRows.Scan(&d.Day, &d.Plays); err != nil {
+			return nil, fmt.Errorf("scan day: %w", err)
+		}
+		st.PlaysPerDay = append(st.PlaysPerDay, d)
+	}
+	return st, dRows.Err()
+}

--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -1,0 +1,87 @@
+// Package analytics provides Tautulli-style media-server analytics: live
+// stream monitoring, persisted watch history, and watched reports built on top
+// of the existing internal/connect media-server connections.
+package analytics
+
+import (
+	"time"
+
+	"github.com/ebenderooock/loom/internal/connect"
+)
+
+// HistoryRecord is a single persisted playback row in play_history. One
+// continuous playback session maps to exactly one record.
+type HistoryRecord struct {
+	ID               string     `json:"id"`
+	ConnectionID     string     `json:"connection_id"`
+	Provider         string     `json:"provider"`
+	SessionKey       string     `json:"session_key"`
+	MediaID          string     `json:"media_id"`
+	User             string     `json:"user"`
+	MediaType        string     `json:"media_type"`
+	Title            string     `json:"title"`
+	GrandparentTitle string     `json:"grandparent_title"`
+	FullTitle        string     `json:"full_title"`
+	Device           string     `json:"device"`
+	Transcode        bool       `json:"transcode"`
+	StartedAt        time.Time  `json:"started_at"`
+	LastSeenAt       time.Time  `json:"last_seen_at"`
+	LastPositionMs   int64      `json:"last_position_ms"`
+	DurationMs       int64      `json:"duration_ms"`
+	WatchedMs        int64      `json:"watched_ms"`
+	EndedAt          *time.Time `json:"ended_at,omitempty"`
+}
+
+// LiveStream is an active session decorated with a progress percentage for the
+// dashboard.
+type LiveStream struct {
+	connect.Session
+	ConnectionName string  `json:"connection_name"`
+	Progress       float64 `json:"progress"` // 0..100
+}
+
+// HistoryFilter narrows a history query.
+type HistoryFilter struct {
+	User   string
+	Limit  int
+	Offset int
+}
+
+// Totals summarises activity over a window.
+type Totals struct {
+	Plays       int   `json:"plays"`
+	UniqueUsers int   `json:"unique_users"`
+	WatchedMs   int64 `json:"watched_ms"`
+}
+
+// UserStat is per-user aggregate activity.
+type UserStat struct {
+	User      string `json:"user"`
+	Plays     int    `json:"plays"`
+	WatchedMs int64  `json:"watched_ms"`
+}
+
+// MediaStat is per-title aggregate activity.
+type MediaStat struct {
+	MediaID   string `json:"media_id"`
+	Title     string `json:"title"`
+	MediaType string `json:"media_type"`
+	Plays     int    `json:"plays"`
+	WatchedMs int64  `json:"watched_ms"`
+}
+
+// DayCount is the play count for a single calendar day (UTC).
+type DayCount struct {
+	Day   string `json:"day"` // YYYY-MM-DD
+	Plays int    `json:"plays"`
+}
+
+// Stats is the full analytics report for a window.
+type Stats struct {
+	WindowDays  int         `json:"window_days"`
+	Totals      Totals      `json:"totals"`
+	TopUsers    []UserStat  `json:"top_users"`
+	TopMedia    []MediaStat `json:"top_media"`
+	LeastMedia  []MediaStat `json:"least_media"`
+	PlaysPerDay []DayCount  `json:"plays_per_day"`
+}

--- a/internal/connect/provider.go
+++ b/internal/connect/provider.go
@@ -14,6 +14,9 @@ import (
 type Provider interface {
 	Test(ctx context.Context, settings ProviderSettings) error
 	NotifyLibraryUpdate(ctx context.Context, settings ProviderSettings) error
+	// ActiveSessions returns the playback sessions currently active on the
+	// server. Providers that don't stream (e.g. Trakt) return nil, nil.
+	ActiveSessions(ctx context.Context, settings ProviderSettings) ([]Session, error)
 }
 
 var httpClient = &http.Client{Timeout: 15 * time.Second}

--- a/internal/connect/sessions.go
+++ b/internal/connect/sessions.go
@@ -1,0 +1,237 @@
+package connect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ActiveSessions for Trakt: it isn't a streaming server.
+func (t *traktProvider) ActiveSessions(_ context.Context, _ ProviderSettings) ([]Session, error) {
+	return nil, nil
+}
+
+// episodeTag formats a SxxEyy tag from season/episode numbers (0 = unknown).
+func episodeTag(season, episode int) string {
+	if season <= 0 && episode <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("S%02dE%02d", season, episode)
+}
+
+// buildFullTitle composes a human-readable title for an episode or movie.
+func buildFullTitle(mediaType, title, show string, season, episode int) string {
+	if mediaType == "episode" && show != "" {
+		tag := episodeTag(season, episode)
+		parts := []string{show}
+		if tag != "" {
+			parts = append(parts, tag)
+		}
+		if title != "" {
+			parts = append(parts, title)
+		}
+		return strings.Join(parts, " - ")
+	}
+	return title
+}
+
+// ---------- Plex ----------
+
+type plexSessionsResponse struct {
+	MediaContainer struct {
+		Metadata []plexSession `json:"Metadata"`
+	} `json:"MediaContainer"`
+}
+
+type plexSession struct {
+	SessionKey       string `json:"sessionKey"`
+	RatingKey        string `json:"ratingKey"`
+	Type             string `json:"type"`
+	Title            string `json:"title"`
+	GrandparentTitle string `json:"grandparentTitle"`
+	ParentIndex      int    `json:"parentIndex"`
+	Index            int    `json:"index"`
+	ViewOffset       int64  `json:"viewOffset"`
+	Duration         int64  `json:"duration"`
+	User             struct {
+		Title string `json:"title"`
+	} `json:"User"`
+	Player struct {
+		Title string `json:"title"`
+		State string `json:"state"`
+	} `json:"Player"`
+	TranscodeSession *json.RawMessage `json:"TranscodeSession"`
+}
+
+func (p *plexProvider) ActiveSessions(ctx context.Context, s ProviderSettings) ([]Session, error) {
+	base := strings.TrimRight(s.Host, "/")
+	req, err := http.NewRequestWithContext(ctx, "GET", base+"/status/sessions", nil)
+	if err != nil {
+		return nil, fmt.Errorf("plex sessions: %w", err)
+	}
+	req.Header.Set("X-Plex-Token", s.APIKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("plex sessions: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("plex sessions: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("plex sessions read: %w", err)
+	}
+	var parsed plexSessionsResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("plex sessions parse: %w", err)
+	}
+
+	out := make([]Session, 0, len(parsed.MediaContainer.Metadata))
+	for _, m := range parsed.MediaContainer.Metadata {
+		mediaType := "other"
+		switch m.Type {
+		case "movie":
+			mediaType = "movie"
+		case "episode":
+			mediaType = "episode"
+		}
+		state := "playing"
+		if m.Player.State == "paused" {
+			state = "paused"
+		}
+		out = append(out, Session{
+			SessionKey:       m.SessionKey,
+			MediaID:          m.RatingKey,
+			User:             m.User.Title,
+			MediaType:        mediaType,
+			Title:            m.Title,
+			GrandparentTitle: m.GrandparentTitle,
+			FullTitle:        buildFullTitle(mediaType, m.Title, m.GrandparentTitle, m.ParentIndex, m.Index),
+			Device:           m.Player.Title,
+			State:            state,
+			PositionMs:       m.ViewOffset,
+			DurationMs:       m.Duration,
+			Transcode:        m.TranscodeSession != nil,
+		})
+	}
+	return out, nil
+}
+
+// ---------- Emby / Jellyfin (shared JSON shape) ----------
+
+type embySession struct {
+	ID             string `json:"Id"`
+	UserName       string `json:"UserName"`
+	DeviceName     string `json:"DeviceName"`
+	NowPlayingItem *struct {
+		Name              string `json:"Name"`
+		SeriesName        string `json:"SeriesName"`
+		Type              string `json:"Type"`
+		ID                string `json:"Id"`
+		RunTimeTicks      int64  `json:"RunTimeTicks"`
+		ParentIndexNumber int    `json:"ParentIndexNumber"`
+		IndexNumber       int    `json:"IndexNumber"`
+	} `json:"NowPlayingItem"`
+	PlayState *struct {
+		PositionTicks int64  `json:"PositionTicks"`
+		IsPaused      bool   `json:"IsPaused"`
+		PlayMethod    string `json:"PlayMethod"`
+	} `json:"PlayState"`
+}
+
+// ticksToMs converts .NET 100ns ticks to milliseconds.
+func ticksToMs(ticks int64) int64 { return ticks / 10000 }
+
+func parseEmbySessions(body []byte) ([]Session, error) {
+	var raw []embySession
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	out := make([]Session, 0, len(raw))
+	for _, s := range raw {
+		if s.NowPlayingItem == nil {
+			continue
+		}
+		item := s.NowPlayingItem
+		mediaType := "other"
+		switch item.Type {
+		case "Movie":
+			mediaType = "movie"
+		case "Episode":
+			mediaType = "episode"
+		}
+		state := "playing"
+		transcode := false
+		var pos int64
+		if s.PlayState != nil {
+			if s.PlayState.IsPaused {
+				state = "paused"
+			}
+			transcode = strings.EqualFold(s.PlayState.PlayMethod, "Transcode")
+			pos = ticksToMs(s.PlayState.PositionTicks)
+		}
+		out = append(out, Session{
+			SessionKey:       s.ID,
+			MediaID:          item.ID,
+			User:             s.UserName,
+			MediaType:        mediaType,
+			Title:            item.Name,
+			GrandparentTitle: item.SeriesName,
+			FullTitle:        buildFullTitle(mediaType, item.Name, item.SeriesName, item.ParentIndexNumber, item.IndexNumber),
+			Device:           s.DeviceName,
+			State:            state,
+			PositionMs:       pos,
+			DurationMs:       ticksToMs(item.RunTimeTicks),
+			Transcode:        transcode,
+		})
+	}
+	return out, nil
+}
+
+func fetchEmbyStyleSessions(ctx context.Context, base string, setAuth func(*http.Request)) ([]Session, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", strings.TrimRight(base, "/")+"/Sessions", nil)
+	if err != nil {
+		return nil, err
+	}
+	setAuth(req)
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	return parseEmbySessions(body)
+}
+
+func (p *embyProvider) ActiveSessions(ctx context.Context, s ProviderSettings) ([]Session, error) {
+	sessions, err := fetchEmbyStyleSessions(ctx, s.Host, func(r *http.Request) {
+		r.Header.Set("X-Emby-Token", s.APIKey)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("emby sessions: %w", err)
+	}
+	return sessions, nil
+}
+
+func (p *jellyfinProvider) ActiveSessions(ctx context.Context, s ProviderSettings) ([]Session, error) {
+	sessions, err := fetchEmbyStyleSessions(ctx, s.Host, func(r *http.Request) {
+		r.Header.Set("Authorization", fmt.Sprintf(`MediaBrowser Token="%s"`, s.APIKey))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("jellyfin sessions: %w", err)
+	}
+	return sessions, nil
+}

--- a/internal/connect/types.go
+++ b/internal/connect/types.go
@@ -76,3 +76,24 @@ type UpdateRequest struct {
 	Settings       *ProviderSettings `json:"settings,omitempty"`
 	NotifyOnImport *bool             `json:"notify_on_import,omitempty"`
 }
+
+// Session is a single active playback reported by a media server. The
+// connection-identifying fields are populated by callers; providers fill the
+// media/playback fields.
+type Session struct {
+	ConnectionID     string       `json:"connection_id"`
+	ConnectionName   string       `json:"connection_name"`
+	Provider         ProviderType `json:"provider"`
+	SessionKey       string       `json:"session_key"`
+	MediaID          string       `json:"media_id"`
+	User             string       `json:"user"`
+	MediaType        string       `json:"media_type"` // movie | episode | other
+	Title            string       `json:"title"`
+	GrandparentTitle string       `json:"grandparent_title,omitempty"`
+	FullTitle        string       `json:"full_title"`
+	Device           string       `json:"device,omitempty"`
+	State            string       `json:"state"` // playing | paused
+	PositionMs       int64        `json:"position_ms"`
+	DurationMs       int64        `json:"duration_ms"`
+	Transcode        bool         `json:"transcode"`
+}

--- a/internal/featureflags/types.go
+++ b/internal/featureflags/types.go
@@ -11,6 +11,11 @@ const (
 	// queue). When disabled the autosearch engine stops recording new search
 	// trace entries; historical entries remain readable.
 	KeySearchLog = "search_log"
+
+	// KeyMediaAnalytics toggles media-server analytics sampling. When disabled
+	// the poller stops collecting new play history; existing history and the
+	// reports remain readable.
+	KeyMediaAnalytics = "media_analytics"
 )
 
 // FlagDef is the static, in-code definition of a feature toggle.
@@ -35,6 +40,13 @@ var Definitions = []FlagDef{
 		Key:         KeySearchLog,
 		Label:       "Search Log",
 		Description: "Record detailed per-search traces (indexer results, rejection reasons, grabs) shown under Search Queue. Disabling stops new traces; existing history stays viewable.",
+		Category:    "Diagnostics",
+		Default:     true,
+	},
+	{
+		Key:         KeyMediaAnalytics,
+		Label:       "Media Analytics",
+		Description: "Monitor active streams and record watch history from connected Plex/Emby/Jellyfin servers, shown under Analytics. Disabling stops new sampling; existing history stays viewable.",
 		Category:    "Diagnostics",
 		Default:     true,
 	},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-chi/httprate"
 
 	"github.com/ebenderooock/loom/internal/alttitles"
+	"github.com/ebenderooock/loom/internal/analytics"
 	"github.com/ebenderooock/loom/internal/anime"
 	"github.com/ebenderooock/loom/internal/apikeys"
 	"github.com/ebenderooock/loom/internal/appconfig"
@@ -98,6 +99,7 @@ type Server struct {
 	seriesSvc         series.Service
 	notifSvc          notifications.Service
 	connectSvc        connect.Service
+	analyticsSvc      *analytics.Service
 	reviewStore       *safety.ReviewStore
 	cleanupSvc        *cleanup.Service
 	requestsSvc       *requests.Service
@@ -280,6 +282,14 @@ func (s *Server) SetNotifications(svc notifications.Service) {
 // SetConnect installs the connect service and rebuilds the HTTP handler.
 func (s *Server) SetConnect(svc connect.Service) {
 	s.connectSvc = svc
+	if s.httpSrv != nil {
+		s.httpSrv.Handler = s.newMux()
+	}
+}
+
+// SetAnalytics installs the media-analytics service and rebuilds the handler.
+func (s *Server) SetAnalytics(svc *analytics.Service) {
+	s.analyticsSvc = svc
 	if s.httpSrv != nil {
 		s.httpSrv.Handler = s.newMux()
 	}
@@ -694,6 +704,15 @@ func (s *Server) newMux() http.Handler {
 				}
 			}
 			r.Mount("/api/v1/connect", connect.Router(s.connectSvc, archiver))
+		}
+
+		// Media analytics routes (admin-only; expose other users' activity).
+		if s.analyticsSvc != nil {
+			adminMW := func(next http.Handler) http.Handler { return next }
+			if s.authSvc != nil {
+				adminMW = s.authSvc.RequireRole("admin")
+			}
+			r.Mount("/api/v1/analytics", analytics.Router(s.analyticsSvc, adminMW))
 		}
 
 		// Calendar routes

--- a/internal/storage/migrations/sqlite/0063_play_history.sql
+++ b/internal/storage/migrations/sqlite/0063_play_history.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS play_history (
+    id                TEXT PRIMARY KEY,
+    connection_id     TEXT NOT NULL,
+    provider          TEXT NOT NULL,
+    session_key       TEXT NOT NULL,
+    media_id          TEXT NOT NULL DEFAULT '',
+    user              TEXT NOT NULL DEFAULT '',
+    media_type        TEXT NOT NULL DEFAULT '',
+    title             TEXT NOT NULL DEFAULT '',
+    grandparent_title TEXT NOT NULL DEFAULT '',
+    full_title        TEXT NOT NULL DEFAULT '',
+    device            TEXT NOT NULL DEFAULT '',
+    transcode         INTEGER NOT NULL DEFAULT 0,
+    started_at        TEXT NOT NULL,
+    last_seen_at      TEXT NOT NULL,
+    last_position_ms  INTEGER NOT NULL DEFAULT 0,
+    duration_ms       INTEGER NOT NULL DEFAULT 0,
+    watched_ms        INTEGER NOT NULL DEFAULT 0,
+    ended_at          TEXT,
+    end_reason        TEXT NOT NULL DEFAULT ''
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_play_history_ended ON play_history (ended_at);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_play_history_user ON play_history (user);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_play_history_started ON play_history (started_at);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE UNIQUE INDEX IF NOT EXISTS idx_play_history_open
+    ON play_history (connection_id, session_key, media_id)
+    WHERE ended_at IS NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS play_history;
+-- +goose StatementEnd

--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { apiFetch } from "@/lib/fetch";
 import {
+  Activity,
   Calendar,
   Compass,
   Inbox,
@@ -38,6 +39,8 @@ import {
   useCommandPalette,
 } from "@/components/command-palette";
 import { cn } from "@/lib/utils";
+import { useFeatureEnabled } from "@/lib/features-api";
+import { useAuth } from "@/hooks/use-auth";
 import { PageHeaderProvider, usePageHeader } from "@/hooks/use-page-header";
 
 interface NavItem {
@@ -132,6 +135,17 @@ function SidebarNav({
   const router = useRouterState();
   const path = router.location.pathname;
   const reviewCount = useReviewCount();
+  const { user } = useAuth();
+  const analyticsEnabled = useFeatureEnabled("media_analytics");
+  const showAnalytics = analyticsEnabled && user?.role === "admin";
+
+  const navItems = React.useMemo(() => {
+    if (!showAnalytics) return PRIMARY_NAV;
+    return [
+      ...PRIMARY_NAV,
+      { to: "/analytics", label: "Analytics", Icon: Activity } as NavItem,
+    ];
+  }, [showAnalytics]);
 
   const isActive = (to: string) =>
     to === "/" ? path === "/" : path === to || path.startsWith(`${to}/`);
@@ -141,7 +155,7 @@ function SidebarNav({
       aria-label="Primary"
       className="flex flex-col gap-0.5 p-2 overflow-y-auto flex-1 min-h-0 scrollbar-thin"
     >
-      {PRIMARY_NAV.map((item) => (
+      {navItems.map((item) => (
         <NavLinkRow
           key={item.to}
           item={item}

--- a/web/src/lib/analytics-api.ts
+++ b/web/src/lib/analytics-api.ts
@@ -1,0 +1,111 @@
+// Typed fetch wrappers + react-query hooks for media-server analytics.
+
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/fetch";
+
+export interface LiveStream {
+  connection_id: string;
+  connection_name: string;
+  provider: string;
+  session_key: string;
+  media_id: string;
+  user: string;
+  media_type: string;
+  title: string;
+  grandparent_title?: string;
+  full_title: string;
+  device?: string;
+  state: string; // playing | paused
+  position_ms: number;
+  duration_ms: number;
+  transcode: boolean;
+  progress: number; // 0..100
+}
+
+export interface HistoryRecord {
+  id: string;
+  connection_id: string;
+  provider: string;
+  user: string;
+  media_type: string;
+  full_title: string;
+  device: string;
+  transcode: boolean;
+  started_at: string;
+  last_seen_at: string;
+  duration_ms: number;
+  watched_ms: number;
+  ended_at?: string;
+}
+
+export interface UserStat {
+  user: string;
+  plays: number;
+  watched_ms: number;
+}
+
+export interface MediaStat {
+  media_id: string;
+  title: string;
+  media_type: string;
+  plays: number;
+  watched_ms: number;
+}
+
+export interface DayCount {
+  day: string;
+  plays: number;
+}
+
+export interface AnalyticsStats {
+  window_days: number;
+  totals: { plays: number; unique_users: number; watched_ms: number };
+  top_users: UserStat[];
+  top_media: MediaStat[];
+  least_media: MediaStat[];
+  plays_per_day: DayCount[];
+}
+
+async function getJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
+  const res = await apiFetch(path, { signal });
+  if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export function useActiveStreams() {
+  return useQuery({
+    queryKey: ["analytics", "streams"],
+    queryFn: ({ signal }) =>
+      getJSON<{ streams: LiveStream[] }>("/api/v1/analytics/streams", signal).then(
+        (b) => b.streams ?? [],
+      ),
+    refetchInterval: 10_000,
+  });
+}
+
+export function useAnalyticsHistory(limit = 50) {
+  return useQuery({
+    queryKey: ["analytics", "history", limit],
+    queryFn: ({ signal }) =>
+      getJSON<{ history: HistoryRecord[] }>(
+        `/api/v1/analytics/history?limit=${limit}`,
+        signal,
+      ).then((b) => b.history ?? []),
+  });
+}
+
+export function useAnalyticsStats(windowDays = 30) {
+  return useQuery({
+    queryKey: ["analytics", "stats", windowDays],
+    queryFn: ({ signal }) =>
+      getJSON<AnalyticsStats>(`/api/v1/analytics/stats?days=${windowDays}`, signal),
+  });
+}
+
+export function formatWatched(ms: number): string {
+  const totalMin = Math.round(ms / 60000);
+  if (totalMin < 60) return `${totalMin}m`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}

--- a/web/src/pages/analytics.tsx
+++ b/web/src/pages/analytics.tsx
@@ -1,0 +1,358 @@
+import * as React from "react";
+import { usePageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  useActiveStreams,
+  useAnalyticsStats,
+  useAnalyticsHistory,
+  formatWatched,
+  type MediaStat,
+  type UserStat,
+} from "@/lib/analytics-api";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Activity,
+  ShieldAlert,
+  PlayCircle,
+  PauseCircle,
+  Users,
+  Film,
+  Clock,
+  Tv,
+  MonitorPlay,
+  Zap,
+} from "lucide-react";
+
+function StatCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className="rounded-md bg-accent/10 p-2 text-accent">{icon}</div>
+        <div>
+          <p className="text-2xl font-semibold leading-none">{value}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{label}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MediaTypeIcon({ type }: { type: string }) {
+  if (type === "movie") return <Film className="h-3.5 w-3.5" />;
+  if (type === "episode") return <Tv className="h-3.5 w-3.5" />;
+  return <MonitorPlay className="h-3.5 w-3.5" />;
+}
+
+function ActiveStreams() {
+  const { data: streams, isLoading } = useActiveStreams();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Activity className="h-4 w-4" /> Active streams
+          {streams && streams.length > 0 && (
+            <Badge variant="secondary">{streams.length}</Badge>
+          )}
+        </CardTitle>
+        <CardDescription>Live playback across your media servers.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : !streams || streams.length === 0 ? (
+          <EmptyState
+            icon={<MonitorPlay />}
+            title="Nothing playing right now"
+            description="Active streams from Plex, Emby, and Jellyfin appear here in real time."
+          />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {streams.map((s) => (
+              <div
+                key={`${s.connection_id}-${s.session_key}-${s.media_id}`}
+                className="rounded-lg border bg-card/50 p-3"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="flex items-center gap-1.5 truncate font-medium">
+                      <MediaTypeIcon type={s.media_type} />
+                      {s.full_title || s.title}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {s.user || "Unknown"}
+                      {s.device ? ` · ${s.device}` : ""}
+                      {` · ${s.connection_name}`}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {s.transcode && (
+                      <Badge variant="outline" className="gap-1 text-[10px]">
+                        <Zap className="h-3 w-3" /> Transcode
+                      </Badge>
+                    )}
+                    {s.state === "paused" ? (
+                      <PauseCircle className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <PlayCircle className="h-4 w-4 text-accent" />
+                    )}
+                  </div>
+                </div>
+                <Progress value={s.progress} className="mt-3 h-1.5" />
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BarList({
+  rows,
+  emptyLabel,
+}: {
+  rows: { label: string; sub?: string; value: number; display: string }[];
+  emptyLabel: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="py-4 text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+  const max = Math.max(...rows.map((r) => r.value), 1);
+  return (
+    <div className="space-y-2.5">
+      {rows.map((r, i) => (
+        <div key={i} className="space-y-1">
+          <div className="flex items-baseline justify-between gap-2 text-sm">
+            <span className="truncate">{r.label}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">{r.display}</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-accent/70"
+              style={{ width: `${(r.value / max) * 100}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function userRows(users: UserStat[]) {
+  return users.map((u) => ({
+    label: u.user,
+    value: u.plays,
+    display: `${u.plays} plays · ${formatWatched(u.watched_ms)}`,
+  }));
+}
+
+function mediaRows(media: MediaStat[]) {
+  return media.map((m) => ({
+    label: m.title,
+    value: m.plays,
+    display: `${m.plays} plays · ${formatWatched(m.watched_ms)}`,
+  }));
+}
+
+function PlaysPerDay({ days }: { days: { day: string; plays: number }[] }) {
+  if (days.length === 0) {
+    return <p className="py-4 text-sm text-muted-foreground">No plays in this window.</p>;
+  }
+  const max = Math.max(...days.map((d) => d.plays), 1);
+  return (
+    <div className="flex h-32 items-end gap-1">
+      {days.map((d) => (
+        <div key={d.day} className="flex flex-1 flex-col items-center gap-1" title={`${d.day}: ${d.plays}`}>
+          <div className="flex w-full flex-1 items-end">
+            <div
+              className="w-full rounded-t bg-accent/70"
+              style={{ height: `${(d.plays / max) * 100}%`, minHeight: d.plays > 0 ? 2 : 0 }}
+            />
+          </div>
+          <span className="text-[9px] text-muted-foreground">{d.day.slice(5)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AnalyticsPage() {
+  const { setHeader } = usePageHeader();
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const [windowDays, setWindowDays] = React.useState(30);
+  React.useEffect(() => setHeader({ title: "Analytics" }), [setHeader]);
+
+  const stats = useAnalyticsStats(windowDays);
+  const history = useAnalyticsHistory(50);
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 p-12 text-center text-muted-foreground">
+        <ShieldAlert className="h-8 w-8" />
+        <p>You need admin access to view analytics.</p>
+      </div>
+    );
+  }
+
+  const s = stats.data;
+
+  return (
+    <div className="space-y-6 p-6">
+      <ActiveStreams />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Watch reports</h2>
+          <p className="text-sm text-muted-foreground">
+            Aggregated playback activity over the selected window.
+          </p>
+        </div>
+        <Select value={String(windowDays)} onValueChange={(v) => setWindowDays(Number(v))}>
+          <SelectTrigger className="w-36">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="7">Last 7 days</SelectItem>
+            <SelectItem value="30">Last 30 days</SelectItem>
+            <SelectItem value="90">Last 90 days</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <StatCard
+          icon={<PlayCircle className="h-5 w-5" />}
+          label="Total plays"
+          value={s ? String(s.totals.plays) : "—"}
+        />
+        <StatCard
+          icon={<Users className="h-5 w-5" />}
+          label="Unique viewers"
+          value={s ? String(s.totals.unique_users) : "—"}
+        />
+        <StatCard
+          icon={<Clock className="h-5 w-5" />}
+          label="Watch time"
+          value={s ? formatWatched(s.totals.watched_ms) : "—"}
+        />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Plays per day</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PlaysPerDay days={s?.plays_per_day ?? []} />
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Users className="h-4 w-4" /> Top viewers
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={userRows(s?.top_users ?? [])} emptyLabel="No activity yet." />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Film className="h-4 w-4" /> Most watched
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BarList rows={mediaRows(s?.top_media ?? [])} emptyLabel="No activity yet." />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent history</CardTitle>
+          <CardDescription>The latest playback sessions across all servers.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {history.isLoading ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : !history.data || history.data.length === 0 ? (
+            <EmptyState
+              icon={<Activity />}
+              title="No watch history yet"
+              description="Once people start watching, their sessions are recorded here."
+            />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead>Watched</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.data.map((h) => (
+                  <TableRow key={h.id}>
+                    <TableCell className="flex items-center gap-1.5">
+                      <MediaTypeIcon type={h.media_type} />
+                      <span className="truncate">{h.full_title}</span>
+                    </TableCell>
+                    <TableCell>{h.user || "—"}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {h.started_at ? new Date(h.started_at).toLocaleString() : "—"}
+                    </TableCell>
+                    <TableCell>{formatWatched(h.watched_ms)}</TableCell>
+                    <TableCell>
+                      <Badge variant={h.ended_at ? "secondary" : "default"}>
+                        {h.ended_at ? "Finished" : "Playing"}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -126,6 +126,14 @@ const requestsRoute = createRoute({
   errorComponent: ErrorFallback,
 });
 
+const analyticsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/analytics",
+  component: lazyRouteComponent(() => import("@/pages/analytics"), "AnalyticsPage"),
+  pendingComponent: PageLoader,
+  errorComponent: ErrorFallback,
+});
+
 const activityRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/activity",
@@ -377,6 +385,7 @@ const routeTree = rootRoute.addChildren([
   seriesRoute,
   discoverRoute,
   requestsRoute,
+  analyticsRoute,
   activityRoute,
   calendarRoute,
   downloadsRoute,


### PR DESCRIPTION
Tautulli-style analytics built on the existing Plex/Emby/Jellyfin connect integration: live stream monitoring, persisted watch history, and most/least-watched reports.

## Backend (internal/analytics)
- Migration 0063 `play_history` with a partial-unique open-row index keyed on (connection_id, session_key, media_id).
- `connect.Session` type + `ActiveSessions` provider methods (Plex `/status/sessions`, Emby/Jellyfin `/Sessions`).
- store/service/poller/handlers. 30s poller gated by the `media_analytics` feature flag.
- Per-connection sample isolation (a failed server doesn't false-end others), accurate watched-time accounting (accumulates only while playing, capped at grace), grace-window reaping, startup orphan cleanup.
- Admin-gated `/api/v1/analytics/{streams,history,stats}`.

## Frontend
- `analytics-api.ts` hooks + admin-only `/analytics` dashboard (active streams, stat cards, CSS-bar reports, recent history table).
- Nav entry gated by the `media_analytics` flag + admin role.

## Verification
- `CGO_ENABLED=0 go build ./...` green; analytics tests pass (10), connect builds.
- `tsc -b` + `pnpm build` green; new FE files lint-clean.

Refs #15