### PR TITLE
Fix torrent magnet metadata timeout + settings sub-nav scroll

### DIFF
--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,9 +21,50 @@ import (
 )
 
 // metadataTimeout is how long we wait for a magnet's metadata to
-// resolve before giving up. Thirty seconds is generous for public
-// swarms and tolerable for private trackers.
-const metadataTimeout = 30 * time.Second
+// resolve before giving up. Sixty seconds tolerates slow swarms and
+// cold trackers while still failing in a reasonable time.
+const metadataTimeout = 60 * time.Second
+
+// defaultTrackers is a curated list of reliable public BitTorrent
+// trackers used to bootstrap peer discovery for magnet links. In
+// NAT'd/containerised environments (e.g. Kubernetes) inbound peer
+// connectivity and DHT responsiveness are limited, so announcing to
+// well-known trackers is the most reliable way to find peers and pull
+// metadata. anacrolix dedups these against any trackers already present
+// in the magnet, so injecting them is safe.
+var defaultTrackers = []string{
+	"udp://tracker.opentrackr.org:1337/announce",
+	"udp://open.tracker.cl:1337/announce",
+	"udp://open.demonii.com:1337/announce",
+	"udp://exodus.desync.com:6969/announce",
+	"udp://tracker.torrent.eu.org:451/announce",
+	"udp://open.stealth.si:80/announce",
+	"https://tracker.gbitt.info:443/announce",
+	"https://tracker.tamersunion.org:443/announce",
+	"https://opentracker.i2p.rocks:443/announce",
+	"https://tracker1.520.jp:443/announce",
+}
+
+// defaultAnnounceList wraps each tracker in its own tier so anacrolix
+// announces to all of them in parallel.
+func defaultAnnounceList() [][]string {
+	list := make([][]string, len(defaultTrackers))
+	for i, tr := range defaultTrackers {
+		list[i] = []string{tr}
+	}
+	return list
+}
+
+// magnetHasTrackers reports whether a magnet URI already carries one or
+// more tracker (tr) parameters. Private-tracker magnets always do, so we
+// use this to avoid announcing private infohashes to public trackers.
+func magnetHasTrackers(magnet string) bool {
+	u, err := url.Parse(magnet)
+	if err != nil {
+		return false
+	}
+	return len(u.Query()["tr"]) > 0
+}
 
 // seedCheckInterval controls how often the seeding supervisor scans
 // all tracked torrents to enforce ratio/time policies.
@@ -259,6 +301,16 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 	t, err := e.client.AddMagnet(magnet)
 	if err != nil {
 		return "", fmt.Errorf("builtin/torrent: adding magnet: %w", err)
+	}
+
+	// When a magnet carries no trackers it can only find peers via DHT,
+	// which is slow or unreachable behind NAT/in containers and is the
+	// usual cause of metadata-resolution timeouts. Inject public trackers
+	// in that case. Magnets that already list trackers (including all
+	// private-tracker magnets) are left untouched so we never announce a
+	// private infohash to public trackers.
+	if !magnetHasTrackers(magnet) {
+		t.AddTrackers(defaultAnnounceList())
 	}
 
 	// Wait for metadata with a timeout.

--- a/internal/downloads/torrent/engine_test.go
+++ b/internal/downloads/torrent/engine_test.go
@@ -265,3 +265,51 @@ func TestStatus_MissingHash(t *testing.T) {
 		t.Errorf("got %d statuses, want 0", len(statuses))
 	}
 }
+
+func TestMagnetHasTrackers(t *testing.T) {
+cases := []struct {
+name   string
+magnet string
+want   bool
+}{
+{
+name:   "trackerless btih magnet",
+magnet: "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&dn=ubuntu",
+want:   false,
+},
+{
+name:   "magnet with one tracker",
+magnet: "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&tr=udp%3A%2F%2Ftracker.example%3A1337%2Fannounce",
+want:   true,
+},
+{
+name:   "magnet with multiple trackers",
+magnet: "magnet:?xt=urn:btih:abc&tr=udp://a:1/announce&tr=udp://b:2/announce",
+want:   true,
+},
+{
+name:   "garbage",
+magnet: "not a magnet",
+want:   false,
+},
+}
+for _, tc := range cases {
+t.Run(tc.name, func(t *testing.T) {
+if got := magnetHasTrackers(tc.magnet); got != tc.want {
+t.Fatalf("magnetHasTrackers(%q) = %v, want %v", tc.magnet, got, tc.want)
+}
+})
+}
+}
+
+func TestDefaultAnnounceList(t *testing.T) {
+list := defaultAnnounceList()
+if len(list) != len(defaultTrackers) {
+t.Fatalf("got %d tiers, want %d", len(list), len(defaultTrackers))
+}
+for i, tier := range list {
+if len(tier) != 1 || tier[0] != defaultTrackers[i] {
+t.Fatalf("tier %d = %v, want [%q]", i, tier, defaultTrackers[i])
+}
+}
+}

--- a/web/src/components/layout/settings-layout.tsx
+++ b/web/src/components/layout/settings-layout.tsx
@@ -204,14 +204,29 @@ export function SettingsLayout() {
     }
   }, [active, setHeader]);
 
-  // The settings layout stays mounted while sub-routes swap, so the window scroll
-  // position is otherwise preserved across navigation. Reset it to the top on each
-  // section change; without this, landing on a tall, async-loading panel (e.g.
-  // Libraries & Naming) while scrolled down causes the sticky sub-nav to visibly
-  // shift as the content clamps and then grows.
+  // The settings layout stays mounted while sub-routes swap, so the sticky
+  // sub-nav (an independent overflow-y-auto scroll container) otherwise keeps
+  // whatever scroll position the browser left it in — e.g. clicking a lower
+  // item focus-scrolls the container, pushing the top groups out of view and
+  // leaving them hidden after navigation. Deterministically reset the nav to
+  // the top on each section change, then only scroll down far enough to reveal
+  // the active item when it sits below the first screenful.
+  const navRef = React.useRef<HTMLElement>(null);
   const activeTo = active?.to;
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     window.scrollTo({ top: 0 });
+    const nav = navRef.current;
+    if (!nav) return;
+    nav.scrollTop = 0;
+    const activeEl = nav.querySelector<HTMLElement>('[aria-current="page"]');
+    if (!activeEl) return;
+    const top =
+      activeEl.getBoundingClientRect().top -
+      nav.getBoundingClientRect().top +
+      nav.scrollTop;
+    if (top + activeEl.offsetHeight > nav.clientHeight) {
+      nav.scrollTop = top - 16;
+    }
   }, [activeTo]);
 
   return (
@@ -241,6 +256,7 @@ export function SettingsLayout() {
 
       {/* Desktop grouped sub-nav */}
       <nav
+        ref={navRef}
         aria-label="Settings sections"
         className="hidden lg:block lg:sticky lg:top-20 lg:self-start lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto scrollbar-thin"
       >


### PR DESCRIPTION
Two user-reported fixes.

## builtin/torrent: magnet metadata timeout
Grabs failed with `builtin/torrent: metadata resolution timed out: context deadline exceeded`. In NAT'd/containerised deploys (the k8s pod) DHT is slow/unreachable, so trackerless magnets had no way to discover peers.

- Inject a curated public tracker list (UDP + HTTPS) **only when a magnet carries no trackers of its own**. This targets the DHT-only case that actually fails, while leaving tracker-bearing magnets — including all private-tracker magnets — untouched, so we never announce a private infohash to public trackers.
- Raise the metadata timeout 30s → 60s for slow/cold swarms.
- Added unit tests for the tracker discriminator + announce-list builder.

## Settings sub-nav 'pushed down'
The sticky settings sub-nav is its own scroll container (`overflow-y-auto max-h`) that stays mounted across sub-route changes. The browser's focus-scroll on a clicked item scrolled the top groups (General/Appearance/Features) out of view, and that state persisted.

- On each section change, deterministically reset the nav to the top (`useLayoutEffect`, rect-based offset), only scrolling down when the active item sits below the first screenful.

## Verification
- `CGO_ENABLED=0 go build ./...` + torrent tests pass.
- `tsc -b` + `pnpm build` + eslint (changed file) clean.