### PR TITLE
feat(plugins): custom post-processing script plugins (#12)

### DIFF
--- a/cmd/loom/serve.go
+++ b/cmd/loom/serve.go
@@ -255,6 +255,10 @@ func cmdServe(ctx context.Context, args []string) error {
 		infra.analyticsPoller.Start(ctx)
 		defer infra.analyticsPoller.Stop()
 	}
+	if infra.pluginRunner != nil {
+		infra.pluginRunner.Start(ctx)
+		defer infra.pluginRunner.Stop()
+	}
 	defer infra.auditSink.Close()
 	defer sysLogBatchWriter.Close()
 

--- a/cmd/loom/wire_infra.go
+++ b/cmd/loom/wire_infra.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ebenderooock/loom/internal/libraries"
 	"github.com/ebenderooock/loom/internal/movies"
 	"github.com/ebenderooock/loom/internal/notifications"
+	"github.com/ebenderooock/loom/internal/plugins"
 	"github.com/ebenderooock/loom/internal/scheduler"
 	"github.com/ebenderooock/loom/internal/server"
 	"github.com/ebenderooock/loom/internal/storage"
@@ -32,6 +33,7 @@ type infraWiring struct {
 	healthMon       *healthmonitor.Monitor
 	auditSink       *auditlog.Sink
 	analyticsPoller *analytics.Poller
+	pluginRunner    *plugins.Runner
 }
 
 // wireInfra constructs infrastructure services (connect, compat shims,
@@ -70,6 +72,17 @@ func wireInfra(
 	// and fans out to all matching notification connections.
 	notifDispatcher := notifications.NewDispatcher(srv.Bus(), media.notifSvc, logger)
 
+	// Plugins — admin-defined custom scripts run on domain events. Gated by an
+	// opt-in feature flag because they execute arbitrary commands.
+	pluginStore := plugins.NewStore(db.DB())
+	pluginRunner := plugins.NewRunner(
+		srv.Bus(),
+		pluginStore,
+		srv.Features().EnabledFunc(featureflags.KeyPlugins),
+		logger,
+	)
+	srv.SetPlugins(pluginStore, pluginRunner)
+
 	// *arr API compatibility shims
 	syncStore := syncprofiles.NewStore(db.DB())
 	srv.SetSyncProfileStore(syncStore)
@@ -105,6 +118,7 @@ func wireInfra(
 		healthMon:       healthMon,
 		auditSink:       auditSink,
 		analyticsPoller: analyticsPoller,
+		pluginRunner:    pluginRunner,
 	}, nil
 }
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,112 @@
+# Plugins (Custom Post-Processing Scripts)
+
+Loom can run **custom scripts** when domain events fire — for example, after a
+download is grabbed, after an import completes, or when playback starts/stops.
+This is Loom's equivalent of the Sonarr/Radarr "Custom Script" connection.
+
+A plugin is simply an executable command that you configure. Loom invokes it as
+a child process, hands it the event payload, captures its output, and records
+the result.
+
+> **Admin only & opt-in.** Plugins execute arbitrary commands, so the feature is
+> gated by the **Plugins (Custom Scripts)** feature flag (disabled by default)
+> and every endpoint requires an admin. Enable it under **Settings → Features**.
+
+## Security & trust model
+
+**Plugins are NOT run in an OS-level sandbox.** A plugin runs as the Loom server
+process user, with that user's privileges and access to the same filesystem,
+network, and (where granted) configuration.
+
+What Loom *does* provide is **failure isolation and resource bounding**:
+
+| Control | Behaviour |
+| --- | --- |
+| Separate process | Each run is a child process; a crash can't take down Loom. |
+| Timeout | Each run has a wall-clock budget (default 30s, max 300s). On expiry the **entire process group** is killed (`SIGKILL`). |
+| No host env | The server environment is **not** inherited, so server secrets aren't leaked. Only a minimal `PATH`, your configured variables, and `LOOM_*` vars are passed. |
+| Output caps | `stdout`/`stderr` are captured up to 64 KiB each; the rest is discarded. |
+| Concurrency cap | Runs execute in a bounded worker pool and never block Loom's event bus. |
+| Panic recovery | A failure in the runner is logged, never propagated. |
+| Run history | Every execution is recorded (success, exit code, duration, output), pruned per-plugin and by age. |
+
+For real isolation, run **Loom itself** under container/Kubernetes controls
+(read-only mounts, dropped capabilities, network policies, a dedicated user).
+
+## How a plugin is invoked
+
+- The command is executed **directly — there is no shell**. Arguments are passed
+  as an argv list (space-separated in the UI). Use an **absolute path** to the
+  executable. If you need shell features, make your command
+  `/bin/sh -c "…"` explicitly.
+- The working directory defaults to `/` (configurable per plugin).
+- The event payload is written to the process **stdin** as a single JSON
+  document, and also exposed via environment variables.
+
+### Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `LOOM_PAYLOAD_VERSION` | Payload schema version (currently `1`). |
+| `LOOM_EVENT` | Event key (e.g. `grab`, `import_complete`). |
+| `LOOM_TOPIC` | Internal bus topic (e.g. `downloads.queued`). |
+| `LOOM_TITLE` | Human-readable title for the event subject. |
+| `LOOM_DATA_JSON` | The `data` object, as a JSON string. |
+| `LOOM_PAYLOAD_JSON` | The full payload, as a JSON string (same as stdin). |
+
+`LOOM_*` keys are reserved — you cannot override them with your own env vars.
+
+### stdin payload (schema v1)
+
+```json
+{
+  "version": 1,
+  "event": "import_complete",
+  "topic": "imports.completed",
+  "title": "The Matrix (1999)",
+  "data": {
+    "title": "The Matrix (1999)",
+    "...": "event-specific fields"
+  },
+  "timestamp": "2026-06-05T11:49:45Z"
+}
+```
+
+The `data` map is populated from the event's structured fields. The exact keys
+depend on the event; `title` is always present when known.
+
+### Exit codes & result
+
+- **Exit `0`** → the run is recorded as **success**.
+- **Any non-zero exit** → recorded as **failure** with the captured exit code.
+- **Timeout** → recorded as failure with exit code `-1` and a "timed out" error.
+
+Loom does not act on a plugin's exit code beyond recording it — a failing plugin
+does not block or revert the underlying import/grab.
+
+## Supported events
+
+| Key | When it fires |
+| --- | --- |
+| `grab` | A release was grabbed and queued to a download client. |
+| `download_complete` | A download finished in the client. |
+| `download_failed` | A download failed. |
+| `import_complete` | A file was imported into the library. |
+| `import_failed` | An import failed. |
+| `playback_started` | A stream started on a connected media server. |
+| `playback_stopped` | A stream stopped. |
+
+## Example plugin
+
+See [`examples/plugins/post-import.sh`](../examples/plugins/post-import.sh) for a
+minimal, dependency-free example that reads the payload from stdin and logs it.
+
+To register it in the UI:
+
+1. **Settings → Features** → enable **Plugins (Custom Scripts)**.
+2. **Settings → Plugins → Add Plugin**.
+   - **Command:** `/scripts/post-import.sh`
+   - **Events:** check *On Import Complete*.
+   - Optionally set **env vars**, a **timeout**, and a **working directory**.
+3. Save, then click **▶ (test)** to run it once with a synthetic payload and
+   inspect the captured output under **History**.

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,29 @@
+# Example Loom plugins
+
+These are minimal, dependency-free example scripts for Loom's
+[Plugins (custom post-processing scripts)](../../docs/plugins.md) feature.
+
+| File | Description |
+| --- | --- |
+| [`post-import.sh`](./post-import.sh) | Logs every event it receives (stdin JSON + `LOOM_*` env vars) to a file and to stdout. |
+
+## Using an example
+
+1. Make the script executable and place it where the Loom server can reach it
+   (for the container deployment, mount it into the pod, e.g. `/scripts`):
+
+   ```sh
+   chmod +x post-import.sh
+   ```
+
+2. In Loom: **Settings → Features** → enable **Plugins (Custom Scripts)**.
+
+3. **Settings → Plugins → Add Plugin**:
+   - **Command:** absolute path to the script, e.g. `/scripts/post-import.sh`
+   - **Events:** choose which events trigger it.
+
+4. Click the **▶ test** button to run it once with a synthetic payload and view
+   the captured output under **History**.
+
+See [`docs/plugins.md`](../../docs/plugins.md) for the full SDK contract and the
+security/trust model.

--- a/examples/plugins/post-import.sh
+++ b/examples/plugins/post-import.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+#
+# Example Loom plugin: logs every event it receives.
+#
+# Loom invokes this script directly (no shell wrapping) when a subscribed event
+# fires. The event payload arrives two ways:
+#   1. As a JSON document on stdin.
+#   2. As LOOM_* environment variables (see docs/plugins.md).
+#
+# Exit 0 for success; any non-zero exit is recorded as a failed run.
+#
+# Register it under Settings -> Plugins with command: /scripts/post-import.sh
+# (after enabling the "Plugins (Custom Scripts)" feature flag).
+
+set -eu
+
+LOG="${LOOM_PLUGIN_LOG:-/tmp/loom-plugin.log}"
+
+# Read the full JSON payload from stdin.
+payload="$(cat)"
+
+{
+  echo "----- $(date -u '+%Y-%m-%dT%H:%M:%SZ') -----"
+  echo "event:  ${LOOM_EVENT:-?}"
+  echo "topic:  ${LOOM_TOPIC:-?}"
+  echo "title:  ${LOOM_TITLE:-?}"
+  echo "payload: ${payload}"
+} >> "$LOG"
+
+# Also echo to stdout so it shows up in the plugin run history.
+echo "handled ${LOOM_EVENT:-unknown} for '${LOOM_TITLE:-unknown}'"
+
+# If you have `jq` available you could pull individual fields, e.g.:
+#   media_title="$(printf '%s' "$payload" | jq -r '.data.title // empty')"
+
+exit 0

--- a/internal/featureflags/types.go
+++ b/internal/featureflags/types.go
@@ -16,6 +16,12 @@ const (
 	// the poller stops collecting new play history; existing history and the
 	// reports remain readable.
 	KeyMediaAnalytics = "media_analytics"
+
+	// KeyPlugins toggles custom post-processing plugins (scripts run on events).
+	// Disabled by default because plugins execute arbitrary commands as the
+	// server process; an admin must opt in. When disabled the runner does not
+	// execute any plugin, though definitions and history remain manageable.
+	KeyPlugins = "plugins"
 )
 
 // FlagDef is the static, in-code definition of a feature toggle.
@@ -49,6 +55,13 @@ var Definitions = []FlagDef{
 		Description: "Monitor active streams and record watch history from connected Plex/Emby/Jellyfin servers, shown under Analytics. Disabling stops new sampling; existing history stays viewable.",
 		Category:    "Diagnostics",
 		Default:     true,
+	},
+	{
+		Key:         KeyPlugins,
+		Label:       "Plugins (Custom Scripts)",
+		Description: "Run admin-defined custom scripts when events fire (grab, import, playback). Plugins execute arbitrary commands as the Loom server process — this is NOT a security sandbox. Disabled by default; enable only if you trust the configured scripts.",
+		Category:    "Diagnostics",
+		Default:     false,
 	},
 }
 

--- a/internal/plugins/exec_helpers.go
+++ b/internal/plugins/exec_helpers.go
@@ -1,0 +1,116 @@
+package plugins
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+)
+
+// Optional interfaces an event may implement to expose structured data, mirrored
+// from the notifications dispatcher so we stay decoupled from source packages.
+type dataProvider interface{ NotificationData() map[string]any }
+type titler interface{ GetTitle() string }
+
+// buildPayload converts a bus event into the stdin payload for plugins.
+func buildPayload(def EventDef, ev eventbus.Event) Payload {
+	data := map[string]any{}
+	if dp, ok := ev.(dataProvider); ok {
+		for k, v := range dp.NotificationData() {
+			data[k] = v
+		}
+	}
+	title := ""
+	if t, ok := ev.(titler); ok {
+		title = t.GetTitle()
+		if title != "" {
+			data["title"] = title
+		}
+	}
+	if title == "" {
+		if s, ok := data["title"].(string); ok {
+			title = s
+		}
+	}
+	return Payload{
+		Version:   PayloadVersion,
+		Event:     def.Key,
+		Topic:     def.Topic,
+		Title:     title,
+		Data:      data,
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+// buildEnv constructs the child process environment. The host environment is
+// intentionally NOT inherited so server secrets cannot leak into plugins. The
+// plugin's explicit env is applied first; Loom-provided LOOM_* vars are applied
+// last so they cannot be overridden.
+func buildEnv(p *Plugin, payload Payload) []string {
+	env := []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	for k, v := range p.Env {
+		if strings.HasPrefix(strings.ToUpper(k), "LOOM_") {
+			continue // reserved; defended at validation time too
+		}
+		env = append(env, k+"="+v)
+	}
+	dataJSON, _ := json.Marshal(payload.Data)
+	env = append(env,
+		"LOOM_PAYLOAD_VERSION="+strconv.Itoa(payload.Version),
+		"LOOM_EVENT="+payload.Event,
+		"LOOM_TOPIC="+payload.Topic,
+		"LOOM_TITLE="+payload.Title,
+	)
+	// The full payload is always available on stdin. Only expose the data map as
+	// an env var when it is small enough to stay well under the OS per-string
+	// argument limit (Linux MAX_ARG_STRLEN ~128 KiB); otherwise read stdin.
+	if len(dataJSON) <= maxEnvJSON {
+		env = append(env, "LOOM_DATA_JSON="+string(dataJSON))
+	}
+	return env
+}
+
+func workingDir(p *Plugin) string {
+	if strings.TrimSpace(p.WorkingDir) != "" {
+		return p.WorkingDir
+	}
+	return "/"
+}
+
+// capWriter accumulates up to limit bytes and silently discards the rest, while
+// always reporting a full write so the os/exec output copier never blocks.
+type capWriter struct {
+	mu    sync.Mutex
+	buf   []byte
+	limit int
+	over  bool
+}
+
+func (w *capWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if remaining := w.limit - len(w.buf); remaining > 0 {
+		if len(p) <= remaining {
+			w.buf = append(w.buf, p...)
+		} else {
+			w.buf = append(w.buf, p[:remaining]...)
+			w.over = true
+		}
+	} else if len(p) > 0 {
+		w.over = true
+	}
+	return len(p), nil
+}
+
+func (w *capWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	s := string(w.buf)
+	if w.over {
+		s += "\n…(truncated)"
+	}
+	return s
+}

--- a/internal/plugins/handlers.go
+++ b/internal/plugins/handlers.go
@@ -1,0 +1,152 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Tester runs a single plugin synchronously (implemented by *Runner).
+type Tester interface {
+	RunOnce(ctx context.Context, p *Plugin) *Run
+}
+
+// Router mounts plugin endpoints. adminMW guards every route: plugins execute
+// arbitrary commands, so the feature is admin-only.
+func Router(store *Store, tester Tester, adminMW func(http.Handler) http.Handler) chi.Router {
+	r := chi.NewRouter()
+	r.Use(adminMW)
+
+	r.Get("/events", listEvents())
+	r.Get("/", listPlugins(store))
+	r.Post("/", createPlugin(store))
+	r.Get("/{id}", getPlugin(store))
+	r.Put("/{id}", updatePlugin(store))
+	r.Delete("/{id}", deletePlugin(store))
+	r.Get("/{id}/runs", listRuns(store))
+	r.Post("/{id}/test", testPlugin(store, tester))
+	return r
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]any{"error": map[string]any{
+		"code": http.StatusText(status), "message": msg,
+	}})
+}
+
+func listEvents() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, SupportedEvents)
+	}
+}
+
+func listPlugins(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ps, err := store.List(r.Context())
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if ps == nil {
+			ps = []*Plugin{}
+		}
+		writeJSON(w, http.StatusOK, ps)
+	}
+}
+
+func getPlugin(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p, err := store.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeErr(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, p)
+	}
+}
+
+func createPlugin(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var p Plugin
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if err := store.Create(r.Context(), &p); err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, p)
+	}
+}
+
+func updatePlugin(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var p Plugin
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		p.ID = chi.URLParam(r, "id")
+		if err := store.Update(r.Context(), &p); err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, p)
+	}
+}
+
+func deletePlugin(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := store.Delete(r.Context(), chi.URLParam(r, "id")); err != nil {
+			writeErr(w, http.StatusNotFound, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func listRuns(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		limit := 50
+		if v := r.URL.Query().Get("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				limit = n
+			}
+		}
+		runs, err := store.ListRuns(r.Context(), chi.URLParam(r, "id"), limit)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if runs == nil {
+			runs = []*Run{}
+		}
+		writeJSON(w, http.StatusOK, runs)
+	}
+}
+
+func testPlugin(store *Store, tester Tester) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if tester == nil {
+			writeErr(w, http.StatusServiceUnavailable, "plugin runner not available")
+			return
+		}
+		p, err := store.Get(r.Context(), chi.URLParam(r, "id"))
+		if err != nil {
+			writeErr(w, http.StatusNotFound, err.Error())
+			return
+		}
+		run := tester.RunOnce(r.Context(), p)
+		writeJSON(w, http.StatusOK, run)
+	}
+}

--- a/internal/plugins/runner.go
+++ b/internal/plugins/runner.go
@@ -1,0 +1,348 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+)
+
+const (
+	workerCount    = 4
+	queueSize      = 128
+	maxOutputBytes = 64 * 1024  // per stream (stdout/stderr) cap
+	maxPayloadByte = 256 * 1024 // stdin payload cap
+	maxEnvJSON     = 96 * 1024  // skip LOOM_DATA_JSON above this (Linux env-string limit)
+	drainTimeout   = 30 * time.Second
+	killWait       = 5 * time.Second
+	execWaitDelay  = 5 * time.Second
+)
+
+// eventJob is one delivered event; a worker expands it to the matching plugins.
+type eventJob struct {
+	def     EventDef
+	payload Payload
+}
+
+// Runner subscribes to the event bus and executes matching plugins in a
+// bounded worker pool, fully decoupled from the bus's own goroutines.
+type Runner struct {
+	bus     eventbus.Bus
+	store   *Store
+	enabled func() bool // feature-flag gate
+	logger  *slog.Logger
+
+	jobs   chan eventJob
+	unsubs []func()
+	wg     sync.WaitGroup // worker pool
+
+	rootCtx context.Context
+	cancel  context.CancelFunc
+
+	// Producer coordination so we can close(jobs) without racing onEvent senders.
+	prodMu   sync.Mutex
+	stopping bool
+	prodWG   sync.WaitGroup
+	stopOnce sync.Once
+
+	childMu  sync.Mutex
+	children map[int]*exec.Cmd // live child PIDs -> cmd, for shutdown teardown
+}
+
+// NewRunner builds a runner. enabled gates execution (feature flag); a nil
+// enabled func is treated as always-enabled.
+func NewRunner(bus eventbus.Bus, store *Store, enabled func() bool, logger *slog.Logger) *Runner {
+	if enabled == nil {
+		enabled = func() bool { return true }
+	}
+	return &Runner{
+		bus:      bus,
+		store:    store,
+		enabled:  enabled,
+		logger:   logger.With("component", "plugin-runner"),
+		jobs:     make(chan eventJob, queueSize),
+		children: make(map[int]*exec.Cmd),
+	}
+}
+
+// Start subscribes to all supported topics and launches the worker pool.
+func (r *Runner) Start(ctx context.Context) {
+	r.rootCtx, r.cancel = context.WithCancel(ctx)
+	for i := 0; i < workerCount; i++ {
+		r.wg.Add(1)
+		go r.worker()
+	}
+	for _, e := range SupportedEvents {
+		unsub := r.bus.Subscribe(e.Topic, func(_ context.Context, ev eventbus.Event) error {
+			r.onEvent(ev)
+			return nil
+		})
+		r.unsubs = append(r.unsubs, unsub)
+	}
+	r.logger.Info("plugin runner started", "topics", len(SupportedEvents), "workers", workerCount)
+}
+
+// Stop unsubscribes, drains in-flight work within a timeout, then tears down any
+// child processes still running. Idempotent.
+func (r *Runner) Stop() {
+	r.stopOnce.Do(r.stop)
+}
+
+func (r *Runner) stop() {
+	// 1. Stop receiving new events.
+	for _, u := range r.unsubs {
+		u()
+	}
+	r.unsubs = nil
+
+	// 2. Block new producers, wait for in-flight onEvent sends, then close.
+	r.prodMu.Lock()
+	r.stopping = true
+	r.prodMu.Unlock()
+	r.prodWG.Wait()
+	close(r.jobs)
+
+	// 3. Wait for workers to drain, up to the drain timeout.
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		r.logger.Info("plugin runner stopped")
+		return
+	case <-time.After(drainTimeout):
+		r.logger.Warn("plugin runner drain timed out; terminating children")
+	}
+
+	// 4. Force in-flight subprocesses to die, then wait a bounded time. We never
+	// block forever: WaitDelay + this bounded wait guarantee Stop() returns.
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.terminateAll()
+	select {
+	case <-done:
+	case <-time.After(killWait):
+		r.logger.Error("plugin runner did not stop cleanly; abandoning workers")
+	}
+	r.logger.Info("plugin runner stopped")
+}
+
+// onEvent runs on a bus goroutine: it must be cheap. It builds the payload and
+// enqueues a single job (no DB access here); a worker expands it to plugins.
+func (r *Runner) onEvent(ev eventbus.Event) {
+	if !r.enabled() {
+		return
+	}
+	def, ok := eventByTopic(ev.Topic())
+	if !ok {
+		return
+	}
+
+	// Register as a producer so Stop() won't close(jobs) mid-send.
+	r.prodMu.Lock()
+	if r.stopping {
+		r.prodMu.Unlock()
+		return
+	}
+	r.prodWG.Add(1)
+	r.prodMu.Unlock()
+	defer r.prodWG.Done()
+
+	job := eventJob{def: def, payload: buildPayload(def, ev)}
+	select {
+	case r.jobs <- job:
+	default:
+		r.logger.Warn("plugin queue full, dropping event", "event", def.Key)
+	}
+}
+
+func (r *Runner) worker() {
+	defer r.wg.Done()
+	for j := range r.jobs {
+		r.dispatch(j)
+	}
+}
+
+// dispatch finds the plugins subscribed to an event and runs each (off the bus).
+func (r *Runner) dispatch(j eventJob) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	plugins, err := r.store.enabledForTopic(ctx, j.def.Key)
+	cancel()
+	if err != nil {
+		r.logger.Error("plugin lookup failed", "event", j.def.Key, "error", err)
+		return
+	}
+	for _, p := range plugins {
+		r.execute(r.rootCtx, p, j.payload)
+	}
+}
+
+// execute runs one plugin subprocess with full isolation/bounding, records the
+// result and returns it. It never propagates panics. parent bounds the run's
+// lifetime (cancelled on shutdown or client disconnect).
+func (r *Runner) execute(parent context.Context, p *Plugin, payload Payload) (result *Run) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Error("plugin execution panicked", "plugin", p.Name, "panic", rec)
+			result = &Run{PluginID: p.ID, PluginName: p.Name, Topic: payload.Topic,
+				Success: false, ExitCode: -1, ErrorMsg: "panicked during execution", StartedAt: time.Now().UTC()}
+		}
+	}()
+
+	if parent == nil {
+		parent = context.Background()
+	}
+	stdin, err := json.Marshal(payload)
+	if err != nil || len(stdin) > maxPayloadByte {
+		return r.recordSkip(p, payload.Topic, "payload too large or unencodable")
+	}
+
+	timeout := time.Duration(p.TimeoutSecs) * time.Second
+	if timeout <= 0 {
+		timeout = defaultTimeout * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, p.Command[0], p.Command[1:]...)
+	cmd.Env = buildEnv(p, payload)
+	cmd.Dir = workingDir(p)
+	cmd.Stdin = bytes.NewReader(stdin)
+	outBuf := &capWriter{limit: maxOutputBytes}
+	errBuf := &capWriter{limit: maxOutputBytes}
+	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
+	// Own process group so a timeout terminates the whole tree.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.WaitDelay = execWaitDelay // bound Wait() even if children hold the pipes
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Signal the process group; ignore ESRCH (already gone).
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+		return nil
+	}
+
+	start := time.Now()
+	runErr := cmd.Start()
+	if runErr == nil {
+		r.track(cmd)
+		runErr = cmd.Wait()
+		r.untrack(cmd)
+	}
+	dur := time.Since(start)
+
+	run := &Run{
+		PluginID:   p.ID,
+		PluginName: p.Name,
+		Topic:      payload.Topic,
+		DurationMs: dur.Milliseconds(),
+		Stdout:     outBuf.String(),
+		Stderr:     errBuf.String(),
+		StartedAt:  start.UTC(),
+	}
+	switch {
+	case ctx.Err() == context.DeadlineExceeded:
+		run.Success = false
+		run.ErrorMsg = "timed out after " + timeout.String()
+		run.ExitCode = -1
+	case ctx.Err() == context.Canceled:
+		run.Success = false
+		run.ErrorMsg = "cancelled"
+		run.ExitCode = -1
+	case runErr == nil:
+		run.Success = true
+		run.ExitCode = 0
+	default:
+		run.Success = false
+		run.ErrorMsg = runErr.Error()
+		var ee *exec.ExitError
+		if errors.As(runErr, &ee) {
+			run.ExitCode = ee.ExitCode()
+		} else {
+			run.ExitCode = -1
+		}
+	}
+
+	r.persistRun(run)
+	if !run.Success {
+		r.logger.Warn("plugin run failed", "plugin", p.Name, "event", payload.Event,
+			"exit", run.ExitCode, "error", run.ErrorMsg)
+	}
+	return run
+}
+
+func (r *Runner) track(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	r.childMu.Lock()
+	r.children[cmd.Process.Pid] = cmd
+	r.childMu.Unlock()
+}
+
+func (r *Runner) untrack(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	r.childMu.Lock()
+	delete(r.children, cmd.Process.Pid)
+	r.childMu.Unlock()
+}
+
+// terminateAll signals SIGKILL to the process group of every tracked child.
+func (r *Runner) terminateAll() {
+	r.childMu.Lock()
+	defer r.childMu.Unlock()
+	for pid := range r.children {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+}
+
+func (r *Runner) persistRun(run *Run) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := r.store.InsertRun(ctx, run); err != nil {
+		r.logger.Warn("failed to record plugin run", "plugin", run.PluginName, "error", err)
+	}
+}
+
+func (r *Runner) recordSkip(p *Plugin, topic, reason string) *Run {
+	run := &Run{
+		PluginID: p.ID, PluginName: p.Name, Topic: topic,
+		Success: false, ExitCode: -1, ErrorMsg: "skipped: " + reason, StartedAt: time.Now().UTC(),
+	}
+	r.persistRun(run)
+	return run
+}
+
+// RunOnce executes a plugin synchronously with a synthetic payload (used by the
+// "test" endpoint) and returns the recorded run. The request context bounds the
+// subprocess, so a client disconnect cancels it.
+func (r *Runner) RunOnce(ctx context.Context, p *Plugin) *Run {
+	def := EventDef{Key: "test", Topic: "test", Label: "Test"}
+	if len(p.Events) > 0 {
+		if d, ok := eventByKey(p.Events[0]); ok {
+			def = d
+		}
+	}
+	payload := Payload{
+		Version: PayloadVersion, Event: def.Key, Topic: def.Topic,
+		Title: "Test event from Loom", Timestamp: time.Now().UTC(),
+		Data: map[string]any{"title": "Test event from Loom", "test": true},
+	}
+	return r.execute(ctx, p, payload)
+}

--- a/internal/plugins/runner_test.go
+++ b/internal/plugins/runner_test.go
@@ -1,0 +1,307 @@
+package plugins
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "loom.db")},
+	}
+	db, err := storage.Open(context.Background(), cfg,
+		slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return db.DB()
+}
+
+func quiet() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newRunner(t *testing.T, enabled bool) (*Runner, *Store) {
+	t.Helper()
+	store := NewStore(openTestDB(t))
+	r := NewRunner(eventbus.NewInProc(), store, func() bool { return enabled }, quiet())
+	return r, store
+}
+
+func TestStoreCRUDAndValidation(t *testing.T) {
+	store := NewStore(openTestDB(t))
+	ctx := context.Background()
+
+	// Missing command rejected.
+	if err := store.Create(ctx, &Plugin{Name: "x", Events: []string{"grab"}}); err == nil {
+		t.Fatal("expected error for empty command")
+	}
+	// Unknown event rejected.
+	if err := store.Create(ctx, &Plugin{Name: "x", Command: []string{"/bin/true"}, Events: []string{"nope"}}); err == nil {
+		t.Fatal("expected error for unknown event")
+	}
+	// Reserved LOOM_ env rejected.
+	if err := store.Create(ctx, &Plugin{Name: "x", Command: []string{"/bin/true"}, Events: []string{"grab"},
+		Env: map[string]string{"LOOM_HACK": "1"}}); err == nil {
+		t.Fatal("expected error for reserved LOOM_ env key")
+	}
+
+	p := &Plugin{Name: "good", Command: []string{"/bin/true"}, Events: []string{"grab", "import_complete"}, TimeoutSecs: 9999}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if p.ID == "" {
+		t.Fatal("expected ID assigned")
+	}
+	if p.TimeoutSecs != maxTimeoutSecs {
+		t.Fatalf("expected timeout capped at %d, got %d", maxTimeoutSecs, p.TimeoutSecs)
+	}
+
+	got, err := store.Get(ctx, p.ID)
+	if err != nil || got.Name != "good" || len(got.Events) != 2 {
+		t.Fatalf("get round-trip failed: %+v err=%v", got, err)
+	}
+
+	got.Enabled = true
+	if err := store.Update(ctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	subs, err := store.enabledForTopic(ctx, "grab")
+	if err != nil || len(subs) != 1 {
+		t.Fatalf("expected 1 enabled plugin for grab, got %d err=%v", len(subs), err)
+	}
+
+	if err := store.Delete(ctx, p.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := store.Get(ctx, p.ID); err == nil {
+		t.Fatal("expected not-found after delete")
+	}
+}
+
+func TestRunOnceSuccessAndStdin(t *testing.T) {
+	r, store := newRunner(t, true)
+	ctx := context.Background()
+	// `cat` echoes the stdin payload to stdout.
+	p := &Plugin{Name: "echo", Enabled: true, Command: []string{"/bin/cat"}, Events: []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	run := r.RunOnce(ctx, p)
+	if !run.Success || run.ExitCode != 0 {
+		t.Fatalf("expected success, got %+v", run)
+	}
+	if !strings.Contains(run.Stdout, "\"event\"") || !strings.Contains(run.Stdout, "Test event") {
+		t.Fatalf("stdin payload not echoed to stdout: %q", run.Stdout)
+	}
+
+	runs, err := store.ListRuns(ctx, p.ID, 10)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("expected 1 recorded run, got %d err=%v", len(runs), err)
+	}
+}
+
+func TestRunOnceTimeoutKills(t *testing.T) {
+	r, store := newRunner(t, true)
+	ctx := context.Background()
+	p := &Plugin{Name: "slow", Enabled: true, Command: []string{"/bin/sh", "-c", "sleep 30"},
+		Events: []string{"grab"}, TimeoutSecs: 1}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	start := time.Now()
+	run := r.RunOnce(ctx, p)
+	if run.Success {
+		t.Fatal("expected timeout failure")
+	}
+	if !strings.Contains(run.ErrorMsg, "timed out") {
+		t.Fatalf("expected timeout error, got %q", run.ErrorMsg)
+	}
+	if time.Since(start) > 10*time.Second {
+		t.Fatal("timeout did not kill the process promptly")
+	}
+}
+
+func TestEnvIsolationAndLoomVars(t *testing.T) {
+	// A host secret must NOT be visible to plugins; LOOM_EVENT must be.
+	t.Setenv("LOOM_TEST_SECRET", "topsecret")
+	r, store := newRunner(t, true)
+	ctx := context.Background()
+	p := &Plugin{Name: "env", Enabled: true,
+		Command: []string{"/bin/sh", "-c", "echo event=$LOOM_EVENT secret=[$LOOM_TEST_SECRET]"},
+		Events:  []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run := r.RunOnce(ctx, p)
+	if !run.Success {
+		t.Fatalf("expected success, got %+v", run)
+	}
+	if !strings.Contains(run.Stdout, "event=grab") {
+		t.Fatalf("LOOM_EVENT not set: %q", run.Stdout)
+	}
+	if !strings.Contains(run.Stdout, "secret=[]") {
+		t.Fatalf("host env leaked into plugin: %q", run.Stdout)
+	}
+}
+
+func TestOutputCapped(t *testing.T) {
+	r, store := newRunner(t, true)
+	ctx := context.Background()
+	p := &Plugin{Name: "spew", Enabled: true,
+		Command: []string{"/bin/sh", "-c", "yes x | head -c 500000"},
+		Events:  []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run := r.RunOnce(ctx, p)
+	if !run.Success {
+		t.Fatalf("expected success, got %+v", run)
+	}
+	if len(run.Stdout) > maxOutputBytes+64 {
+		t.Fatalf("stdout not capped: %d bytes", len(run.Stdout))
+	}
+	if !strings.Contains(run.Stdout, "truncated") {
+		t.Fatalf("expected truncation marker, got %d bytes", len(run.Stdout))
+	}
+}
+
+// fakeEvent implements eventbus.Event plus the optional data interfaces.
+type fakeEvent struct {
+	topic string
+	title string
+	data  map[string]any
+}
+
+func (e fakeEvent) Topic() string                    { return e.topic }
+func (e fakeEvent) GetTitle() string                 { return e.title }
+func (e fakeEvent) NotificationData() map[string]any { return e.data }
+
+func TestEventDrivenExecution(t *testing.T) {
+	bus := eventbus.NewInProc()
+	store := NewStore(openTestDB(t))
+	r := NewRunner(bus, store, func() bool { return true }, quiet())
+	ctx := context.Background()
+
+	marker := filepath.Join(t.TempDir(), "ran.txt")
+	p := &Plugin{Name: "touch", Enabled: true,
+		Command: []string{"/bin/sh", "-c", "cat > " + marker},
+		Events:  []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	r.Start(ctx)
+	defer r.Stop()
+
+	if err := bus.Publish(ctx, fakeEvent{topic: topicDownloadQueued, title: "Big Movie",
+		data: map[string]any{"title": "Big Movie"}}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(marker); err == nil && strings.Contains(string(b), "Big Movie") {
+			return // plugin ran and received the payload
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("plugin did not run on event within timeout")
+}
+
+func TestDisabledFlagSkipsExecution(t *testing.T) {
+	bus := eventbus.NewInProc()
+	store := NewStore(openTestDB(t))
+	r := NewRunner(bus, store, func() bool { return false }, quiet())
+	ctx := context.Background()
+	p := &Plugin{Name: "noop", Enabled: true, Command: []string{"/bin/true"},
+		Events: []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	r.Start(ctx)
+	defer r.Stop()
+	_ = bus.Publish(ctx, fakeEvent{topic: topicDownloadQueued, data: map[string]any{}})
+
+	time.Sleep(300 * time.Millisecond)
+	runs, _ := store.ListRuns(ctx, p.ID, 10)
+	if len(runs) != 0 {
+		t.Fatalf("expected no runs when feature disabled, got %d", len(runs))
+	}
+}
+
+// TestStopIsIdempotentAndSafeUnderLoad publishes events while stopping to prove
+// the producer/consumer close coordination doesn't panic, and that Stop() can
+// be called more than once.
+func TestStopIsIdempotentAndSafeUnderLoad(t *testing.T) {
+	bus := eventbus.NewInProc()
+	store := NewStore(openTestDB(t))
+	r := NewRunner(bus, store, func() bool { return true }, quiet())
+	ctx := context.Background()
+	p := &Plugin{Name: "quick", Enabled: true, Command: []string{"/bin/true"},
+		Events: []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	r.Start(ctx)
+
+	stop := make(chan struct{})
+	var pub sync.WaitGroup
+	pub.Add(1)
+	go func() {
+		defer pub.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = bus.Publish(ctx, fakeEvent{topic: topicDownloadQueued, data: map[string]any{}})
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	r.Stop() // must not panic despite concurrent publishes
+	r.Stop() // idempotent
+	close(stop)
+	pub.Wait()
+}
+
+func TestUnknownTopicIgnored(t *testing.T) {
+	r, store := newRunner(t, true)
+	ctx := context.Background()
+	p := &Plugin{Name: "p", Enabled: true, Command: []string{"/bin/true"},
+		Events: []string{"grab"}, TimeoutSecs: 10}
+	if err := store.Create(ctx, p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	r.Start(ctx)
+	defer r.Stop()
+	// A topic with no SupportedEvents mapping must be a no-op.
+	r.onEvent(fakeEvent{topic: "movies.added", data: map[string]any{}})
+	time.Sleep(150 * time.Millisecond)
+	runs, _ := store.ListRuns(ctx, p.ID, 10)
+	if len(runs) != 0 {
+		t.Fatalf("expected no runs for unmapped topic, got %d", len(runs))
+	}
+}

--- a/internal/plugins/store.go
+++ b/internal/plugins/store.go
@@ -1,0 +1,286 @@
+package plugins
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Tunables for run-history retention.
+const (
+	maxRunsPerPlugin = 200
+	maxRunAge        = 30 * 24 * time.Hour
+	maxTimeoutSecs   = 300
+	defaultTimeout   = 30
+)
+
+// Store is the persistence + validation layer for plugins and their run history.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore returns a sqlite-backed plugin store.
+func NewStore(db *sql.DB) *Store { return &Store{db: db} }
+
+// List returns all plugins ordered by name.
+func (s *Store) List(ctx context.Context) ([]*Plugin, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, enabled, command, events, env, timeout_secs, working_dir, created_at, updated_at
+		FROM plugins ORDER BY name ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("list plugins: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Plugin
+	for rows.Next() {
+		p, err := scanPlugin(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// Get returns a single plugin by id.
+func (s *Store) Get(ctx context.Context, id string) (*Plugin, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, enabled, command, events, env, timeout_secs, working_dir, created_at, updated_at
+		FROM plugins WHERE id = ?`, id)
+	p, err := scanPlugin(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("plugin not found: %s", id)
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+// enabledForTopic returns enabled plugins subscribed to the given event key.
+func (s *Store) enabledForTopic(ctx context.Context, eventKey string) ([]*Plugin, error) {
+	all, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []*Plugin
+	for _, p := range all {
+		if !p.Enabled {
+			continue
+		}
+		for _, e := range p.Events {
+			if e == eventKey {
+				out = append(out, p)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// Create validates and inserts a plugin, assigning ID/timestamps.
+func (s *Store) Create(ctx context.Context, p *Plugin) error {
+	if err := validate(p); err != nil {
+		return err
+	}
+	p.ID = uuid.New().String()
+	now := time.Now().UTC()
+	p.CreatedAt, p.UpdatedAt = now, now
+
+	cmd, _ := json.Marshal(p.Command)
+	evs, _ := json.Marshal(p.Events)
+	env, _ := json.Marshal(p.Env)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO plugins (id, name, enabled, command, events, env, timeout_secs, working_dir, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.ID, p.Name, boolToInt(p.Enabled), string(cmd), string(evs), string(env),
+		p.TimeoutSecs, p.WorkingDir, p.CreatedAt.Format(time.RFC3339Nano), p.UpdatedAt.Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("create plugin: %w", err)
+	}
+	return nil
+}
+
+// Update validates and persists changes to an existing plugin.
+func (s *Store) Update(ctx context.Context, p *Plugin) error {
+	if err := validate(p); err != nil {
+		return err
+	}
+	existing, err := s.Get(ctx, p.ID)
+	if err != nil {
+		return err
+	}
+	p.CreatedAt = existing.CreatedAt
+	p.UpdatedAt = time.Now().UTC()
+
+	cmd, _ := json.Marshal(p.Command)
+	evs, _ := json.Marshal(p.Events)
+	env, _ := json.Marshal(p.Env)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE plugins SET name = ?, enabled = ?, command = ?, events = ?, env = ?,
+		    timeout_secs = ?, working_dir = ?, updated_at = ?
+		WHERE id = ?`,
+		p.Name, boolToInt(p.Enabled), string(cmd), string(evs), string(env),
+		p.TimeoutSecs, p.WorkingDir, p.UpdatedAt.Format(time.RFC3339Nano), p.ID)
+	if err != nil {
+		return fmt.Errorf("update plugin: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("plugin not found: %s", p.ID)
+	}
+	return nil
+}
+
+// Delete removes a plugin and its run history.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM plugin_runs WHERE plugin_id = ?`, id); err != nil {
+		return fmt.Errorf("delete plugin runs: %w", err)
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM plugins WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete plugin: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("plugin not found: %s", id)
+	}
+	return nil
+}
+
+// InsertRun records a run and prunes old history (best-effort).
+func (s *Store) InsertRun(ctx context.Context, r *Run) error {
+	if r.ID == "" {
+		r.ID = uuid.New().String()
+	}
+	if r.StartedAt.IsZero() {
+		r.StartedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO plugin_runs (id, plugin_id, plugin_name, topic, success, exit_code, duration_ms, stdout, stderr, error_msg, started_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.PluginID, r.PluginName, r.Topic, boolToInt(r.Success), r.ExitCode, r.DurationMs,
+		r.Stdout, r.Stderr, r.ErrorMsg, r.StartedAt.Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("insert run: %w", err)
+	}
+	s.prune(ctx, r.PluginID)
+	return nil
+}
+
+// prune enforces per-plugin count and global age retention (best-effort).
+func (s *Store) prune(ctx context.Context, pluginID string) {
+	// Keep only the most recent maxRunsPerPlugin rows for this plugin.
+	_, _ = s.db.ExecContext(ctx, `
+		DELETE FROM plugin_runs
+		WHERE plugin_id = ? AND id NOT IN (
+		    SELECT id FROM plugin_runs WHERE plugin_id = ? ORDER BY started_at DESC LIMIT ?
+		)`, pluginID, pluginID, maxRunsPerPlugin)
+	cutoff := time.Now().UTC().Add(-maxRunAge).Format(time.RFC3339Nano)
+	_, _ = s.db.ExecContext(ctx, `DELETE FROM plugin_runs WHERE started_at < ?`, cutoff)
+}
+
+// ListRuns returns recent runs for a plugin, newest first.
+func (s *Store) ListRuns(ctx context.Context, pluginID string, limit int) ([]*Run, error) {
+	if limit <= 0 || limit > maxRunsPerPlugin {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, plugin_id, plugin_name, topic, success, exit_code, duration_ms, stdout, stderr, error_msg, started_at
+		FROM plugin_runs WHERE plugin_id = ? ORDER BY started_at DESC LIMIT ?`, pluginID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Run
+	for rows.Next() {
+		var r Run
+		var success int
+		var started string
+		if err := rows.Scan(&r.ID, &r.PluginID, &r.PluginName, &r.Topic, &success,
+			&r.ExitCode, &r.DurationMs, &r.Stdout, &r.Stderr, &r.ErrorMsg, &started); err != nil {
+			return nil, err
+		}
+		r.Success = success != 0
+		r.StartedAt, _ = time.Parse(time.RFC3339Nano, started)
+		out = append(out, &r)
+	}
+	return out, rows.Err()
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanPlugin(sc scanner) (*Plugin, error) {
+	var p Plugin
+	var enabled int
+	var cmd, evs, env, created, updated string
+	if err := sc.Scan(&p.ID, &p.Name, &enabled, &cmd, &evs, &env, &p.TimeoutSecs, &p.WorkingDir, &created, &updated); err != nil {
+		return nil, err
+	}
+	p.Enabled = enabled != 0
+	_ = json.Unmarshal([]byte(cmd), &p.Command)
+	_ = json.Unmarshal([]byte(evs), &p.Events)
+	_ = json.Unmarshal([]byte(env), &p.Env)
+	if p.Env == nil {
+		p.Env = map[string]string{}
+	}
+	p.CreatedAt, _ = time.Parse(time.RFC3339Nano, created)
+	p.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updated)
+	return &p, nil
+}
+
+// validate normalizes and checks a plugin before persistence.
+func validate(p *Plugin) error {
+	p.Name = strings.TrimSpace(p.Name)
+	if p.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	// Trim empty argv entries.
+	cmd := make([]string, 0, len(p.Command))
+	for _, a := range p.Command {
+		if strings.TrimSpace(a) != "" {
+			cmd = append(cmd, a)
+		}
+	}
+	p.Command = cmd
+	if len(p.Command) == 0 {
+		return fmt.Errorf("command is required")
+	}
+	if len(p.Events) == 0 {
+		return fmt.Errorf("at least one event must be selected")
+	}
+	for _, e := range p.Events {
+		if _, ok := eventByKey(e); !ok {
+			return fmt.Errorf("unknown event: %s", e)
+		}
+	}
+	if p.TimeoutSecs <= 0 {
+		p.TimeoutSecs = defaultTimeout
+	}
+	if p.TimeoutSecs > maxTimeoutSecs {
+		p.TimeoutSecs = maxTimeoutSecs
+	}
+	if p.Env == nil {
+		p.Env = map[string]string{}
+	}
+	for k := range p.Env {
+		if strings.HasPrefix(strings.ToUpper(k), "LOOM_") {
+			return fmt.Errorf("environment variable %q is reserved (LOOM_* keys are set by Loom)", k)
+		}
+	}
+	return nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/plugins/types.go
+++ b/internal/plugins/types.go
@@ -1,0 +1,113 @@
+// Package plugins implements custom post-processing "script" plugins: an
+// admin configures an executable command that Loom runs whenever a subscribed
+// domain event fires (a grab, an import, a playback, ...). It is the rough
+// equivalent of Sonarr/Radarr "Custom Scripts".
+//
+// Trust model: a plugin is an arbitrary command that runs as the Loom server
+// process user, with that user's privileges and access to the same filesystem,
+// network and (where granted) configuration. This is NOT an OS-level sandbox.
+// What Loom provides is *failure isolation and resource bounding*: each plugin
+// runs as a separate child process with a timeout (the whole process group is
+// killed on expiry), output is size-capped, the host environment is not
+// inherited (so server secrets are not leaked into plugins), execution is
+// concurrency-limited and never blocks the event bus, and panics are recovered.
+// For real isolation, run Loom itself under container/Kubernetes controls.
+package plugins
+
+import "time"
+
+// Plugin is an admin-configured executable invoked on subscribed events.
+type Plugin struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Enabled     bool              `json:"enabled"`
+	Command     []string          `json:"command"`      // argv; Command[0] is the executable. No shell.
+	Events      []string          `json:"events"`       // SupportedEvent keys this plugin subscribes to.
+	Env         map[string]string `json:"env"`          // extra environment variables (LOOM_* keys rejected).
+	TimeoutSecs int               `json:"timeout_secs"` // per-run wall-clock budget.
+	WorkingDir  string            `json:"working_dir"`  // optional; defaults to "/" when empty.
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// Run is a single recorded execution of a plugin (history).
+type Run struct {
+	ID         string    `json:"id"`
+	PluginID   string    `json:"plugin_id"`
+	PluginName string    `json:"plugin_name"`
+	Topic      string    `json:"topic"`
+	Success    bool      `json:"success"`
+	ExitCode   int       `json:"exit_code"`
+	DurationMs int64     `json:"duration_ms"`
+	Stdout     string    `json:"stdout"`
+	Stderr     string    `json:"stderr"`
+	ErrorMsg   string    `json:"error_msg"`
+	StartedAt  time.Time `json:"started_at"`
+}
+
+// EventDef is a curated event a plugin may subscribe to. Keys are stable and
+// map to an internal event bus topic; the data exposed for each is treated as
+// a stable contract for plugin authors.
+type EventDef struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+	Topic string `json:"topic"`
+}
+
+// Bus topic strings are duplicated here (as in the notifications dispatcher) to
+// avoid import cycles with the downloads/imports/analytics packages.
+const (
+	topicDownloadQueued    = "downloads.queued"
+	topicDownloadCompleted = "downloads.completed"
+	topicDownloadFailed    = "downloads.failed"
+	topicImportCompleted   = "imports.completed"
+	topicImportFailed      = "imports.failed"
+	topicPlaybackStarted   = "analytics.playback.started"
+	topicPlaybackStopped   = "analytics.playback.stopped"
+)
+
+// SupportedEvents is the curated allow-list of events plugins may run on. We do
+// not expose arbitrary internal topics, both to keep the contract stable and to
+// avoid leaking event data that was never reviewed for external consumption.
+var SupportedEvents = []EventDef{
+	{Key: "grab", Label: "On Grab (download queued)", Topic: topicDownloadQueued},
+	{Key: "download_complete", Label: "On Download Complete", Topic: topicDownloadCompleted},
+	{Key: "download_failed", Label: "On Download Failed", Topic: topicDownloadFailed},
+	{Key: "import_complete", Label: "On Import Complete", Topic: topicImportCompleted},
+	{Key: "import_failed", Label: "On Import Failed", Topic: topicImportFailed},
+	{Key: "playback_started", Label: "On Playback Started", Topic: topicPlaybackStarted},
+	{Key: "playback_stopped", Label: "On Playback Stopped", Topic: topicPlaybackStopped},
+}
+
+// eventByTopic maps a bus topic back to its supported-event key.
+func eventByTopic(topic string) (EventDef, bool) {
+	for _, e := range SupportedEvents {
+		if e.Topic == topic {
+			return e, true
+		}
+	}
+	return EventDef{}, false
+}
+
+// eventByKey returns the EventDef for a supported-event key.
+func eventByKey(key string) (EventDef, bool) {
+	for _, e := range SupportedEvents {
+		if e.Key == key {
+			return e, true
+		}
+	}
+	return EventDef{}, false
+}
+
+// Payload is the JSON document delivered to a plugin on stdin.
+type Payload struct {
+	Version   int            `json:"version"`
+	Event     string         `json:"event"` // supported-event key
+	Topic     string         `json:"topic"`
+	Title     string         `json:"title"`
+	Data      map[string]any `json:"data"`
+	Timestamp time.Time      `json:"timestamp"`
+}
+
+// PayloadVersion is the schema version embedded in every Payload.
+const PayloadVersion = 1

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,7 @@ import (
 	"github.com/ebenderooock/loom/internal/notifications"
 	"github.com/ebenderooock/loom/internal/organizer"
 	"github.com/ebenderooock/loom/internal/packs"
+	"github.com/ebenderooock/loom/internal/plugins"
 	"github.com/ebenderooock/loom/internal/qualityprofiles"
 	"github.com/ebenderooock/loom/internal/requests"
 	"github.com/ebenderooock/loom/internal/rss"
@@ -100,6 +101,8 @@ type Server struct {
 	notifSvc          notifications.Service
 	connectSvc        connect.Service
 	analyticsSvc      *analytics.Service
+	pluginStore       *plugins.Store
+	pluginTester      plugins.Tester
 	reviewStore       *safety.ReviewStore
 	cleanupSvc        *cleanup.Service
 	requestsSvc       *requests.Service
@@ -291,6 +294,15 @@ func (s *Server) SetConnect(svc connect.Service) {
 // SetAnalytics installs the media-analytics service and rebuilds the handler.
 func (s *Server) SetAnalytics(svc *analytics.Service) {
 	s.analyticsSvc = svc
+	if s.httpSrv != nil {
+		s.httpSrv.Handler = s.newMux()
+	}
+}
+
+// SetPlugins installs the plugins store + runner (tester) and rebuilds the handler.
+func (s *Server) SetPlugins(store *plugins.Store, tester plugins.Tester) {
+	s.pluginStore = store
+	s.pluginTester = tester
 	if s.httpSrv != nil {
 		s.httpSrv.Handler = s.newMux()
 	}
@@ -724,6 +736,15 @@ func (s *Server) newMux() http.Handler {
 				adminMW = s.authSvc.RequireRole("admin")
 			}
 			r.Mount("/api/v1/analytics", analytics.Router(s.analyticsSvc, adminMW))
+		}
+
+		// Plugins (custom scripts) routes — admin-only; plugins run commands.
+		if s.pluginStore != nil {
+			adminMW := func(next http.Handler) http.Handler { return next }
+			if s.authSvc != nil {
+				adminMW = s.authSvc.RequireRole("admin")
+			}
+			r.Mount("/api/v1/plugins", plugins.Router(s.pluginStore, s.pluginTester, adminMW))
 		}
 
 		// Calendar routes

--- a/internal/storage/migrations/sqlite/0067_plugins.sql
+++ b/internal/storage/migrations/sqlite/0067_plugins.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS plugins (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    enabled       INTEGER NOT NULL DEFAULT 0,
+    command       TEXT NOT NULL DEFAULT '[]',
+    events        TEXT NOT NULL DEFAULT '[]',
+    env           TEXT NOT NULL DEFAULT '{}',
+    timeout_secs  INTEGER NOT NULL DEFAULT 30,
+    working_dir   TEXT NOT NULL DEFAULT '',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS plugin_runs (
+    id           TEXT PRIMARY KEY,
+    plugin_id    TEXT NOT NULL,
+    plugin_name  TEXT NOT NULL DEFAULT '',
+    topic        TEXT NOT NULL DEFAULT '',
+    success      INTEGER NOT NULL DEFAULT 0,
+    exit_code    INTEGER NOT NULL DEFAULT 0,
+    duration_ms  INTEGER NOT NULL DEFAULT 0,
+    stdout       TEXT NOT NULL DEFAULT '',
+    stderr       TEXT NOT NULL DEFAULT '',
+    error_msg    TEXT NOT NULL DEFAULT '',
+    started_at   TEXT NOT NULL
+);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_plugin_runs_plugin ON plugin_runs (plugin_id, started_at DESC);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS idx_plugin_runs_started ON plugin_runs (started_at DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS plugin_runs;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP TABLE IF EXISTS plugins;
+-- +goose StatementEnd

--- a/web/src/components/layout/settings-layout.tsx
+++ b/web/src/components/layout/settings-layout.tsx
@@ -13,6 +13,7 @@ import {
   ListPlus,
   Network,
   Palette,
+  Puzzle,
   Radio,
   RefreshCw,
   Repeat,
@@ -139,6 +140,13 @@ export const SETTINGS_GROUPS: SettingsNavGroup[] = [
     items: [
       { to: "/settings/notifications", label: "Notifications", Icon: Bell, kind: "page" },
       { to: "/settings/request-bots", label: "Request Bots", Icon: Bot, kind: "page" },
+      {
+        to: "/settings/plugins",
+        label: "Plugins",
+        Icon: Puzzle,
+        kind: "page",
+        adminOnly: true,
+      },
       {
         to: "/settings/connect",
         label: "Connect",

--- a/web/src/lib/plugins-api.ts
+++ b/web/src/lib/plugins-api.ts
@@ -1,0 +1,129 @@
+// Typed fetch wrappers + react-query hooks for custom-script plugins.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/fetch";
+
+export interface Plugin {
+  id: string;
+  name: string;
+  enabled: boolean;
+  command: string[];
+  events: string[];
+  env: Record<string, string>;
+  timeout_secs: number;
+  working_dir: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PluginEvent {
+  key: string;
+  label: string;
+  topic: string;
+}
+
+export interface PluginRun {
+  id: string;
+  plugin_id: string;
+  plugin_name: string;
+  topic: string;
+  success: boolean;
+  exit_code: number;
+  duration_ms: number;
+  stdout: string;
+  stderr: string;
+  error_msg: string;
+  started_at: string;
+}
+
+export interface PluginInput {
+  name: string;
+  enabled: boolean;
+  command: string[];
+  events: string[];
+  env: Record<string, string>;
+  timeout_secs: number;
+  working_dir: string;
+}
+
+const BASE = "/api/v1/plugins";
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { "Content-Type": "application/json" };
+    init.body = JSON.stringify(body);
+  }
+  const res = await apiFetch(path, init);
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  let parsed: unknown;
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+  if (!res.ok) {
+    const env = parsed as { error?: { message?: string } } | undefined;
+    throw new Error(env?.error?.message ?? `${method} ${path} failed: ${res.status}`);
+  }
+  return parsed as T;
+}
+
+export function usePlugins() {
+  return useQuery({
+    queryKey: ["plugins"],
+    queryFn: () => request<Plugin[]>("GET", BASE),
+  });
+}
+
+export function usePluginEvents() {
+  return useQuery({
+    queryKey: ["plugin-events"],
+    queryFn: () => request<PluginEvent[]>("GET", `${BASE}/events`),
+    staleTime: 60 * 60 * 1000,
+  });
+}
+
+export function usePluginRuns(pluginId: string | null) {
+  return useQuery({
+    queryKey: ["plugin-runs", pluginId],
+    queryFn: () => request<PluginRun[]>("GET", `${BASE}/${pluginId}/runs?limit=50`),
+    enabled: !!pluginId,
+  });
+}
+
+export function useCreatePlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: PluginInput) => request<Plugin>("POST", BASE, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["plugins"] }),
+  });
+}
+
+export function useUpdatePlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: PluginInput }) =>
+      request<Plugin>("PUT", `${BASE}/${id}`, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["plugins"] }),
+  });
+}
+
+export function useDeletePlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => request<void>("DELETE", `${BASE}/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["plugins"] }),
+  });
+}
+
+export function useTestPlugin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => request<PluginRun>("POST", `${BASE}/${id}/test`),
+    onSuccess: (_data, id) => qc.invalidateQueries({ queryKey: ["plugin-runs", id] }),
+  });
+}

--- a/web/src/pages/plugins.tsx
+++ b/web/src/pages/plugins.tsx
@@ -1,0 +1,505 @@
+import * as React from "react";
+import { toast } from "sonner";
+import {
+  Puzzle,
+  Plus,
+  Play,
+  Trash2,
+  Pencil,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+import { useSetPageHeader } from "@/hooks/use-page-header";
+import { useFeatureEnabled } from "@/lib/features-api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  type Plugin,
+  type PluginInput,
+  type PluginRun,
+  usePlugins,
+  usePluginEvents,
+  usePluginRuns,
+  useCreatePlugin,
+  useUpdatePlugin,
+  useDeletePlugin,
+  useTestPlugin,
+} from "@/lib/plugins-api";
+
+const emptyForm: PluginInput = {
+  name: "",
+  enabled: false,
+  command: [],
+  events: [],
+  env: {},
+  timeout_secs: 30,
+  working_dir: "",
+};
+
+function toForm(p: Plugin): PluginInput {
+  return {
+    name: p.name,
+    enabled: p.enabled,
+    command: p.command,
+    events: p.events,
+    env: p.env ?? {},
+    timeout_secs: p.timeout_secs,
+    working_dir: p.working_dir,
+  };
+}
+
+// argv <-> single-line string. We split on whitespace; advise quoting-free args.
+function argvToText(argv: string[]): string {
+  return argv.join(" ");
+}
+function textToArgv(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+function envToText(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+}
+function textToEnv(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t || !t.includes("=")) continue;
+    const idx = t.indexOf("=");
+    out[t.slice(0, idx).trim()] = t.slice(idx + 1);
+  }
+  return out;
+}
+
+export function PluginsPage() {
+  useSetPageHeader("Plugins", "Run custom scripts when Loom events fire");
+  const enabled = useFeatureEnabled("plugins", false);
+  const { data: plugins, isLoading } = usePlugins();
+  const { data: events } = usePluginEvents();
+  const del = useDeletePlugin();
+  const test = useTestPlugin();
+
+  const [editing, setEditing] = React.useState<Plugin | null>(null);
+  const [creating, setCreating] = React.useState(false);
+  const [runsFor, setRunsFor] = React.useState<string | null>(null);
+
+  return (
+    <div className="space-y-6">
+      {!enabled && (
+        <Card className="border-amber-500/40 bg-amber-500/5">
+          <CardContent className="flex items-start gap-3 pt-6 text-sm">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+            <div>
+              <p className="font-medium">Plugins are disabled.</p>
+              <p className="text-muted-foreground">
+                Enable the “Plugins (Custom Scripts)” feature under Settings →
+                Features to let Loom run these scripts. You can still manage
+                definitions here.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card className="border-destructive/30 bg-destructive/5">
+        <CardContent className="flex items-start gap-3 pt-6 text-sm">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+          <div>
+            <p className="font-medium">Security notice</p>
+            <p className="text-muted-foreground">
+              Plugins run arbitrary commands as the Loom server process, with its
+              privileges and filesystem/network access. This is not an OS
+              sandbox. Only configure scripts you fully trust, and rely on
+              container/Kubernetes controls for real isolation.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {plugins?.length ?? 0} plugin{plugins?.length === 1 ? "" : "s"}{" "}
+          configured
+        </p>
+        <Button onClick={() => setCreating(true)} size="sm">
+          <Plus className="mr-1 h-4 w-4" /> Add Plugin
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-32 w-full" />
+      ) : !plugins || plugins.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-10 text-center text-muted-foreground">
+            <Puzzle className="h-8 w-8" />
+            <p>No plugins yet. Add one to run a script on grab/import/playback.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {plugins.map((p) => (
+            <Card key={p.id}>
+              <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+                <div className="space-y-1">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    {p.name}
+                    {p.enabled ? (
+                      <Badge variant="secondary">Enabled</Badge>
+                    ) : (
+                      <Badge variant="outline">Disabled</Badge>
+                    )}
+                  </CardTitle>
+                  <CardDescription className="font-mono text-xs break-all">
+                    {p.command.join(" ")}
+                  </CardDescription>
+                  <div className="flex flex-wrap gap-1 pt-1">
+                    {p.events.map((e) => (
+                      <Badge key={e} variant="outline" className="text-[10px]">
+                        {events?.find((d) => d.key === e)?.label ?? e}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() =>
+                      test.mutate(p.id, {
+                        onSuccess: (run) => {
+                          setRunsFor(p.id);
+                          toast[run.success ? "success" : "error"](
+                            run.success
+                              ? "Test run succeeded"
+                              : `Test run failed: ${run.error_msg || "exit " + run.exit_code}`,
+                          );
+                        },
+                        onError: (e) => toast.error(String(e)),
+                      })
+                    }
+                    disabled={test.isPending}
+                  >
+                    {test.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Play className="h-4 w-4" />
+                    )}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setRunsFor(p.id)}>
+                    History
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={() => setEditing(p)}>
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      if (confirm(`Delete plugin "${p.name}"?`)) {
+                        del.mutate(p.id, {
+                          onSuccess: () => toast.success("Plugin deleted"),
+                          onError: (e) => toast.error(String(e)),
+                        });
+                      }
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {(creating || editing) && (
+        <PluginDialog
+          plugin={editing}
+          events={events ?? []}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      {runsFor && (
+        <RunsDialog pluginId={runsFor} onClose={() => setRunsFor(null)} />
+      )}
+    </div>
+  );
+}
+
+function PluginDialog({
+  plugin,
+  events,
+  onClose,
+}: {
+  plugin: Plugin | null;
+  events: { key: string; label: string }[];
+  onClose: () => void;
+}) {
+  const create = useCreatePlugin();
+  const update = useUpdatePlugin();
+  const [form, setForm] = React.useState<PluginInput>(
+    plugin ? toForm(plugin) : emptyForm,
+  );
+  const [cmdText, setCmdText] = React.useState(
+    plugin ? argvToText(plugin.command) : "",
+  );
+  const [envText, setEnvText] = React.useState(
+    plugin ? envToText(plugin.env ?? {}) : "",
+  );
+
+  const toggleEvent = (key: string) =>
+    setForm((f) => ({
+      ...f,
+      events: f.events.includes(key)
+        ? f.events.filter((e) => e !== key)
+        : [...f.events, key],
+    }));
+
+  const submit = () => {
+    const input: PluginInput = {
+      ...form,
+      command: textToArgv(cmdText),
+      env: textToEnv(envText),
+    };
+    const opts = {
+      onSuccess: () => {
+        toast.success(plugin ? "Plugin updated" : "Plugin created");
+        onClose();
+      },
+      onError: (e: unknown) => toast.error(String(e)),
+    };
+    if (plugin) update.mutate({ id: plugin.id, input }, opts);
+    else create.mutate(input, opts);
+  };
+
+  const pending = create.isPending || update.isPending;
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{plugin ? "Edit Plugin" : "Add Plugin"}</DialogTitle>
+          <DialogDescription>
+            Loom passes the event payload as JSON on stdin and{" "}
+            <code>LOOM_*</code> environment variables. Exit 0 = success.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Name</Label>
+            <Input
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="My script"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Command</Label>
+            <Input
+              className="font-mono"
+              value={cmdText}
+              onChange={(e) => setCmdText(e.target.value)}
+              placeholder="/scripts/post-import.sh --verbose"
+            />
+            <p className="text-xs text-muted-foreground">
+              Executed directly (no shell). Space-separated arguments. Use an
+              absolute path.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Events</Label>
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {events.map((ev) => (
+                <label
+                  key={ev.key}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <Checkbox
+                    checked={form.events.includes(ev.key)}
+                    onCheckedChange={() => toggleEvent(ev.key)}
+                  />
+                  {ev.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>Timeout (seconds)</Label>
+              <Input
+                type="number"
+                min={1}
+                max={300}
+                value={form.timeout_secs}
+                onChange={(e) =>
+                  setForm({ ...form, timeout_secs: Number(e.target.value) })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Working directory</Label>
+              <Input
+                value={form.working_dir}
+                onChange={(e) =>
+                  setForm({ ...form, working_dir: e.target.value })
+                }
+                placeholder="/"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Environment variables (optional)</Label>
+            <textarea
+              className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm"
+              rows={3}
+              value={envText}
+              onChange={(e) => setEnvText(e.target.value)}
+              placeholder={"KEY=value\nANOTHER=value"}
+            />
+            <p className="text-xs text-muted-foreground">
+              One per line. The host environment is not inherited.{" "}
+              <code>LOOM_*</code> keys are reserved.
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border border-border p-3">
+            <div>
+              <Label>Enabled</Label>
+              <p className="text-xs text-muted-foreground">
+                Run this plugin when its events fire.
+              </p>
+            </div>
+            <Switch
+              checked={form.enabled}
+              onCheckedChange={(v) => setForm({ ...form, enabled: v })}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending}>
+            {pending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}
+            {plugin ? "Save" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RunsDialog({
+  pluginId,
+  onClose,
+}: {
+  pluginId: string;
+  onClose: () => void;
+}) {
+  const { data: runs, isLoading } = usePluginRuns(pluginId);
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Run History</DialogTitle>
+          <DialogDescription>Most recent executions first.</DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : !runs || runs.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No runs recorded yet.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {runs.map((r) => (
+              <RunRow key={r.id} run={r} />
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RunRow({ run }: { run: PluginRun }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="rounded-md border border-border p-3 text-sm">
+      <button
+        className="flex w-full items-center justify-between gap-2 text-left"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="flex items-center gap-2">
+          {run.success ? (
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          ) : (
+            <XCircle className="h-4 w-4 text-destructive" />
+          )}
+          <span className="font-mono text-xs">{run.topic}</span>
+          <span className="text-xs text-muted-foreground">
+            exit {run.exit_code} · {run.duration_ms}ms
+          </span>
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {new Date(run.started_at).toLocaleString()}
+        </span>
+      </button>
+      {run.error_msg && (
+        <p className="mt-1 text-xs text-destructive">{run.error_msg}</p>
+      )}
+      {open && (
+        <div className="mt-2 space-y-2">
+          {run.stdout && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">stdout</p>
+              <pre className="max-h-48 overflow-auto rounded bg-muted p-2 text-[11px]">
+                {run.stdout}
+              </pre>
+            </div>
+          )}
+          {run.stderr && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground">stderr</p>
+              <pre className="max-h-48 overflow-auto rounded bg-muted p-2 text-[11px]">
+                {run.stderr}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -282,6 +282,11 @@ const settingsRequestBotsRoute = settingsChild(
   () => import("@/pages/request-bots"),
   "RequestBotsPage",
 );
+const settingsPluginsRoute = settingsChild(
+  "plugins",
+  () => import("@/pages/plugins"),
+  "PluginsPage",
+);
 const settingsConnectRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: "connect",
@@ -414,6 +419,7 @@ const routeTree = rootRoute.addChildren([
     settingsSearchQueueRoute,
     settingsNotificationsRoute,
     settingsRequestBotsRoute,
+    settingsPluginsRoute,
     settingsConnectRoute,
     settingsSyncProfilesRoute,
     settingsHealthRoute,


### PR DESCRIPTION
Implements issue #12 — an extensibility layer that runs admin-defined scripts when domain events fire. The Loom equivalent of Sonarr/Radarr custom scripts.

## Checklist (#12)
- [x] Plugin SDK / interface for third-party extensions
- [x] Custom post-processing scripts on import/grab/notification events
- [x] Sandboxing & failure isolation
- [x] Docs + example plugin

## SDK contract
A plugin is an admin-configured executable. Loom invokes it (no shell) on subscribed events, passing the event payload as JSON on **stdin** plus fixed `LOOM_*` env vars. Exit 0 = success; output is captured (size-capped) into per-plugin **run history**. Supported events: grab, download complete/failed, import complete/failed, playback started/stopped.

## Failure isolation & resource bounding
This is **not** an OS sandbox (documented honestly in-app and in docs). Plugins run as the server process. What Loom provides:
- subprocess per run; wall-clock **timeout** (default 30s, max 300s) with **process-group SIGKILL** + `WaitDelay` so shutdown can't hang on a hostile child;
- host environment **not inherited** (no secret leakage) — only a minimal PATH, the plugin's own env, and `LOOM_*`;
- stdout/stderr **caps** (64 KiB each) with non-blocking drain;
- bounded **worker pool decoupled from the event bus** (the bus handler only builds a payload and enqueues — no DB/exec on bus goroutines);
- **panic recovery**; idempotent **drain-then-kill** `Stop()` with safe producer/consumer channel-close coordination.

Opt-in **`plugins` feature flag** (default OFF) gates execution; every endpoint is **admin-only**.

## Surface
- `internal/plugins` (types, sqlite store w/ migration 0067 + per-plugin & age retention, runner, admin router); featureflags `KeyPlugins`; server route + serve lifecycle.
- Frontend **Settings → Plugins** admin page: CRUD, event checkboxes, env/timeout/working-dir, enable toggle, **test run**, run-history viewer, security notice.
- `docs/plugins.md` + `examples/plugins/post-import.sh`.

## Tests (race-clean)
store CRUD/validation (reserved `LOOM_*` env rejected, timeout capped, unknown event rejected), stdin payload echo, timeout kill, **env isolation** (host secret not visible), output cap, **event-driven execution** end-to-end via the bus, disabled-flag skip, **idempotent Stop under concurrent publishes**, unmapped-topic ignored. `go build`/`vet` (CGO=0), plugins/storage/featureflags tests (CGO=1, `-race`), and `web build` all green.

## Notes
sqlite-only migration (deployment uses sqlite), consistent with recent features. Deploy is held pending VPN.

Closes #12.