### PR TITLE
fix(torrent): keep magnet adds queued when metadata is slow

### DIFF
--- a/internal/downloads/torrent/client_test.go
+++ b/internal/downloads/torrent/client_test.go
@@ -141,8 +141,8 @@ func TestAdd_TorrentURLInfohashMismatchRejected(t *testing.T) {
 }
 
 // When the .torrent fetch fails and an explicit tracker-bearing magnet
-// is available, Add falls back to the magnet. The transformed error
-// (metadata timeout from AddMagnet, not the HTTP 404) proves fallback.
+// is available, Add falls back to the magnet. Even if metadata is not
+// yet available, the add should succeed and keep the torrent queued.
 func TestAdd_FallsBackToExplicitMagnet(t *testing.T) {
 	t.Parallel()
 	cl := newAddTestClient(t)
@@ -157,13 +157,16 @@ func TestAdd_FallsBackToExplicitMagnet(t *testing.T) {
 
 	magnet := "magnet:?xt=urn:btih:" + strings.Repeat("b", 40) +
 		"&tr=udp%3A%2F%2Ftracker.invalid%3A1337%2Fannounce"
-	_, err := cl.Add(ctx, downloads.AddRequest{
+	res, err := cl.Add(ctx, downloads.AddRequest{
 		Title:      "x",
 		Magnet:     magnet, // explicit, has trackers
 		TorrentURL: srv.URL + "/x.torrent",
 	})
-	if !errors.Is(err, ErrMetadataTimeout) {
-		t.Errorf("error = %v, want ErrMetadataTimeout (proving magnet fallback)", err)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if res.ItemID != strings.Repeat("b", 40) {
+		t.Errorf("ItemID = %q, want %q", res.ItemID, strings.Repeat("b", 40))
 	}
 }
 

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -342,16 +342,20 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 	// Wait for metadata with a timeout. Use the engine's lifecycle context
 	// rather than the caller's context so that a short-lived HTTP request
 	// context being cancelled (e.g. client disconnect, write timeout) does
-	// not abort metadata resolution mid-flight and leave the torrent in a
-	// broken state.
+	// not abort metadata resolution mid-flight.
 	waitCtx, waitCancel := context.WithTimeout(e.lifecycleCtx(), metadataTimeout)
 	defer waitCancel()
 
 	select {
 	case <-t.GotInfo():
 	case <-waitCtx.Done():
-		t.Drop()
-		return "", fmt.Errorf("%w: %w", ErrMetadataTimeout, waitCtx.Err())
+		// Do not fail the add when metadata is slow. Keep the torrent in the
+		// engine and let metadata continue resolving asynchronously; status()
+		// reports it as queued while Info() is still nil.
+		e.logger.Warn("magnet metadata not yet available; keeping torrent queued",
+			"error", waitCtx.Err(),
+			"timeout", metadataTimeout,
+		)
 	}
 
 	hash := strings.ToLower(t.InfoHash().HexString())
@@ -371,7 +375,19 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 	}
 	e.mu.Unlock()
 
-	t.DownloadAll()
+	if t.Info() != nil {
+		t.DownloadAll()
+	} else {
+		// Metadata was not available within metadataTimeout. Start the
+		// download as soon as metainfo arrives.
+		go func(t *torrent.Torrent) {
+			select {
+			case <-t.GotInfo():
+				t.DownloadAll()
+			case <-e.lifecycleCtx().Done():
+			}
+		}(t)
+	}
 
 	e.logger.Info("magnet added",
 		"hash", hash,


### PR DESCRIPTION
## Summary
- keep magnet-based add requests queued when metadata has not resolved within the initial timeout
- avoid dropping the torrent and returning an error in this case
- only call DownloadAll after metadata exists; if still pending, wait asynchronously and start download when info arrives
- update torrent client tests to assert successful fallback-to-magnet behavior

## Why
Some torrents still failed with:
"builtin/torrent: metadata resolution timed out: context deadline exceeded"

That happened when magnet metadata discovery was slower than the timeout window. Failing the add in that state is too strict: the torrent can still resolve shortly after and should remain queued.

## Validation
- go test ./internal/downloads/torrent/...
