### PR TITLE
fix(torrent): prefer .torrent file over magnet to fix metadata timeouts

### DIFF
--- a/internal/downloads/torrent/client.go
+++ b/internal/downloads/torrent/client.go
@@ -129,10 +129,11 @@ func (c *Client) Add(ctx context.Context, req downloads.AddRequest) (downloads.A
 	}
 
 	meta := torrentMeta{
-		Title:      req.Title,
-		Category:   category,
-		SavePath:   savePath,
-		SeedPolicy: seedPolicy,
+		Title:            req.Title,
+		Category:         category,
+		SavePath:         savePath,
+		SeedPolicy:       seedPolicy,
+		ExpectedInfohash: req.Infohash,
 	}
 
 	var hash string
@@ -142,15 +143,32 @@ func (c *Client) Add(ctx context.Context, req downloads.AddRequest) (downloads.A
 	case len(req.RawBytes) > 0:
 		hash, err = c.engine.AddTorrentBytes(ctx, req.RawBytes, meta)
 
+	case req.TorrentURL != "":
+		// Prefer fetching the .torrent file over adding a magnet. A
+		// .torrent file embeds the metainfo, so metadata resolves
+		// instantly without any peer/DHT/tracker discovery. Magnets —
+		// especially the bare infohash magnets synthesised from an
+		// indexer's hash, which carry no trackers — depend on peer
+		// discovery, and DHT is effectively dead in NAT'd/containerised
+		// deployments. Using the .torrent avoids spurious
+		// "metadata resolution timed out" grab failures.
+		data, fetchErr := fetchTorrentURL(ctx, req.TorrentURL)
+		if fetchErr == nil {
+			hash, err = c.engine.AddTorrentBytes(ctx, data, meta)
+		} else {
+			err = fetchErr
+		}
+		// Fall back to the magnet only when the .torrent is
+		// unreachable/invalid AND the magnet was explicitly supplied by
+		// the indexer (it carries trackers). We never fall back to a
+		// synthesised bare-infohash magnet: it would fail the same way
+		// and could leak a private infohash to public trackers.
+		if err != nil && magnetHasTrackers(req.Magnet) {
+			hash, err = c.engine.AddMagnet(ctx, req.Magnet, meta)
+		}
+
 	case req.Magnet != "":
 		hash, err = c.engine.AddMagnet(ctx, req.Magnet, meta)
-
-	case req.TorrentURL != "":
-		data, fetchErr := fetchTorrentURL(ctx, req.TorrentURL)
-		if fetchErr != nil {
-			return downloads.AddResult{}, fetchErr
-		}
-		hash, err = c.engine.AddTorrentBytes(ctx, data, meta)
 
 	default:
 		return downloads.AddResult{}, fmt.Errorf(

--- a/internal/downloads/torrent/client_test.go
+++ b/internal/downloads/torrent/client_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
@@ -49,6 +50,152 @@ func TestAdd_NoInput(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalidInput) {
 		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+// --- Add dispatch: prefer .torrent URL over magnet ---
+
+// torrentInfohash returns the lowercase hex infohash of a .torrent blob.
+func torrentInfohash(t *testing.T, data []byte) string {
+	t.Helper()
+	mi, err := metainfo.Load(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("load torrent: %v", err)
+	}
+	return strings.ToLower(mi.HashInfoBytes().HexString())
+}
+
+// serveTorrent serves the given bytes as a .torrent file.
+func serveTorrent(t *testing.T, data []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		w.Write(data)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newAddTestClient(t *testing.T) *Client {
+	t.Helper()
+	e := newTestEngine(t)
+	return &Client{id: "c", name: "c", engine: e, defConfig: Config{DownloadDir: e.dataDir}}
+}
+
+// When both a bare-infohash magnet and a fetchable .torrent URL are
+// present, Add must prefer the .torrent (instant metadata). The test
+// engine has DHT disabled, so a wrong choice of the trackerless magnet
+// would fail with a metadata timeout rather than succeed quickly.
+func TestAdd_PrefersTorrentURLOverMagnet(t *testing.T) {
+	t.Parallel()
+	cl := newAddTestClient(t)
+
+	data := buildMinimalTorrent(t)
+	ih := torrentInfohash(t, data)
+	srv := serveTorrent(t, data)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	res, err := cl.Add(ctx, downloads.AddRequest{
+		Title:      "x",
+		Infohash:   ih,
+		Magnet:     "magnet:?xt=urn:btih:" + ih, // bare, no trackers
+		TorrentURL: srv.URL + "/x.torrent",
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if res.ItemID != ih {
+		t.Errorf("ItemID = %q, want %q", res.ItemID, ih)
+	}
+}
+
+// A .torrent whose infohash does not match the indexer-advertised hash
+// must be rejected, and must NOT fall back to the synthesized bare
+// magnet (which carries no trackers).
+func TestAdd_TorrentURLInfohashMismatchRejected(t *testing.T) {
+	t.Parallel()
+	cl := newAddTestClient(t)
+
+	data := buildMinimalTorrent(t)
+	srv := serveTorrent(t, data)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cl.Add(ctx, downloads.AddRequest{
+		Title:      "x",
+		Infohash:   strings.Repeat("a", 40), // wrong hash → bare magnet via Normalize
+		TorrentURL: srv.URL + "/x.torrent",
+	})
+	if err == nil {
+		t.Fatal("expected error for infohash mismatch")
+	}
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+	if errors.Is(err, ErrMetadataTimeout) {
+		t.Error("must not fall back to the synthesized bare magnet")
+	}
+}
+
+// When the .torrent fetch fails and an explicit tracker-bearing magnet
+// is available, Add falls back to the magnet. The transformed error
+// (metadata timeout from AddMagnet, not the HTTP 404) proves fallback.
+func TestAdd_FallsBackToExplicitMagnet(t *testing.T) {
+	t.Parallel()
+	cl := newAddTestClient(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	magnet := "magnet:?xt=urn:btih:" + strings.Repeat("b", 40) +
+		"&tr=udp%3A%2F%2Ftracker.invalid%3A1337%2Fannounce"
+	_, err := cl.Add(ctx, downloads.AddRequest{
+		Title:      "x",
+		Magnet:     magnet, // explicit, has trackers
+		TorrentURL: srv.URL + "/x.torrent",
+	})
+	if !errors.Is(err, ErrMetadataTimeout) {
+		t.Errorf("error = %v, want ErrMetadataTimeout (proving magnet fallback)", err)
+	}
+}
+
+// When the .torrent fetch fails and only a synthesized bare-infohash
+// magnet exists, Add does NOT fall back (privacy: never announce a
+// possibly-private bare infohash to public trackers). The original
+// fetch error surfaces.
+func TestAdd_NoFallbackToBareMagnet(t *testing.T) {
+	t.Parallel()
+	cl := newAddTestClient(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := cl.Add(ctx, downloads.AddRequest{
+		Title:      "x",
+		Infohash:   strings.Repeat("c", 40), // → bare magnet via Normalize
+		TorrentURL: srv.URL + "/x.torrent",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrMetadataTimeout) {
+		t.Error("must not fall back to the synthesized bare magnet")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected the HTTP fetch error to surface, got %v", err)
 	}
 }
 

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -91,6 +91,12 @@ type torrentMeta struct {
 	Category   string
 	SavePath   string
 	SeedPolicy SeedPolicy
+
+	// ExpectedInfohash, when set, is compared against the infohash of a
+	// fetched .torrent file before it is added. This guards against an
+	// indexer download URL that resolves to the wrong (stale, redirected,
+	// or malicious) torrent. Empty disables the check.
+	ExpectedInfohash string
 }
 
 // trackedTorrent pairs the anacrolix torrent handle with Loom metadata.
@@ -358,6 +364,16 @@ func (e *Engine) AddTorrentBytes(ctx context.Context, data []byte, meta torrentM
 	mi, err := metainfo.Load(bytes.NewReader(data))
 	if err != nil {
 		return "", fmt.Errorf("%w: parsing torrent bytes: %v", ErrInvalidInput, err)
+	}
+
+	// Verify the fetched torrent matches the infohash the indexer
+	// advertised. A mismatch means the download URL served the wrong
+	// content, so we refuse it rather than grab something unexpected.
+	if meta.ExpectedInfohash != "" {
+		got := strings.ToLower(mi.HashInfoBytes().HexString())
+		if want := strings.ToLower(strings.TrimSpace(meta.ExpectedInfohash)); got != want {
+			return "", fmt.Errorf("%w: torrent infohash %s does not match expected %s", ErrInvalidInput, got, want)
+		}
 	}
 
 	t, err := e.client.AddTorrent(mi)


### PR DESCRIPTION
## Problem
All torrent grabs fail with `builtin/torrent: metadata resolution timed out: context deadline exceeded`.

## Root cause (diagnosed in-cluster)
In the NAT'd Kubernetes pod, BitTorrent **DHT is dead** — a debug harness on the pod's node found **0 peers** for a torrent with thousands of seeders (DNS/TCP/UDP-tracker egress all verified working; anacrolix fetches metadata fine when a reachable tracker exists).

For indexers like YTS that expose an `infohash` **plus** a downloadable `.torrent` URL, `buildDownloadRequest` sets both `req.Magnet` (a **bare** infohash magnet, no trackers) and `req.TorrentURL`. `client.Add()`'s switch checked `Magnet` first, so Loom resolved metadata via the dead DHT instead of just fetching the `.torrent` (which embeds metadata and needs no peers).

## Fix
`client.Add()` now prefers fetching the `.torrent` file over a magnet. Safeguards:
- **Infohash validation**: the fetched `.torrent`'s infohash must match the indexer-advertised hash, else it's rejected (guards against stale/wrong/malicious downloads).
- **Safe fallback**: fall back to the magnet only when it was *explicitly* supplied (carries trackers); never to a synthesised bare-infohash magnet — it would fail identically and could leak a private infohash to public trackers.

## Tests
Added coverage for: `.torrent` preference, infohash-mismatch rejection, fallback to an explicit magnet, and no-fallback to a bare magnet. `go test ./internal/downloads/torrent/` green.