### PR TITLE
feat(analytics): bandwidth/transcoding stats, dashboard widgets, playback notifications (#15)

### DIFF
--- a/cmd/loom/wire_infra.go
+++ b/cmd/loom/wire_infra.go
@@ -54,7 +54,7 @@ func wireInfra(
 
 	// Media analytics — live stream monitoring + watch history, sampled from
 	// enabled Plex/Emby/Jellyfin connections and gated by a feature flag.
-	analyticsSvc := analytics.NewService(analytics.NewStore(db.DB()), connectSvc, logger)
+	analyticsSvc := analytics.NewService(analytics.NewStore(db.DB()), connectSvc, srv.Bus(), logger)
 	srv.SetAnalytics(analyticsSvc)
 	analyticsPoller := analytics.NewPoller(
 		analyticsSvc,

--- a/internal/analytics/events.go
+++ b/internal/analytics/events.go
@@ -1,0 +1,71 @@
+package analytics
+
+import "github.com/ebenderooock/loom/internal/connect"
+
+// Event bus topics for playback activity. The notifications dispatcher maps both
+// of these to the on_playback notification event type.
+const (
+	TopicPlaybackStarted = "analytics.playback.started"
+	TopicPlaybackStopped = "analytics.playback.stopped"
+)
+
+// PlaybackEvent is emitted when a stream starts or stops. It implements
+// eventbus.Event plus the optional NotificationData/GetTitle interfaces the
+// notification dispatcher uses to render messages.
+type PlaybackEvent struct {
+	topic          string
+	ConnectionName string
+	Provider       string
+	User           string
+	MediaType      string
+	FullTitle      string
+	Device         string
+	Transcode      bool
+	BitrateKbps    int64
+	WatchedMs      int64
+}
+
+func newPlaybackEvent(topic, connectionName string, rec HistoryRecord) *PlaybackEvent {
+	return &PlaybackEvent{
+		topic:          topic,
+		ConnectionName: connectionName,
+		Provider:       rec.Provider,
+		User:           rec.User,
+		MediaType:      rec.MediaType,
+		FullTitle:      rec.FullTitle,
+		Device:         rec.Device,
+		Transcode:      rec.Transcode,
+		BitrateKbps:    rec.BitrateKbps,
+		WatchedMs:      rec.WatchedMs,
+	}
+}
+
+// Topic implements eventbus.Event.
+func (e *PlaybackEvent) Topic() string { return e.topic }
+
+// GetTitle implements the dispatcher's optional titler interface.
+func (e *PlaybackEvent) GetTitle() string { return e.FullTitle }
+
+// NotificationData implements the dispatcher's optional dataProvider interface.
+func (e *PlaybackEvent) NotificationData() map[string]any {
+	return map[string]any{
+		"title":        e.FullTitle,
+		"user":         e.User,
+		"device":       e.Device,
+		"server":       e.ConnectionName,
+		"provider":     e.Provider,
+		"media_type":   e.MediaType,
+		"transcode":    e.Transcode,
+		"bitrate_kbps": e.BitrateKbps,
+		"watched_ms":   e.WatchedMs,
+	}
+}
+
+// liveStreamFrom builds a snapshot LiveStream from a connect session.
+func liveStreamFrom(sess connect.Session, connName string) LiveStream {
+	return LiveStream{
+		Session:        sess,
+		ConnectionName: connName,
+		Progress:       progress(sess.PositionMs, sess.DurationMs),
+	}
+}

--- a/internal/analytics/service.go
+++ b/internal/analytics/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ebenderooock/loom/internal/connect"
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
 	"github.com/google/uuid"
 )
 
@@ -41,15 +42,21 @@ type Service struct {
 	store   *Store
 	conns   ConnectionSource
 	fetch   SessionFetcher
+	bus     eventbus.Bus
 	logger  *slog.Logger
 	minPlay time.Duration // minimum watched time to count a play in stats
 
 	mu       sync.RWMutex
 	snapshot []LiveStream
+
+	// baselined is false until the first Sample completes; the baseline pass
+	// suppresses start events for already-running streams.
+	baselined bool
 }
 
-// NewService creates an analytics service.
-func NewService(store *Store, conns ConnectionSource, logger *slog.Logger) *Service {
+// NewService creates an analytics service. bus may be nil (playback start/stop
+// notifications are then disabled).
+func NewService(store *Store, conns ConnectionSource, bus eventbus.Bus, logger *slog.Logger) *Service {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -57,6 +64,7 @@ func NewService(store *Store, conns ConnectionSource, logger *slog.Logger) *Serv
 		store:    store,
 		conns:    conns,
 		fetch:    defaultFetcher,
+		bus:      bus,
 		logger:   logger.With("module", "analytics"),
 		minPlay:  60 * time.Second,
 		snapshot: []LiveStream{},
@@ -151,6 +159,13 @@ func (s *Service) Sample(ctx context.Context, interval time.Duration) {
 	now := time.Now().UTC()
 	grace := 2 * interval
 
+	// The first sample after startup is a baseline: ResetOrphans has just closed
+	// all open rows, so every active session looks "new". Suppress start events
+	// for that pass so a restart doesn't spam "Playback Started" for streams that
+	// were already running.
+	suppressStarts := !s.baselined
+	s.baselined = true
+
 	// Preserve previous snapshot entries for connections that failed this tick
 	// (mark stale by keeping them) and rebuild from successful ones.
 	prev := s.ActiveStreams()
@@ -160,23 +175,43 @@ func (s *Service) Sample(ctx context.Context, interval time.Duration) {
 	}
 
 	newSnapshot := []LiveStream{}
+	var events []*PlaybackEvent
 	for _, res := range results {
 		if !res.ok {
 			// Keep last-known streams for this connection rather than dropping.
 			newSnapshot = append(newSnapshot, prevByConn[res.conn.ID]...)
 			continue
 		}
-		newSnapshot = append(newSnapshot, s.persistConnection(ctx, res.conn, res.sessions, now, grace)...)
+		streams, evs := s.persistConnection(ctx, res.conn, res.sessions, now, grace, suppressStarts)
+		newSnapshot = append(newSnapshot, streams...)
+		events = append(events, evs...)
 	}
 
 	s.mu.Lock()
 	s.snapshot = newSnapshot
 	s.mu.Unlock()
+
+	// Publish playback start/stop notifications after persistence succeeds, so a
+	// notification only ever corresponds to a real recorded state change.
+	s.publish(ctx, events)
+}
+
+// publish emits collected playback events on the bus (best-effort, nil-safe).
+func (s *Service) publish(ctx context.Context, events []*PlaybackEvent) {
+	if s.bus == nil || len(events) == 0 {
+		return
+	}
+	for _, ev := range events {
+		if err := s.bus.Publish(ctx, ev); err != nil {
+			s.logger.Warn("analytics: publish playback event failed", "topic", ev.Topic(), "error", err)
+		}
+	}
 }
 
 // persistConnection reconciles one connection's active sessions against its
-// open history rows and returns the live streams for the snapshot.
-func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, sessions []connect.Session, now time.Time, grace time.Duration) []LiveStream {
+// open history rows and returns the live streams for the snapshot plus any
+// playback start/stop events to publish.
+func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, sessions []connect.Session, now time.Time, grace time.Duration, suppressStarts bool) ([]LiveStream, []*PlaybackEvent) {
 	open, err := s.store.OpenRowsForConn(ctx, c.ID)
 	if err != nil {
 		s.logger.Warn("analytics: load open rows failed", "connection", c.Name, "error", err)
@@ -189,6 +224,7 @@ func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, 
 
 	active := map[sessionKey]bool{}
 	streams := make([]LiveStream, 0, len(sessions))
+	var events []*PlaybackEvent
 
 	for _, sess := range sessions {
 		k := sessionKey{session: sess.SessionKey, media: sess.MediaID}
@@ -208,7 +244,7 @@ func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, 
 				}
 				watched += delta.Milliseconds()
 			}
-			if err := s.store.UpdateOpen(ctx, row.ID, now, sess.PositionMs, watched, sess.Transcode); err != nil {
+			if err := s.store.UpdateOpen(ctx, row.ID, now, sess.PositionMs, watched, sess.Transcode, sess.BitrateKbps); err != nil {
 				s.logger.Warn("analytics: update row failed", "error", err)
 			} else {
 				row.WatchedMs = watched
@@ -232,19 +268,18 @@ func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, 
 				LastPositionMs:   sess.PositionMs,
 				DurationMs:       sess.DurationMs,
 				WatchedMs:        0,
+				BitrateKbps:      sess.BitrateKbps,
 			}
 			if err := s.store.InsertOpen(ctx, rec); err != nil {
 				s.logger.Warn("analytics: insert row failed", "error", err)
+			} else if !suppressStarts {
+				events = append(events, newPlaybackEvent(TopicPlaybackStarted, c.Name, rec))
 			}
 		}
 
 		sess.ConnectionID = c.ID
 		sess.Provider = c.Provider
-		streams = append(streams, LiveStream{
-			Session:        sess,
-			ConnectionName: c.Name,
-			Progress:       progress(sess.PositionMs, sess.DurationMs),
-		})
+		streams = append(streams, liveStreamFrom(sess, c.Name))
 	}
 
 	// Reap: close open rows for this connection that are no longer active and
@@ -256,13 +291,16 @@ func (s *Service) persistConnection(ctx context.Context, c *connect.Connection, 
 			continue
 		}
 		if row.LastSeenAt.Before(cutoff) {
-			if err := s.store.Close(ctx, row.ID, row.LastSeenAt, "disappeared"); err != nil {
+			closed, err := s.store.Close(ctx, row.ID, row.LastSeenAt, "disappeared")
+			if err != nil {
 				s.logger.Warn("analytics: close row failed", "error", err)
+			} else if closed {
+				events = append(events, newPlaybackEvent(TopicPlaybackStopped, c.Name, row))
 			}
 		}
 	}
 
-	return streams
+	return streams, events
 }
 
 func progress(pos, dur int64) float64 {

--- a/internal/analytics/service_test.go
+++ b/internal/analytics/service_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"io"
+	"sync"
 	"log/slog"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ebenderooock/loom/internal/connect"
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
 	"github.com/ebenderooock/loom/internal/kernel/config"
 	"github.com/ebenderooock/loom/internal/storage"
 )
@@ -43,12 +45,39 @@ func quiet() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-func newSvc(t *testing.T, conns ...*connect.Connection) (*Service, *Store) {
+// captureBus records published events for assertions. It satisfies
+// eventbus.Bus; Subscribe is unused in these tests.
+type captureBus struct {
+	mu     sync.Mutex
+	events []eventbus.Event
+}
+
+func (b *captureBus) Publish(_ context.Context, ev eventbus.Event) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, ev)
+	return nil
+}
+
+func (b *captureBus) Subscribe(string, eventbus.Handler) func() { return func() {} }
+
+func (b *captureBus) topics() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.events))
+	for i, e := range b.events {
+		out[i] = e.Topic()
+	}
+	return out
+}
+
+func newSvc(t *testing.T, conns ...*connect.Connection) (*Service, *Store, *captureBus) {
 	t.Helper()
 	db := openTestDB(t)
 	store := NewStore(db)
-	svc := NewService(store, &fakeSource{conns: conns}, quiet())
-	return svc, store
+	bus := &captureBus{}
+	svc := NewService(store, &fakeSource{conns: conns}, bus, quiet())
+	return svc, store, bus
 }
 
 func plexConn(id, name string) *connect.Connection {
@@ -56,7 +85,7 @@ func plexConn(id, name string) *connect.Connection {
 }
 
 func TestPersistContinuityAccumulatesWatched(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
@@ -66,8 +95,8 @@ func TestPersistContinuityAccumulatesWatched(t *testing.T) {
 		PositionMs: 1000, DurationMs: 600000}
 
 	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(30*time.Second), grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace, false)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(30*time.Second), grace, false)
 
 	open, err := store.OpenRowsForConn(ctx, "c1")
 	if err != nil {
@@ -82,16 +111,16 @@ func TestPersistContinuityAccumulatesWatched(t *testing.T) {
 }
 
 func TestPersistCapsDeltaAtGrace(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
 	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
 
 	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace, false)
 	// A long gap (server unreachable): delta is 10m but must cap at grace (60s).
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(10*time.Minute), grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(10*time.Minute), grace, false)
 
 	open, _ := store.OpenRowsForConn(ctx, "c1")
 	if len(open) != 1 || open[0].WatchedMs != 60000 {
@@ -100,7 +129,7 @@ func TestPersistCapsDeltaAtGrace(t *testing.T) {
 }
 
 func TestPausedDoesNotAccumulate(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
@@ -109,8 +138,8 @@ func TestPausedDoesNotAccumulate(t *testing.T) {
 	paused.State = "paused"
 
 	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
-	svc.persistConnection(ctx, conn, []connect.Session{playing}, t0, grace)
-	svc.persistConnection(ctx, conn, []connect.Session{paused}, t0.Add(30*time.Second), grace)
+	svc.persistConnection(ctx, conn, []connect.Session{playing}, t0, grace, false)
+	svc.persistConnection(ctx, conn, []connect.Session{paused}, t0.Add(30*time.Second), grace, false)
 
 	open, _ := store.OpenRowsForConn(ctx, "c1")
 	if len(open) != 1 || open[0].WatchedMs != 0 {
@@ -119,17 +148,17 @@ func TestPausedDoesNotAccumulate(t *testing.T) {
 }
 
 func TestReapOnDisappear(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
 	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
 
 	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace, false)
 
 	// Disappears; now is past lastSeen + grace, so it must be closed.
-	svc.persistConnection(ctx, conn, nil, t0.Add(2*grace+time.Second), grace)
+	svc.persistConnection(ctx, conn, nil, t0.Add(2*grace+time.Second), grace, false)
 
 	open, _ := store.OpenRowsForConn(ctx, "c1")
 	if len(open) != 0 {
@@ -142,16 +171,16 @@ func TestReapOnDisappear(t *testing.T) {
 }
 
 func TestReapWaitsForGrace(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
 	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 600000}
 
 	t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace, false)
 	// Missed a single poll (30s) — within grace, must NOT reap.
-	svc.persistConnection(ctx, conn, nil, t0.Add(30*time.Second), grace)
+	svc.persistConnection(ctx, conn, nil, t0.Add(30*time.Second), grace, false)
 
 	open, _ := store.OpenRowsForConn(ctx, "c1")
 	if len(open) != 1 {
@@ -160,7 +189,7 @@ func TestReapWaitsForGrace(t *testing.T) {
 }
 
 func TestDistinctMediaSameSessionKey(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	grace := 60 * time.Second
@@ -168,7 +197,7 @@ func TestDistinctMediaSameSessionKey(t *testing.T) {
 
 	a := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 1}
 	b := connect.Session{SessionKey: "10", MediaID: "200", State: "playing", DurationMs: 1}
-	svc.persistConnection(ctx, conn, []connect.Session{a, b}, t0, grace)
+	svc.persistConnection(ctx, conn, []connect.Session{a, b}, t0, grace, false)
 
 	open, _ := store.OpenRowsForConn(ctx, "c1")
 	if len(open) != 2 {
@@ -177,11 +206,11 @@ func TestDistinctMediaSameSessionKey(t *testing.T) {
 }
 
 func TestResetOrphansClosesOpenRows(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	conn := plexConn("c1", "Plex")
 	ctx := context.Background()
 	sess := connect.Session{SessionKey: "10", MediaID: "100", State: "playing", DurationMs: 1}
-	svc.persistConnection(ctx, conn, []connect.Session{sess}, time.Now().UTC(), 60*time.Second)
+	svc.persistConnection(ctx, conn, []connect.Session{sess}, time.Now().UTC(), 60*time.Second, false)
 
 	svc.ResetOrphans(ctx)
 
@@ -192,7 +221,7 @@ func TestResetOrphansClosesOpenRows(t *testing.T) {
 }
 
 func TestStatsThresholdAndAggregates(t *testing.T) {
-	svc, store := newSvc(t)
+	svc, store, _ := newSvc(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -228,7 +257,7 @@ func TestStatsThresholdAndAggregates(t *testing.T) {
 func TestSampleIsolatesFailedConnection(t *testing.T) {
 	connA := plexConn("a", "A")
 	connB := plexConn("b", "B")
-	svc, store := newSvc(t, connA, connB)
+	svc, store, _ := newSvc(t, connA, connB)
 	ctx := context.Background()
 
 	failB := false
@@ -255,4 +284,153 @@ func TestSampleIsolatesFailedConnection(t *testing.T) {
 	if len(openB) != 1 {
 		t.Fatalf("failed connection's history must not be reaped, %d open", len(openB))
 	}
+}
+
+func countTopic(topics []string, want string) int {
+n := 0
+for _, tp := range topics {
+if tp == want {
+n++
+}
+}
+return n
+}
+
+func topicsOf(evs []*PlaybackEvent) []string {
+out := make([]string, 0, len(evs))
+for _, ev := range evs {
+out = append(out, ev.Topic())
+}
+return out
+}
+
+func TestSamplePublishesStartAndStop(t *testing.T) {
+conn := plexConn("c1", "Plex")
+svc, _, bus := newSvc(t, conn)
+ctx := context.Background()
+
+playing := false
+svc.fetch = func(_ context.Context, c *connect.Connection) ([]connect.Session, error) {
+if !playing {
+return nil, nil
+}
+return []connect.Session{{SessionKey: "1", MediaID: "m1", User: "alice",
+MediaType: "movie", FullTitle: "Movie A", State: "playing", DurationMs: 600000}}, nil
+}
+
+// Baseline sample (nothing playing) primes the service past the startup pass.
+svc.Sample(ctx, 30*time.Second)
+if got := len(bus.topics()); got != 0 {
+t.Fatalf("baseline sample must emit nothing, got %v", bus.topics())
+}
+
+// Now a session appears -> one start event.
+playing = true
+svc.Sample(ctx, 30*time.Second)
+if got := countTopic(bus.topics(), TopicPlaybackStarted); got != 1 {
+t.Fatalf("expected 1 start event, got %d (%v)", got, bus.topics())
+}
+
+// Second sample with the same session must NOT emit another start.
+svc.Sample(ctx, 30*time.Second)
+if got := countTopic(bus.topics(), TopicPlaybackStarted); got != 1 {
+t.Fatalf("expected still 1 start event after continuity, got %d", got)
+}
+
+// Stop playing; one tick later it's within grace -> no stop yet.
+playing = false
+svc.Sample(ctx, 30*time.Second)
+if got := countTopic(bus.topics(), TopicPlaybackStopped); got != 0 {
+t.Fatalf("one-tick disappearance must not emit a stop, got %d", got)
+}
+}
+
+func TestFirstSampleSuppressesStartEvents(t *testing.T) {
+conn := plexConn("c1", "Plex")
+svc, _, bus := newSvc(t, conn)
+ctx := context.Background()
+
+svc.fetch = func(_ context.Context, c *connect.Connection) ([]connect.Session, error) {
+return []connect.Session{{SessionKey: "1", MediaID: "m1", User: "alice",
+	MediaType: "movie", FullTitle: "Movie A", State: "playing", DurationMs: 600000}}, nil
+}
+
+// The baseline sample after startup must not emit a start event for a stream
+// that was already running before Loom started (avoids restart spam).
+svc.Sample(ctx, 30*time.Second)
+if got := countTopic(bus.topics(), TopicPlaybackStarted); got != 0 {
+t.Fatalf("baseline sample must suppress start events, got %d (%v)", got, bus.topics())
+}
+}
+
+func TestPersistConnectionReturnsStartAndStopEvents(t *testing.T) {
+conn := plexConn("c1", "Plex")
+svc, _, _ := newSvc(t, conn)
+ctx := context.Background()
+grace := 60 * time.Second
+t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+sess := connect.Session{SessionKey: "1", MediaID: "m1", User: "alice", MediaType: "movie",
+FullTitle: "Movie A", State: "playing", DurationMs: 600000}
+
+// New row -> exactly one start event returned.
+_, evs := svc.persistConnection(ctx, conn, []connect.Session{sess}, t0, grace, false)
+if countTopic(topicsOf(evs), TopicPlaybackStarted) != 1 || len(evs) != 1 {
+t.Fatalf("expected 1 start event, got %v", topicsOf(evs))
+}
+
+// Suppressed baseline -> no start event for the same continuing session.
+_, evs = svc.persistConnection(ctx, conn, []connect.Session{sess}, t0.Add(30*time.Second), grace, true)
+if len(evs) != 0 {
+t.Fatalf("continuing session must not emit events, got %v", topicsOf(evs))
+}
+
+// Session gone past grace -> exactly one stop event returned.
+_, evs = svc.persistConnection(ctx, conn, nil, t0.Add(2*grace+time.Second), grace, false)
+if countTopic(topicsOf(evs), TopicPlaybackStopped) != 1 || len(evs) != 1 {
+t.Fatalf("expected 1 stop event after grace, got %v", topicsOf(evs))
+}
+}
+
+func TestStartupReapEmitsNoEvents(t *testing.T) {
+conn := plexConn("c1", "Plex")
+svc, _, bus := newSvc(t, conn)
+ctx := context.Background()
+sess := connect.Session{SessionKey: "1", MediaID: "m1", State: "playing", DurationMs: 600000}
+svc.persistConnection(ctx, conn, []connect.Session{sess}, time.Now().UTC(), 60*time.Second, false)
+
+svc.ResetOrphans(ctx)
+
+if len(bus.topics()) != 0 {
+t.Fatalf("startup reap must not publish events, got %v", bus.topics())
+}
+}
+
+func TestStickyTranscodeCounts(t *testing.T) {
+svc, _, _ := newSvc(t)
+conn := plexConn("c1", "Plex")
+ctx := context.Background()
+grace := 60 * time.Second
+t0 := time.Date(2026, 6, 4, 20, 0, 0, 0, time.UTC)
+
+// First sample: transcoding. Second sample: direct-play. The play must still
+// count as a transcode (sticky) and the bitrate must be retained.
+transcoding := connect.Session{SessionKey: "1", MediaID: "m1", User: "alice", MediaType: "movie",
+FullTitle: "Movie A", State: "playing", DurationMs: 600000, Transcode: true, BitrateKbps: 8000}
+direct := transcoding
+direct.Transcode = false
+direct.BitrateKbps = 0
+
+svc.persistConnection(ctx, conn, []connect.Session{transcoding}, t0, grace, false)
+svc.persistConnection(ctx, conn, []connect.Session{direct}, t0.Add(90*time.Second), grace, false)
+
+stats, err := svc.Stats(ctx, 30)
+if err != nil {
+t.Fatalf("stats: %v", err)
+}
+if stats.Totals.TranscodePlays != 1 || stats.Totals.DirectPlays != 0 {
+t.Fatalf("expected sticky transcode (1 transcode, 0 direct), got %+v", stats.Totals)
+}
+if stats.Totals.AvgBitrateKbps != 8000 {
+t.Fatalf("expected retained 8000 kbps avg, got %d", stats.Totals.AvgBitrateKbps)
+}
 }

--- a/internal/analytics/store.go
+++ b/internal/analytics/store.go
@@ -28,7 +28,7 @@ func (s *Store) OpenRowsForConn(ctx context.Context, connID string) ([]HistoryRe
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, connection_id, provider, session_key, media_id, user, media_type,
 		       title, grandparent_title, full_title, device, transcode,
-		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms
+		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms, bitrate_kbps
 		FROM play_history
 		WHERE connection_id = ? AND ended_at IS NULL`, connID)
 	if err != nil {
@@ -43,7 +43,7 @@ func (s *Store) OpenRowsForConn(ctx context.Context, connID string) ([]HistoryRe
 		var transcode int
 		if err := rows.Scan(&r.ID, &r.ConnectionID, &r.Provider, &r.SessionKey, &r.MediaID,
 			&r.User, &r.MediaType, &r.Title, &r.GrandparentTitle, &r.FullTitle, &r.Device, &transcode,
-			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs); err != nil {
+			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs, &r.BitrateKbps); err != nil {
 			return nil, fmt.Errorf("scan open row: %w", err)
 		}
 		r.Transcode = transcode != 0
@@ -64,44 +64,52 @@ func (s *Store) InsertOpen(ctx context.Context, r HistoryRecord) error {
 		INSERT INTO play_history
 		(id, connection_id, provider, session_key, media_id, user, media_type,
 		 title, grandparent_title, full_title, device, transcode,
-		 started_at, last_seen_at, last_position_ms, duration_ms, watched_ms)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		 started_at, last_seen_at, last_position_ms, duration_ms, watched_ms, bitrate_kbps)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		r.ID, r.ConnectionID, r.Provider, r.SessionKey, r.MediaID, r.User, r.MediaType,
 		r.Title, r.GrandparentTitle, r.FullTitle, r.Device, transcode,
 		r.StartedAt.UTC().Format(tsLayout), r.LastSeenAt.UTC().Format(tsLayout),
-		r.LastPositionMs, r.DurationMs, r.WatchedMs)
+		r.LastPositionMs, r.DurationMs, r.WatchedMs, r.BitrateKbps)
 	if err != nil {
 		return fmt.Errorf("insert open: %w", err)
 	}
 	return nil
 }
 
-// UpdateOpen advances an open row with the latest sample.
-func (s *Store) UpdateOpen(ctx context.Context, id string, lastSeen time.Time, positionMs, watchedMs int64, transcode bool) error {
+// UpdateOpen advances an open row with the latest sample. The transcode flag is
+// sticky: once a session is observed transcoding it stays marked, so a session
+// that switches modes still counts as a transcode play. Bitrate is recorded
+// only when the sample reports a non-zero value (direct play often reports 0).
+func (s *Store) UpdateOpen(ctx context.Context, id string, lastSeen time.Time, positionMs, watchedMs int64, transcode bool, bitrateKbps int64) error {
 	t := 0
 	if transcode {
 		t = 1
 	}
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE play_history
-		SET last_seen_at = ?, last_position_ms = ?, watched_ms = ?, transcode = ?
+		SET last_seen_at = ?, last_position_ms = ?, watched_ms = ?,
+		    transcode = CASE WHEN ? = 1 THEN 1 ELSE transcode END,
+		    bitrate_kbps = CASE WHEN ? > 0 THEN ? ELSE bitrate_kbps END
 		WHERE id = ?`,
-		lastSeen.UTC().Format(tsLayout), positionMs, watchedMs, t, id)
+		lastSeen.UTC().Format(tsLayout), positionMs, watchedMs, t, bitrateKbps, bitrateKbps, id)
 	if err != nil {
 		return fmt.Errorf("update open: %w", err)
 	}
 	return nil
 }
 
-// Close finalises an open row, setting ended_at and a reason.
-func (s *Store) Close(ctx context.Context, id string, endedAt time.Time, reason string) error {
-	_, err := s.db.ExecContext(ctx, `
+// Close finalises an open row, setting ended_at and a reason. It returns true
+// when a row was actually closed (so callers only emit a stop event for genuine
+// transitions, never for a no-op close).
+func (s *Store) Close(ctx context.Context, id string, endedAt time.Time, reason string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
 		UPDATE play_history SET ended_at = ?, end_reason = ? WHERE id = ? AND ended_at IS NULL`,
 		endedAt.UTC().Format(tsLayout), reason, id)
 	if err != nil {
-		return fmt.Errorf("close row: %w", err)
+		return false, fmt.Errorf("close row: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // CloseAllOpen finalises every open row (used on startup to clear orphans).
@@ -126,7 +134,7 @@ func (s *Store) ListHistory(ctx context.Context, f HistoryFilter) ([]HistoryReco
 	query := `
 		SELECT id, connection_id, provider, session_key, media_id, user, media_type,
 		       title, grandparent_title, full_title, device, transcode,
-		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms, ended_at
+		       started_at, last_seen_at, last_position_ms, duration_ms, watched_ms, bitrate_kbps, ended_at
 		FROM play_history`
 	args := []any{}
 	if f.User != "" {
@@ -150,7 +158,7 @@ func (s *Store) ListHistory(ctx context.Context, f HistoryFilter) ([]HistoryReco
 		var transcode int
 		if err := rows.Scan(&r.ID, &r.ConnectionID, &r.Provider, &r.SessionKey, &r.MediaID,
 			&r.User, &r.MediaType, &r.Title, &r.GrandparentTitle, &r.FullTitle, &r.Device, &transcode,
-			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs, &ended); err != nil {
+			&started, &lastSeen, &r.LastPositionMs, &r.DurationMs, &r.WatchedMs, &r.BitrateKbps, &ended); err != nil {
 			return nil, fmt.Errorf("scan history: %w", err)
 		}
 		r.Transcode = transcode != 0
@@ -174,9 +182,15 @@ func (s *Store) Stats(ctx context.Context, since time.Time, windowDays int, minW
 
 	// Totals.
 	row := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*), COUNT(DISTINCT user), COALESCE(SUM(watched_ms),0)
-		FROM play_history WHERE started_at >= ? AND watched_ms >= ?`, sinceStr, minWatchedMs)
-	if err := row.Scan(&st.Totals.Plays, &st.Totals.UniqueUsers, &st.Totals.WatchedMs); err != nil {
+		SELECT COUNT(*), COUNT(DISTINCT user), COALESCE(SUM(watched_ms),0),
+		       COALESCE(SUM(CASE WHEN transcode = 1 THEN 1 ELSE 0 END),0),
+		       COALESCE(SUM(CASE WHEN transcode = 0 THEN 1 ELSE 0 END),0),
+		       COALESCE((SELECT CAST(AVG(bitrate_kbps) AS INTEGER) FROM play_history
+		                 WHERE started_at >= ? AND watched_ms >= ? AND bitrate_kbps > 0),0)
+		FROM play_history WHERE started_at >= ? AND watched_ms >= ?`,
+		sinceStr, minWatchedMs, sinceStr, minWatchedMs)
+	if err := row.Scan(&st.Totals.Plays, &st.Totals.UniqueUsers, &st.Totals.WatchedMs,
+		&st.Totals.TranscodePlays, &st.Totals.DirectPlays, &st.Totals.AvgBitrateKbps); err != nil {
 		return nil, fmt.Errorf("stats totals: %w", err)
 	}
 

--- a/internal/analytics/types.go
+++ b/internal/analytics/types.go
@@ -29,6 +29,7 @@ type HistoryRecord struct {
 	LastPositionMs   int64      `json:"last_position_ms"`
 	DurationMs       int64      `json:"duration_ms"`
 	WatchedMs        int64      `json:"watched_ms"`
+	BitrateKbps      int64      `json:"bitrate_kbps"`
 	EndedAt          *time.Time `json:"ended_at,omitempty"`
 }
 
@@ -49,9 +50,12 @@ type HistoryFilter struct {
 
 // Totals summarises activity over a window.
 type Totals struct {
-	Plays       int   `json:"plays"`
-	UniqueUsers int   `json:"unique_users"`
-	WatchedMs   int64 `json:"watched_ms"`
+	Plays          int   `json:"plays"`
+	UniqueUsers    int   `json:"unique_users"`
+	WatchedMs      int64 `json:"watched_ms"`
+	TranscodePlays int   `json:"transcode_plays"`
+	DirectPlays    int   `json:"direct_plays"`
+	AvgBitrateKbps int64 `json:"avg_bitrate_kbps"` // average reported session bitrate (>0 only)
 }
 
 // UserStat is per-user aggregate activity.

--- a/internal/connect/sessions.go
+++ b/internal/connect/sessions.go
@@ -56,6 +56,12 @@ type plexSession struct {
 	Index            int    `json:"index"`
 	ViewOffset       int64  `json:"viewOffset"`
 	Duration         int64  `json:"duration"`
+	Media            []struct {
+		Bitrate int64 `json:"bitrate"`
+	} `json:"Media"`
+	Session *struct {
+		Bandwidth int64 `json:"bandwidth"`
+	} `json:"Session"`
 	User             struct {
 		Title string `json:"title"`
 	} `json:"User"`
@@ -105,6 +111,14 @@ func (p *plexProvider) ActiveSessions(ctx context.Context, s ProviderSettings) (
 		if m.Player.State == "paused" {
 			state = "paused"
 		}
+		// Prefer the live streaming bandwidth Plex reports for the session;
+		// fall back to the source media bitrate.
+		var bitrate int64
+		if m.Session != nil && m.Session.Bandwidth > 0 {
+			bitrate = m.Session.Bandwidth
+		} else if len(m.Media) > 0 {
+			bitrate = m.Media[0].Bitrate
+		}
 		out = append(out, Session{
 			SessionKey:       m.SessionKey,
 			MediaID:          m.RatingKey,
@@ -118,6 +132,7 @@ func (p *plexProvider) ActiveSessions(ctx context.Context, s ProviderSettings) (
 			PositionMs:       m.ViewOffset,
 			DurationMs:       m.Duration,
 			Transcode:        m.TranscodeSession != nil,
+			BitrateKbps:      bitrate,
 		})
 	}
 	return out, nil
@@ -143,6 +158,9 @@ type embySession struct {
 		IsPaused      bool   `json:"IsPaused"`
 		PlayMethod    string `json:"PlayMethod"`
 	} `json:"PlayState"`
+	TranscodingInfo *struct {
+		Bitrate int64 `json:"Bitrate"` // bits per second
+	} `json:"TranscodingInfo"`
 }
 
 // ticksToMs converts .NET 100ns ticks to milliseconds.
@@ -176,6 +194,11 @@ func parseEmbySessions(body []byte) ([]Session, error) {
 			transcode = strings.EqualFold(s.PlayState.PlayMethod, "Transcode")
 			pos = ticksToMs(s.PlayState.PositionTicks)
 		}
+		// Emby/Jellyfin only report a bitrate while transcoding (bits/sec).
+		var bitrate int64
+		if s.TranscodingInfo != nil && s.TranscodingInfo.Bitrate > 0 {
+			bitrate = s.TranscodingInfo.Bitrate / 1000
+		}
 		out = append(out, Session{
 			SessionKey:       s.ID,
 			MediaID:          item.ID,
@@ -189,6 +212,7 @@ func parseEmbySessions(body []byte) ([]Session, error) {
 			PositionMs:       pos,
 			DurationMs:       ticksToMs(item.RunTimeTicks),
 			Transcode:        transcode,
+			BitrateKbps:      bitrate,
 		})
 	}
 	return out, nil

--- a/internal/connect/types.go
+++ b/internal/connect/types.go
@@ -96,4 +96,5 @@ type Session struct {
 	PositionMs       int64        `json:"position_ms"`
 	DurationMs       int64        `json:"duration_ms"`
 	Transcode        bool         `json:"transcode"`
+	BitrateKbps      int64        `json:"bitrate_kbps"` // streaming bitrate in kbps, 0 if unknown
 }

--- a/internal/notifications/dispatcher.go
+++ b/internal/notifications/dispatcher.go
@@ -19,6 +19,8 @@ const (
 	topicDownloadFailed    = "downloads.failed"
 	topicImportCompleted   = "imports.completed"
 	topicImportFailed      = "imports.failed"
+	topicPlaybackStarted   = "analytics.playback.started"
+	topicPlaybackStopped   = "analytics.playback.stopped"
 )
 
 // topicEventMap maps event bus topics to notification EventTypes.
@@ -29,6 +31,8 @@ var topicEventMap = map[string]EventType{
 	topicDownloadFailed:    EventOnHealthIssue,
 	topicImportCompleted:   EventOnDownload,
 	topicImportFailed:      EventOnHealthIssue,
+	topicPlaybackStarted:   EventOnPlayback,
+	topicPlaybackStopped:   EventOnPlayback,
 }
 
 const (
@@ -275,6 +279,17 @@ func formatEvent(eventType EventType, ev eventbus.Event) Notification {
 	case topicImportFailed:
 		title = "Import Failed"
 		message = fmt.Sprintf("Failed to import %s: %s", dataStr(data, "title"), dataStr(data, "error"))
+
+	case topicPlaybackStarted:
+		title = "Playback Started"
+		message = fmt.Sprintf("%s started watching %s", dataStr(data, "user"), dataStr(data, "title"))
+		if d := dataStr(data, "server"); d != "(unknown)" {
+			message += fmt.Sprintf(" on %s", d)
+		}
+
+	case topicPlaybackStopped:
+		title = "Playback Stopped"
+		message = fmt.Sprintf("%s stopped watching %s", dataStr(data, "user"), dataStr(data, "title"))
 
 	default:
 		title = "Loom Event"

--- a/internal/notifications/handlers.go
+++ b/internal/notifications/handlers.go
@@ -93,6 +93,7 @@ func createConnection(svc Service) http.HandlerFunc {
 			OnDelete:            req.OnDelete,
 			OnHealthIssue:       req.OnHealthIssue,
 			OnApplicationUpdate: req.OnApplicationUpdate,
+			OnPlayback:          req.OnPlayback,
 			Tags:                req.Tags,
 		}
 
@@ -172,6 +173,9 @@ func updateConnection(svc Service) http.HandlerFunc {
 		}
 		if req.OnApplicationUpdate != nil {
 			existing.OnApplicationUpdate = *req.OnApplicationUpdate
+		}
+		if req.OnPlayback != nil {
+			existing.OnPlayback = *req.OnPlayback
 		}
 		if req.Tags != nil {
 			existing.Tags = req.Tags

--- a/internal/notifications/service.go
+++ b/internal/notifications/service.go
@@ -39,7 +39,7 @@ func (s *service) ListConnections(ctx context.Context) ([]*Connection, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, name, type, enabled, settings,
 		       on_grab, on_download, on_upgrade, on_rename, on_delete,
-		       on_health_issue, on_application_update, tags, created_at, updated_at
+		       on_health_issue, on_application_update, on_playback, tags, created_at, updated_at
 		FROM notification_connections ORDER BY name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("list connections: %w", err)
@@ -61,7 +61,7 @@ func (s *service) GetConnection(ctx context.Context, id string) (*Connection, er
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, name, type, enabled, settings,
 		       on_grab, on_download, on_upgrade, on_rename, on_delete,
-		       on_health_issue, on_application_update, tags, created_at, updated_at
+		       on_health_issue, on_application_update, on_playback, tags, created_at, updated_at
 		FROM notification_connections WHERE id = ?`, id)
 
 	c, err := scanConnectionRow(row)
@@ -94,11 +94,11 @@ func (s *service) CreateConnection(ctx context.Context, c *Connection) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO notification_connections
 		(id, name, type, enabled, settings, on_grab, on_download, on_upgrade,
-		 on_rename, on_delete, on_health_issue, on_application_update, tags, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 on_rename, on_delete, on_health_issue, on_application_update, on_playback, tags, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		c.ID, c.Name, string(c.Type), c.Enabled, string(settingsJSON),
 		c.OnGrab, c.OnDownload, c.OnUpgrade, c.OnRename, c.OnDelete,
-		c.OnHealthIssue, c.OnApplicationUpdate, string(tagsJSON),
+		c.OnHealthIssue, c.OnApplicationUpdate, c.OnPlayback, string(tagsJSON),
 		c.CreatedAt.Format(time.RFC3339), c.UpdatedAt.Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("create connection: %w", err)
@@ -122,12 +122,12 @@ func (s *service) UpdateConnection(ctx context.Context, c *Connection) error {
 		UPDATE notification_connections
 		SET name = ?, type = ?, enabled = ?, settings = ?,
 		    on_grab = ?, on_download = ?, on_upgrade = ?, on_rename = ?,
-		    on_delete = ?, on_health_issue = ?, on_application_update = ?,
+		    on_delete = ?, on_health_issue = ?, on_application_update = ?, on_playback = ?,
 		    tags = ?, updated_at = ?
 		WHERE id = ?`,
 		c.Name, string(c.Type), c.Enabled, string(settingsJSON),
 		c.OnGrab, c.OnDownload, c.OnUpgrade, c.OnRename,
-		c.OnDelete, c.OnHealthIssue, c.OnApplicationUpdate,
+		c.OnDelete, c.OnHealthIssue, c.OnApplicationUpdate, c.OnPlayback,
 		string(tagsJSON), c.UpdatedAt.Format(time.RFC3339), c.ID)
 	if err != nil {
 		return fmt.Errorf("update connection: %w", err)
@@ -284,7 +284,7 @@ func scanConnection(rows *sql.Rows) (*Connection, error) {
 	var createdAt, updatedAt string
 	if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Enabled, &c.Settings,
 		&c.OnGrab, &c.OnDownload, &c.OnUpgrade, &c.OnRename, &c.OnDelete,
-		&c.OnHealthIssue, &c.OnApplicationUpdate, &c.Tags, &createdAt, &updatedAt); err != nil {
+		&c.OnHealthIssue, &c.OnApplicationUpdate, &c.OnPlayback, &c.Tags, &createdAt, &updatedAt); err != nil {
 		return nil, fmt.Errorf("scan connection: %w", err)
 	}
 	c.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
@@ -298,7 +298,7 @@ func scanConnectionRow(row *sql.Row) (*Connection, error) {
 	var createdAt, updatedAt string
 	if err := row.Scan(&c.ID, &c.Name, &c.Type, &c.Enabled, &c.Settings,
 		&c.OnGrab, &c.OnDownload, &c.OnUpgrade, &c.OnRename, &c.OnDelete,
-		&c.OnHealthIssue, &c.OnApplicationUpdate, &c.Tags, &createdAt, &updatedAt); err != nil {
+		&c.OnHealthIssue, &c.OnApplicationUpdate, &c.OnPlayback, &c.Tags, &createdAt, &updatedAt); err != nil {
 		return nil, err
 	}
 	c.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)

--- a/internal/notifications/templates.go
+++ b/internal/notifications/templates.go
@@ -26,6 +26,7 @@ var defaultTemplates = map[EventType]string{
 	EventOnDelete:            "Deleted: {{.Title}} ({{.Year}})",
 	EventOnHealthIssue:       "Health issue: {{.Title}}",
 	EventOnApplicationUpdate: "Application updated: {{.Title}}",
+	EventOnPlayback:          "Playback: {{.Title}}",
 	EventOnTest:              "Test notification: {{.Title}}",
 }
 

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -32,6 +32,7 @@ const (
 	EventOnDelete            EventType = "on_delete"
 	EventOnHealthIssue       EventType = "on_health_issue"
 	EventOnApplicationUpdate EventType = "on_application_update"
+	EventOnPlayback          EventType = "on_playback"
 	EventOnTest              EventType = "on_test"
 )
 
@@ -49,6 +50,7 @@ type Connection struct {
 	OnDelete            bool             `json:"on_delete"`
 	OnHealthIssue       bool             `json:"on_health_issue"`
 	OnApplicationUpdate bool             `json:"on_application_update"`
+	OnPlayback          bool             `json:"on_playback"`
 	Tags                StringSlice      `json:"tags"`
 	CreatedAt           time.Time        `json:"created_at"`
 	UpdatedAt           time.Time        `json:"updated_at"`
@@ -71,6 +73,8 @@ func (c *Connection) SubscribesTo(event EventType) bool {
 		return c.OnHealthIssue
 	case EventOnApplicationUpdate:
 		return c.OnApplicationUpdate
+	case EventOnPlayback:
+		return c.OnPlayback
 	default:
 		return false
 	}
@@ -176,6 +180,7 @@ type CreateConnectionRequest struct {
 	OnDelete            bool               `json:"on_delete"`
 	OnHealthIssue       bool               `json:"on_health_issue"`
 	OnApplicationUpdate bool               `json:"on_application_update"`
+	OnPlayback          bool               `json:"on_playback"`
 	Tags                []string           `json:"tags,omitempty"`
 }
 
@@ -192,5 +197,6 @@ type UpdateConnectionRequest struct {
 	OnDelete            *bool               `json:"on_delete,omitempty"`
 	OnHealthIssue       *bool               `json:"on_health_issue,omitempty"`
 	OnApplicationUpdate *bool               `json:"on_application_update,omitempty"`
+	OnPlayback          *bool               `json:"on_playback,omitempty"`
 	Tags                []string            `json:"tags,omitempty"`
 }

--- a/internal/storage/migrations/sqlite/0065_play_history_bitrate.sql
+++ b/internal/storage/migrations/sqlite/0065_play_history_bitrate.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE play_history ADD COLUMN bitrate_kbps INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE play_history DROP COLUMN bitrate_kbps;
+-- +goose StatementEnd

--- a/internal/storage/migrations/sqlite/0066_notification_on_playback.sql
+++ b/internal/storage/migrations/sqlite/0066_notification_on_playback.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE notification_connections ADD COLUMN on_playback INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE notification_connections DROP COLUMN on_playback;
+-- +goose StatementEnd

--- a/web/src/lib/analytics-api.ts
+++ b/web/src/lib/analytics-api.ts
@@ -19,6 +19,7 @@ export interface LiveStream {
   position_ms: number;
   duration_ms: number;
   transcode: boolean;
+  bitrate_kbps: number;
   progress: number; // 0..100
 }
 
@@ -35,6 +36,7 @@ export interface HistoryRecord {
   last_seen_at: string;
   duration_ms: number;
   watched_ms: number;
+  bitrate_kbps: number;
   ended_at?: string;
 }
 
@@ -59,7 +61,14 @@ export interface DayCount {
 
 export interface AnalyticsStats {
   window_days: number;
-  totals: { plays: number; unique_users: number; watched_ms: number };
+  totals: {
+    plays: number;
+    unique_users: number;
+    watched_ms: number;
+    transcode_plays: number;
+    direct_plays: number;
+    avg_bitrate_kbps: number;
+  };
   top_users: UserStat[];
   top_media: MediaStat[];
   least_media: MediaStat[];
@@ -108,4 +117,11 @@ export function formatWatched(ms: number): string {
   const h = Math.floor(totalMin / 60);
   const m = totalMin % 60;
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+// formatBitrate renders a kbps value as Mbps/kbps; 0 means "unknown".
+export function formatBitrate(kbps: number): string {
+  if (!kbps || kbps <= 0) return "—";
+  if (kbps >= 1000) return `${(kbps / 1000).toFixed(1)} Mbps`;
+  return `${Math.round(kbps)} kbps`;
 }

--- a/web/src/lib/notifications-api.ts
+++ b/web/src/lib/notifications-api.ts
@@ -48,6 +48,7 @@ export interface NotificationConnection {
   on_delete: boolean;
   on_health_issue: boolean;
   on_application_update: boolean;
+  on_playback: boolean;
   tags: string[];
   created_at: string;
   updated_at: string;
@@ -65,6 +66,7 @@ export interface CreateConnectionRequest {
   on_delete?: boolean;
   on_health_issue?: boolean;
   on_application_update?: boolean;
+  on_playback?: boolean;
   tags?: string[];
 }
 
@@ -80,6 +82,7 @@ export interface UpdateConnectionRequest {
   on_delete?: boolean;
   on_health_issue?: boolean;
   on_application_update?: boolean;
+  on_playback?: boolean;
   tags?: string[];
 }
 
@@ -357,6 +360,7 @@ export const EVENT_TYPES = [
   { key: "on_delete" as const, label: "On Delete" },
   { key: "on_health_issue" as const, label: "On Health Issue" },
   { key: "on_application_update" as const, label: "On App Update" },
+  { key: "on_playback" as const, label: "On Playback" },
 ];
 
 export const TEMPLATE_VARIABLES = [

--- a/web/src/pages/analytics.tsx
+++ b/web/src/pages/analytics.tsx
@@ -6,6 +6,7 @@ import {
   useAnalyticsStats,
   useAnalyticsHistory,
   formatWatched,
+  formatBitrate,
   type MediaStat,
   type UserStat,
 } from "@/lib/analytics-api";
@@ -77,6 +78,7 @@ function MediaTypeIcon({ type }: { type: string }) {
 
 function ActiveStreams() {
   const { data: streams, isLoading } = useActiveStreams();
+  const totalBandwidth = (streams ?? []).reduce((sum, s) => sum + (s.bitrate_kbps || 0), 0);
 
   return (
     <Card>
@@ -85,6 +87,11 @@ function ActiveStreams() {
           <Activity className="h-4 w-4" /> Active streams
           {streams && streams.length > 0 && (
             <Badge variant="secondary">{streams.length}</Badge>
+          )}
+          {totalBandwidth > 0 && (
+            <Badge variant="outline" className="ml-auto gap-1 font-normal">
+              <Zap className="h-3 w-3" /> {formatBitrate(totalBandwidth)} total
+            </Badge>
           )}
         </CardTitle>
         <CardDescription>Live playback across your media servers.</CardDescription>
@@ -115,6 +122,7 @@ function ActiveStreams() {
                       {s.user || "Unknown"}
                       {s.device ? ` · ${s.device}` : ""}
                       {` · ${s.connection_name}`}
+                      {s.bitrate_kbps > 0 ? ` · ${formatBitrate(s.bitrate_kbps)}` : ""}
                     </p>
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
@@ -268,6 +276,21 @@ export function AnalyticsPage() {
           icon={<Clock className="h-5 w-5" />}
           label="Watch time"
           value={s ? formatWatched(s.totals.watched_ms) : "—"}
+        />
+        <StatCard
+          icon={<Zap className="h-5 w-5" />}
+          label="Transcoded plays"
+          value={s ? String(s.totals.transcode_plays) : "—"}
+        />
+        <StatCard
+          icon={<MonitorPlay className="h-5 w-5" />}
+          label="Direct plays"
+          value={s ? String(s.totals.direct_plays) : "—"}
+        />
+        <StatCard
+          icon={<Activity className="h-5 w-5" />}
+          label="Avg session bitrate"
+          value={s ? formatBitrate(s.totals.avg_bitrate_kbps) : "—"}
         />
       </div>
 

--- a/web/src/pages/dashboard.tsx
+++ b/web/src/pages/dashboard.tsx
@@ -17,6 +17,14 @@ import {
   useDashboardActivity,
 } from "@/lib/dashboard-api";
 import { useSetPageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
+import { useFeatureEnabled } from "@/lib/features-api";
+import {
+  useActiveStreams,
+  useAnalyticsStats,
+  formatWatched,
+  formatBitrate,
+} from "@/lib/analytics-api";
 import { Link } from "@tanstack/react-router";
 import { cn, formatBytes, formatSpeed } from "@/lib/utils";
 import {
@@ -34,8 +42,14 @@ import {
   FolderOpen,
   ArrowDown,
   ArrowUp,
+  Activity,
+  MonitorPlay,
+  PlayCircle,
+  PauseCircle,
+  Zap,
   type LucideIcon,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 
 // ---------------------------------------------------------------------------
@@ -458,6 +472,10 @@ export function DashboardPage() {
   const dlClients = useDashboardDownloadClients();
   useSetPageHeader("Dashboard");
 
+  const { user } = useAuth();
+  const analyticsEnabled = useFeatureEnabled("media_analytics");
+  const showAnalytics = analyticsEnabled && user?.role === "admin";
+
   const movieCount = movies.data?.total ?? 0;
   const seriesCount = series.data?.total ?? 0;
   const indexerCount = indexers.data?.indexers?.length ?? 0;
@@ -519,6 +537,93 @@ export function DashboardPage() {
         <StorageCard />
         <ActiveDownloadsCard />
       </div>
+
+      {/* Row 4: Media-server analytics (admin + feature flag) */}
+      {showAnalytics && <DashboardAnalyticsRow />}
+    </div>
+  );
+}
+
+function DashboardAnalyticsRow() {
+  const { data: streams } = useActiveStreams();
+  const { data: stats } = useAnalyticsStats(7);
+  const totalBandwidth = (streams ?? []).reduce((sum, s) => sum + (s.bitrate_kbps || 0), 0);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Activity className="h-4 w-4 text-accent" /> Active streams
+            {streams && streams.length > 0 && (
+              <Badge variant="secondary">{streams.length}</Badge>
+            )}
+            {totalBandwidth > 0 && (
+              <Badge variant="outline" className="ml-auto gap-1 font-normal">
+                <Zap className="h-3 w-3" /> {formatBitrate(totalBandwidth)}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!streams || streams.length === 0 ? (
+            <p className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+              <MonitorPlay className="h-4 w-4" /> Nothing playing right now.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {streams.slice(0, 5).map((s) => (
+                <div
+                  key={`${s.connection_id}-${s.session_key}-${s.media_id}`}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  {s.state === "paused" ? (
+                    <PauseCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <PlayCircle className="h-4 w-4 shrink-0 text-accent" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">{s.full_title || s.title}</span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {s.user || "Unknown"}
+                  </span>
+                  {s.transcode && <Zap className="h-3 w-3 shrink-0 text-amber-400" />}
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 border-t pt-3 text-right">
+            <Link to="/analytics" className="text-xs text-accent hover:underline">
+              View analytics →
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Last 7 days</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-3 gap-3">
+          <MiniStat label="Plays" value={stats ? String(stats.totals.plays) : "—"} />
+          <MiniStat
+            label="Viewers"
+            value={stats ? String(stats.totals.unique_users) : "—"}
+          />
+          <MiniStat
+            label="Watch time"
+            value={stats ? formatWatched(stats.totals.watched_ms) : "—"}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function MiniStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border bg-card/50 p-3">
+      <p className="text-xl font-semibold leading-none">{value}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{label}</p>
     </div>
   );
 }

--- a/web/src/pages/notifications.tsx
+++ b/web/src/pages/notifications.tsx
@@ -88,6 +88,7 @@ interface FormState {
   on_delete: boolean;
   on_health_issue: boolean;
   on_application_update: boolean;
+  on_playback: boolean;
 }
 
 function defaultForm(): FormState {
@@ -103,6 +104,7 @@ function defaultForm(): FormState {
     on_delete: false,
     on_health_issue: true,
     on_application_update: false,
+    on_playback: false,
   };
 }
 
@@ -119,6 +121,7 @@ function formFromConnection(c: NotificationConnection): FormState {
     on_delete: c.on_delete,
     on_health_issue: c.on_health_issue,
     on_application_update: c.on_application_update,
+    on_playback: c.on_playback,
   };
 }
 
@@ -517,6 +520,7 @@ export function NotificationsPage() {
       on_delete: form.on_delete,
       on_health_issue: form.on_health_issue,
       on_application_update: form.on_application_update,
+      on_playback: form.on_playback,
     };
   }
 
@@ -559,6 +563,7 @@ export function NotificationsPage() {
         on_delete: form.on_delete,
         on_health_issue: form.on_health_issue,
         on_application_update: form.on_application_update,
+        on_playback: form.on_playback,
       };
       await update.mutateAsync({ id: original.id, body });
       toast.success(`Notification "${form.name}" updated.`);


### PR DESCRIPTION
Finishes the three remaining checklist items on #15 (Tautulli-style media-server analytics).

## What's new
- **Bandwidth & transcoding stats** — parse session bitrate from Plex/Emby/Jellyfin (`connect`), persist `bitrate_kbps` (migration 0065). `UpdateOpen` keeps a sticky transcode flag and the last non-zero bitrate. Stats expose transcode/direct play counts + avg session bitrate. Analytics page shows total bandwidth, per-stream bitrate, and new stat cards.
- **Dashboard widgets** — admin + `media_analytics`-flag-gated analytics row (active streams + 7-day stats) on the dashboard.
- **Activity-based notification triggers** — analytics publishes playback start/stop events on the eventbus after a confirmed recorded state change. New `on_playback` notification toggle (migration 0066) wired end-to-end through notifications service/dispatcher/templates/handlers and the Notifications UI. The first post-startup sample is treated as a baseline and suppresses start events, so a restart never spams "Playback Started" for already-running streams.

## Tests
analytics: start/stop/continuity publishing, baseline suppression, sticky transcode counts, persistConnection event returns, startup reap emits none. Build (CGO=0), vet, analytics/storage tests (CGO=1), and web build all green.

## Notes
Migrations are sqlite-only (deployment uses sqlite), consistent with recent features. Deploy is held pending VPN; live playback-notification verification requires an active media-server stream.