### PR TITLE
ci: gate cross-OS tests to releases; run day-to-day CI on self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  # Custom labels exposed by our ARC (actions-runner-controller) RunnerDeployment
+  # in the homelab Kubernetes cluster. Listed here so actionlint doesn't flag
+  # `runs-on: arc-runners` as an unknown label.
+  labels:
+    - arc-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -20,12 +21,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [arc-runners, macos-latest, windows-latest]
+        # Day-to-day CI (push/PR) runs ONLY on the self-hosted Kubernetes
+        # runners — zero GitHub-hosted minutes. The macOS/Windows legs that
+        # validate the published cross-platform binaries are gated to release
+        # tags (v*), so they don't burn hosted minutes on every push.
+        #
+        # Later, to run cross-OS tests on your OWN machines: register them as
+        # self-hosted runners and swap "macos-latest"/"windows-latest" below for
+        # your runner labels. To run them on every push too, move those labels
+        # into the base list (the `|| fromJSON('["arc-runners"]')` branch).
+        os: ${{ github.ref_type == 'tag' && fromJSON('["arc-runners", "macos-latest", "windows-latest"]') || fromJSON('["arc-runners"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
           cache: true
       - run: go mod download
       - run: go vet ./...
@@ -43,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
           cache: true
       - uses: golangci/golangci-lint-action@v6
         with:
@@ -56,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
@@ -85,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
           cache: true
       - run: go build -trimpath -ldflags="-s -w" -o /tmp/loom ./cmd/loom
 


### PR DESCRIPTION
## Problem
The CI `go` job matrix was `[arc-runners, macos-latest, windows-latest]`, so the **macOS (10×) and Windows (2×) hosted runners ran on every push/PR** — the main driver exhausting the 2000-minute GitHub-hosted budget.

## Change
- **Day-to-day CI (push/PR) now runs only on the self-hosted `arc-runners`** → zero hosted minutes.
- **Cross-OS test legs (macOS/Windows) are gated to release tags (`v*`)** via a dynamic matrix, so they still validate the published cross-platform binaries right before they ship.
- Added a `tags: ["v*"]` trigger so the gated matrix fires on releases.
- Structured so you can later point the cross-OS legs at **your own macOS/Windows machines** (registered as self-hosted runners) with a one-line label swap.
- Aligned `setup-go` to **1.26** (matches `go.mod`; avoids per-step toolchain auto-download).
- Added `.github/actionlint.yaml` registering the custom `arc-runners` label.

Cross-OS **compile** coverage still runs on every push via the existing cross-compile build matrix (GOOS darwin/windows/freebsd on Linux runners).

## Companion infra fix (already applied to the cluster, not in this repo)
The self-hosted runner wasn't producing pods due to two issues, now fixed live:
1. **PodSecurity** blocked the privileged docker-in-docker sidecar → labeled the runner namespace `pod-security.kubernetes.io/enforce=privileged`.
2. The RunnerDeployment had **no labels** → added the `arc-runners` label so `runs-on: arc-runners` matches. Also scaled to 2 replicas.

## Validation
- `actionlint` clean across all workflows (with the new label config).
- YAML parses; dynamic-matrix expression validated by actionlint.