### PR TITLE
Expose built-in torrent peer port (inbound + DHT)

### DIFF
--- a/deploy/helm/loom/templates/deployment.yaml
+++ b/deploy/helm/loom/templates/deployment.yaml
@@ -44,6 +44,14 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.torrent.expose.enabled }}
+            - name: bt-tcp
+              containerPort: {{ .Values.torrent.listenPort }}
+              protocol: TCP
+            - name: bt-udp
+              containerPort: {{ .Values.torrent.listenPort }}
+              protocol: UDP
+            {{- end }}
           env:
             - name: LOOM_HTTP_ADDR
               value: ":{{ .Values.service.port }}"

--- a/deploy/helm/loom/templates/service-torrent.yaml
+++ b/deploy/helm/loom/templates/service-torrent.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.torrent.expose.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "loom.fullname" . }}-torrent
+  labels:
+    {{- include "loom.labels" . | nindent 4 }}
+  annotations:
+    {{- if and (eq .Values.torrent.expose.type "LoadBalancer") .Values.torrent.expose.loadBalancerIP }}
+    metallb.io/loadBalancerIPs: {{ .Values.torrent.expose.loadBalancerIP | quote }}
+    {{- end }}
+    {{- with .Values.torrent.expose.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.torrent.expose.type }}
+  {{- if and (ne .Values.torrent.expose.type "ClusterIP") .Values.torrent.expose.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.torrent.expose.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: bt-tcp
+      port: {{ .Values.torrent.listenPort }}
+      targetPort: bt-tcp
+      protocol: TCP
+      {{- if and (eq .Values.torrent.expose.type "NodePort") (gt (int .Values.torrent.expose.nodePort) 0) }}
+      nodePort: {{ .Values.torrent.expose.nodePort }}
+      {{- end }}
+    - name: bt-udp
+      port: {{ .Values.torrent.listenPort }}
+      targetPort: bt-udp
+      protocol: UDP
+      {{- if and (eq .Values.torrent.expose.type "NodePort") (gt (int .Values.torrent.expose.nodePortUdp) 0) }}
+      nodePort: {{ .Values.torrent.expose.nodePortUdp }}
+      {{- end }}
+  selector:
+    {{- include "loom.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/loom/values.yaml
+++ b/deploy/helm/loom/values.yaml
@@ -40,6 +40,36 @@ service:
   type: ClusterIP
   port: 8989
 
+# ---------- BitTorrent peer port ----------
+# Exposes the built-in torrent client's listen port so inbound peer
+# connections and DHT work. Behind NAT/in-cluster the pod is otherwise a
+# "leech" (outbound-only): DHT-only magnets struggle to find peers and
+# metadata resolution can time out. The port is preserved end-to-end so
+# DHT/tracker announces (which advertise listenPort) stay correct.
+#
+# listenPort MUST match the port configured on the builtin/torrent
+# download client in Loom (default 6881).
+#
+# For reachability from the public internet you must also port-forward
+# WAN:listenPort -> <service IP>:listenPort on your router.
+torrent:
+  listenPort: 6881
+  expose:
+    enabled: false
+    # LoadBalancer (e.g. MetalLB) is recommended because it preserves the
+    # port. NodePort and ClusterIP are also accepted.
+    type: LoadBalancer
+    # Optional fixed IP for LoadBalancer services (honoured by MetalLB via
+    # the metallb.io/loadBalancerIPs annotation). Empty = auto-assign.
+    loadBalancerIP: ""
+    # Preserve client source IPs (better peer/DHT behaviour). Only applied
+    # for non-ClusterIP services.
+    externalTrafficPolicy: Local
+    annotations: {}
+    # nodePort / nodePortUdp only apply when type is NodePort (30000-32767).
+    nodePort: 0
+    nodePortUdp: 0
+
 ingress:
   enabled: false
   className: ""

--- a/deploy/helm/values-homelab.yaml
+++ b/deploy/helm/values-homelab.yaml
@@ -31,6 +31,19 @@ service:
   type: ClusterIP
   port: 9999
 
+# ---------- BitTorrent peer port (built-in torrent client) ----------
+# Exposed via MetalLB so inbound peer connections + DHT work, instead of
+# the pod being an outbound-only leech. Port preserved end-to-end (6881).
+# For internet reachability, port-forward WAN:6881 -> 192.168.3.203:6881
+# on the router. listenPort must match the builtin/torrent client config.
+torrent:
+  listenPort: 6881
+  expose:
+    enabled: true
+    type: LoadBalancer
+    loadBalancerIP: "192.168.3.203"
+    externalTrafficPolicy: Local
+
 # ---------- Ingress (Traefik) ----------
 ingress:
   enabled: true


### PR DESCRIPTION
Behind NAT/in-cluster the pod was outbound-only, so DHT-only magnets struggled to find peers and metadata resolution timed out. This adds an optional dedicated Service exposing the built-in torrent client's listen port (TCP+UDP), preserving the port end-to-end so DHT/tracker announces (which advertise the listen port) stay correct.

## Changes
- `values.yaml`: new `torrent.expose` block — disabled by default; supports LoadBalancer/NodePort/ClusterIP, MetalLB IP via `metallb.io/loadBalancerIPs` annotation, `externalTrafficPolicy: Local`. `listenPort` must match the builtin/torrent client config (default 6881).
- `deployment.yaml`: add `bt-tcp`/`bt-udp` container ports when enabled.
- `service-torrent.yaml`: new templated Service (TCP + UDP).
- `values-homelab.yaml`: enable via MetalLB LoadBalancer at `192.168.3.203`.

## Verified
- Already applied to the live cluster (helm rev 103): LB IP `192.168.3.203` assigned, `nc` to TCP 6881 succeeds, app healthy.
- For full internet reachability, port-forward `WAN:6881 -> 192.168.3.203:6881` on the router (outbound announce + inbound forward then share the WAN IP, so advertised peer addr is correct).

Follow-up to the magnet tracker-injection fix (#42).