### PR TITLE
fix(search): category-capability indexer selection + apostrophe-safe query normalization

### DIFF
--- a/internal/indexers/registry.go
+++ b/internal/indexers/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -210,12 +211,13 @@ func (r *Registry) Search(ctx context.Context, q Query, opts SearchOptions) Aggr
 	sem := make(chan struct{}, limit)
 
 	type partial struct {
-		id      string
-		name    string
-		out     *Results
-		err     error
-		skipped bool
-		elapsed time.Duration
+		id         string
+		name       string
+		out        *Results
+		err        error
+		skipped    bool
+		skipReason string
+		elapsed    time.Duration
 	}
 	ch := make(chan partial, len(targets))
 	var wg sync.WaitGroup
@@ -228,7 +230,20 @@ func (r *Registry) Search(ctx context.Context, q Query, opts SearchOptions) Aggr
 		if q.Term == "" && queryHasIDs(q) && !indexerSupportsAnyQueryID(ix, q) {
 			slog.Debug("registry: skipping indexer (no supported IDs, no text fallback)",
 				"indexer", ix.Name(), "query_ids", queryIDSummary(q))
-			ch <- partial{id: ix.ID(), name: ix.Name(), skipped: true}
+			ch <- partial{id: ix.ID(), name: ix.Name(), skipped: true,
+				skipReason: "indexer does not support any of the query's ID types"}
+			continue
+		}
+
+		// Skip indexers whose advertised categories cannot serve this
+		// query (e.g. a movies-only indexer for a TV search). This avoids
+		// wasted requests/timeouts and the false "indexer failed"
+		// diagnostics they produce.
+		if !indexerServesCategories(ix, q) {
+			slog.Debug("registry: skipping indexer (categories not served)",
+				"indexer", ix.Name(), "query_categories", queryCategorySummary(q))
+			ch <- partial{id: ix.ID(), name: ix.Name(), skipped: true,
+				skipReason: "indexer does not serve the requested categories"}
 			continue
 		}
 
@@ -259,7 +274,10 @@ func (r *Registry) Search(ctx context.Context, q Query, opts SearchOptions) Aggr
 		}
 		if p.skipped {
 			d.Status = "skipped"
-			d.ErrorMessage = "indexer does not support any of the query's ID types"
+			d.ErrorMessage = p.skipReason
+			if d.ErrorMessage == "" {
+				d.ErrorMessage = "indexer skipped"
+			}
 		} else if p.err != nil {
 			agg.Errors[p.id] = p.err.Error()
 			d.ErrorMessage = p.err.Error()
@@ -367,6 +385,21 @@ func (r *Registry) SearchStream(ctx context.Context, q Query, opts SearchOptions
 			case events <- StreamEvent{
 				Type: EventIndexerError, IndexerID: ix.ID(), IndexerName: ix.Name(),
 				Error: "skipped: indexer does not support any of the query's ID types", Status: "skipped",
+			}:
+			case <-ctx.Done():
+			}
+			continue
+		}
+
+		// Skip indexers whose categories cannot serve this query (same
+		// check as Search).
+		if !indexerServesCategories(ix, q) {
+			slog.Debug("registry: stream skipping indexer (categories not served)",
+				"indexer", ix.Name(), "query_categories", queryCategorySummary(q))
+			select {
+			case events <- StreamEvent{
+				Type: EventIndexerError, IndexerID: ix.ID(), IndexerName: ix.Name(),
+				Error: "skipped: indexer does not serve the requested categories", Status: "skipped",
 			}:
 			case <-ctx.Done():
 			}
@@ -584,6 +617,51 @@ func indexerSupportsAnyQueryID(ix Indexer, q Query) bool {
 		return true
 	}
 	return false
+}
+
+// indexerServesCategories reports whether the indexer can serve the
+// query's requested categories. It compares at the top-level family
+// granularity (e.g. 2040 → 2000) so a movies-only indexer is skipped
+// for a TV search and vice-versa. An indexer that advertises no
+// categories is allowed (unknown caps → don't break it); a query that
+// requests no categories matches every indexer.
+func indexerServesCategories(ix Indexer, q Query) bool {
+	if len(q.Categories) == 0 {
+		return true
+	}
+	caps := ix.Caps()
+	if len(caps.Categories) == 0 {
+		return true // unknown caps → allow
+	}
+	families := make(map[Category]bool, len(caps.Categories))
+	for _, c := range caps.Categories {
+		families[c.Family()] = true
+	}
+	for _, qc := range q.Categories {
+		if families[qc.Family()] {
+			return true
+		}
+	}
+	return false
+}
+
+// queryCategorySummary returns a human-readable summary of requested
+// category families for diagnostics.
+func queryCategorySummary(q Query) string {
+	if len(q.Categories) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(q.Categories))
+	seen := make(map[Category]bool, len(q.Categories))
+	for _, c := range q.Categories {
+		f := c.Family()
+		if seen[f] {
+			continue
+		}
+		seen[f] = true
+		parts = append(parts, strconv.Itoa(int(f)))
+	}
+	return strings.Join(parts, ",")
 }
 
 // queryIDSummary returns a human-readable summary of which IDs are set.

--- a/internal/indexers/registry_test.go
+++ b/internal/indexers/registry_test.go
@@ -113,6 +113,84 @@ func TestRegistrySearchSelectsByID(t *testing.T) {
 	}
 }
 
+// --- p3: capability-based (category) indexer selection ---
+
+func TestRegistrySearchSkipsIndexerByCategoryCaps(t *testing.T) {
+	t.Parallel()
+	r := indexers.NewRegistry()
+	movies := &fakeIndexer{
+		id:   "movies",
+		name: "MoviesOnly",
+		caps: indexers.Caps{Categories: []indexers.Category{indexers.CategoryMovies}},
+		results: []indexers.Result{
+			{IndexerID: "movies", Title: "M", MagnetURI: "magnet:?xt=urn:btih:aaa"},
+		},
+	}
+	tv := &fakeIndexer{
+		id:   "tv",
+		name: "TVOnly",
+		caps: indexers.Caps{Categories: []indexers.Category{indexers.CategoryTV}},
+		results: []indexers.Result{
+			{IndexerID: "tv", Title: "T", Category: []indexers.Category{indexers.CategoryTV},
+				MagnetURI: "magnet:?xt=urn:btih:bbb"},
+		},
+	}
+	_ = r.Register(movies)
+	_ = r.Register(tv)
+
+	q := indexers.Query{Term: "show", Categories: []indexers.Category{indexers.CategoryTV}}
+	out := r.Search(context.Background(), q, indexers.SearchOptions{})
+
+	if movies.calls.Load() != 0 {
+		t.Errorf("movies-only indexer should be skipped for a TV search, got %d calls", movies.calls.Load())
+	}
+	if tv.calls.Load() != 1 {
+		t.Errorf("tv indexer should be queried once, got %d", tv.calls.Load())
+	}
+	if _, ok := out.Errors["movies"]; ok {
+		t.Error("a skipped indexer must not be reported as an error")
+	}
+	if out.Diagnostics == nil {
+		t.Fatal("expected diagnostics")
+	}
+	var found bool
+	for _, d := range out.Diagnostics.Indexers {
+		if d.ID == "movies" {
+			found = true
+			if d.Status != "skipped" {
+				t.Errorf("movies status = %q, want skipped", d.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a diagnostic entry for the skipped indexer")
+	}
+}
+
+func TestRegistrySearchUnknownCategoryCapsNotSkipped(t *testing.T) {
+	t.Parallel()
+	r := indexers.NewRegistry()
+	// No advertised categories → unknown caps → must not be skipped.
+	any := &fakeIndexer{
+		id:   "any",
+		name: "AnyCat",
+		results: []indexers.Result{
+			{IndexerID: "any", Title: "X", Category: []indexers.Category{indexers.CategoryTV},
+				MagnetURI: "magnet:?xt=urn:btih:ccc"},
+		},
+	}
+	_ = r.Register(any)
+
+	q := indexers.Query{Term: "show", Categories: []indexers.Category{indexers.CategoryTV}}
+	out := r.Search(context.Background(), q, indexers.SearchOptions{})
+	if any.calls.Load() != 1 {
+		t.Errorf("indexer with unknown caps should be queried, got %d calls", any.calls.Load())
+	}
+	if len(out.Results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(out.Results))
+	}
+}
+
 func TestRegistrySearchSurfacesIndexerError(t *testing.T) {
 	t.Parallel()
 	r := indexers.NewRegistry()

--- a/internal/indexers/sanitize_test.go
+++ b/internal/indexers/sanitize_test.go
@@ -1,0 +1,41 @@
+package indexers_test
+
+import (
+	"testing"
+
+	"github.com/ebenderooock/loom/internal/indexers"
+)
+
+func TestSanitizeTerm(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		in            string
+		seasonEpisode bool
+		want          string
+	}{
+		{"apostrophe stripped not spaced", "Clarkson's Farm", false, "Clarksons Farm"},
+		{"smart apostrophe stripped", "Clarkson\u2019s Farm", false, "Clarksons Farm"},
+		{"contraction", "Don't Look Up", false, "Dont Look Up"},
+		{"double quotes stripped", "\"Star Wars\"", false, "Star Wars"},
+		{"smart double quotes stripped", "\u201CStar Wars\u201D", false, "Star Wars"},
+		{"backtick stripped", "Rock`n Roll", false, "Rockn Roll"},
+		{"colon becomes space", "Mission: Impossible", false, "Mission Impossible"},
+		{"collapses whitespace", "a   b", false, "a b"},
+		{"season stripped with params", "The Show S01E02", true, "The Show"},
+		{"season kept without params", "The Show S01E02", false, "The Show S01E02"},
+		{"empty", "", false, ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := indexers.SanitizeTerm(tc.in, tc.seasonEpisode)
+			if got != tc.want {
+				t.Errorf("SanitizeTerm(%q, %v) = %q, want %q", tc.in, tc.seasonEpisode, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/indexers/types.go
+++ b/internal/indexers/types.go
@@ -152,18 +152,30 @@ type Query struct {
 // search queries (e.g. S01E01, S03, 1x05).
 var reSeasonEpisode = regexp.MustCompile(`(?i)\b[Ss]\d{1,2}(?:[Ee]\d{1,2})?\b|\b\d{1,2}[Xx]\d{1,2}\b`)
 
-// reSpecialChars matches punctuation that breaks most newznab/torznab
-// tokenizers.
-var reSpecialChars = regexp.MustCompile(`[''"""` + "`" + `:;!?@#$%^&*()+=\[\]{}<>|\\~/]`)
+// reStripChars matches apostrophes, quotes and backticks — intra-word
+// punctuation that must be removed entirely (not replaced with a space)
+// so possessives and contractions collapse the way release names do.
+// e.g. "Clarkson's Farm" → "Clarksons Farm", not "Clarkson s Farm".
+// Covers both ASCII and the common "smart" Unicode variants.
+var reStripChars = regexp.MustCompile(`['"` + "`" + "\u2018\u2019\u201C\u201D]")
+
+// reSeparatorChars matches punctuation that genuinely separates words
+// and so collapses to a space.
+var reSeparatorChars = regexp.MustCompile(`[:;!?@#$%^&*()+=\[\]{}<>|\\~/]`)
 
 // SanitizeTerm cleans a user-provided search term for indexer APIs.
 // When hasSeasonEpisodeParams is true the season/episode tokens are
 // stripped because they are sent as dedicated API parameters.
+//
+// Apostrophes/quotes are deleted (so "Clarkson's" → "Clarksons"),
+// matching Prowlarr/Sonarr normalisation and the way scene/p2p release
+// names drop them; other special characters become spaces.
 func SanitizeTerm(term string, hasSeasonEpisodeParams bool) string {
 	if hasSeasonEpisodeParams {
 		term = reSeasonEpisode.ReplaceAllString(term, " ")
 	}
-	term = reSpecialChars.ReplaceAllString(term, " ")
+	term = reStripChars.ReplaceAllString(term, "")
+	term = reSeparatorChars.ReplaceAllString(term, " ")
 	return strings.TrimSpace(strings.Join(strings.Fields(term), " "))
 }
 


### PR DESCRIPTION
Two search-reliability fixes (Prowlarr parity).

## p3 — Capability-based indexer selection
The registry now **skips indexers whose advertised category families cannot serve a query** (e.g. movies-only YTS for a TV search). This avoids wasted requests/timeouts and the false "indexer failed" diagnostics those produce. Indexers that advertise no categories are still queried (unknown caps → allow). Applied in both `Search` and `SearchStream`, surfaced as a distinct `skipped` diagnostic.

## p6 — Query punctuation normalization
`SanitizeTerm` now **strips apostrophes/quotes** (ASCII + smart Unicode variants) instead of replacing them with a space:
- before: `Clarkson's Farm` → `q=clarkson s farm`
- after: `Clarkson's Farm` → `q=clarksons farm`

This matches scene/p2p release naming and Prowlarr/Sonarr normalization. Other special characters still collapse to spaces.

## p5 — Rate limiting
Already wired via `throttle.Wrap` in `kinds.go` (60/min + burst 5 + per-definition `RequestDelay` capping). No change needed.

## Tests
- `TestSanitizeTerm` — apostrophes/quotes/backtick stripped, colon→space, season-token handling.
- `TestRegistrySearchSkipsIndexerByCategoryCaps` — movies-only indexer skipped (0 calls) for a TV search, reported as `skipped` not error.
- `TestRegistrySearchUnknownCategoryCapsNotSkipped` — indexers with unknown caps still queried.

All `./internal/indexers/...`, torrent, and autosearch suites green.