### PR TITLE
fix(indexers): fetch torrent URLs through live indexers

### DIFF
--- a/internal/autosearch/engine.go
+++ b/internal/autosearch/engine.go
@@ -1242,6 +1242,22 @@ func (e *Engine) grabRelease(ctx context.Context, sr *ScoredRelease) (*GrabbedRe
 	// Build the download request.
 	req := buildDownloadRequest(&sr.Result)
 
+	// If the indexer exposed a direct .torrent URL, fetch it through the
+	// live indexer client first so tracker auth cookies, per-indexer
+	// proxies, and anti-bot headers are preserved.
+	if e.indexerSvc != nil && sr.Result.IndexerID != "" && req.TorrentURL != "" {
+		if data, err := e.indexerSvc.FetchDownload(ctx, sr.Result.IndexerID, req.TorrentURL); err == nil {
+			req.RawBytes = data
+		} else {
+			e.logger.Warn("autosearch: indexer-backed torrent fetch failed; falling back to direct URL/magnet",
+				"indexer_id", sr.Result.IndexerID,
+				"title", sr.Result.Title,
+				"url", req.TorrentURL,
+				"error", err,
+			)
+		}
+	}
+
 	// Apply per-indexer seed policy overrides if available.
 	if sr.Result.IndexerID != "" {
 		if def, err := e.indexerSvc.Get(ctx, sr.Result.IndexerID); err == nil {

--- a/internal/downloads/router.go
+++ b/internal/downloads/router.go
@@ -17,6 +17,11 @@ import (
 // without importing the indexers.Service directly (avoiding cycles).
 type IndexerConfigLookup func(ctx context.Context, id string) (indexers.Definition, error)
 
+// IndexerDownloadFetch retrieves a release download URL through the live
+// indexer client so tracker auth cookies, per-indexer proxies, and
+// anti-bot headers are preserved.
+type IndexerDownloadFetch func(ctx context.Context, id, rawURL string) ([]byte, error)
+
 // Router is a service that listens for indexer search results and routes
 // them to configured download clients. It decouples the indexer intake
 // pipeline from downloads, allowing each to run independently and recover
@@ -34,6 +39,7 @@ type Router struct {
 	clock          Clock
 	metadataRouter *metadata.Router
 	indexerLookup  IndexerConfigLookup
+	indexerFetch   IndexerDownloadFetch
 
 	// unsubscribe is the function returned by Subscribe; stored so
 	// we can clean up on shutdown if needed.
@@ -42,9 +48,10 @@ type Router struct {
 
 // NewRouter wires a Router to a downloads Service, metadata Router, and event bus.
 // It immediately subscribes to indexer results but does not block.
-// The optional indexerLookup, when non-nil, enables per-indexer seed
-// policy overrides on grabs.
-func NewRouter(svc *Service, metadataRouter *metadata.Router, bus eventbus.Bus, logger *slog.Logger, clock Clock, indexerLookup IndexerConfigLookup) *Router {
+// The optional indexerLookup enables per-indexer seed policy overrides;
+// indexerFetch enables authenticated/proxied .torrent downloads through
+// the live indexer client.
+func NewRouter(svc *Service, metadataRouter *metadata.Router, bus eventbus.Bus, logger *slog.Logger, clock Clock, indexerLookup IndexerConfigLookup, indexerFetch IndexerDownloadFetch) *Router {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -58,6 +65,7 @@ func NewRouter(svc *Service, metadataRouter *metadata.Router, bus eventbus.Bus, 
 		logger:         logger.With("module", "downloads/router"),
 		clock:          clock,
 		indexerLookup:  indexerLookup,
+		indexerFetch:   indexerFetch,
 	}
 
 	// Subscribe to indexer results. The handler runs synchronously in
@@ -132,6 +140,18 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 	var addErr error
 	for _, client := range clients {
 		req := buildAddRequest(result)
+		if r.indexerFetch != nil && result.IndexerID != "" && req.TorrentURL != "" {
+			if data, fetchErr := r.indexerFetch(ctx, result.IndexerID, req.TorrentURL); fetchErr == nil {
+				req.RawBytes = data
+			} else {
+				r.logger.Warn("router: indexer-backed torrent fetch failed; falling back to direct URL/magnet",
+					"indexer_id", result.IndexerID,
+					"title", result.Title,
+					"url", req.TorrentURL,
+					"error", fetchErr,
+				)
+			}
+		}
 		// Apply per-indexer seed policy overrides when available.
 		if r.indexerLookup != nil && result.IndexerID != "" {
 			if def, lookupErr := r.indexerLookup(ctx, result.IndexerID); lookupErr == nil {

--- a/internal/downloads/router_test.go
+++ b/internal/downloads/router_test.go
@@ -52,7 +52,7 @@ func newTestRouter(t *testing.T, bus eventbus.Bus) (*Router, *testClock) {
 	var metadataRouter *metadata.Router
 
 	clock := &testClock{now: time.Now()}
-	router := NewRouter(svc, metadataRouter, bus, slog.Default(), clock, nil)
+	router := NewRouter(svc, metadataRouter, bus, slog.Default(), clock, nil, nil)
 	return router, clock
 }
 

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -513,6 +513,7 @@ func (e *Engine) Status(hashes ...string) []TorrentStatus {
 // EngineSummary aggregates the engine's live state for the management UI.
 type EngineSummary struct {
 	TotalTorrents int
+	Queued        int
 	Downloading   int
 	Seeding       int
 	Paused        int
@@ -548,11 +549,13 @@ func (e *Engine) Summary() EngineSummary {
 		sum.DownloadRate += s.DownloadRate
 		sum.UploadRate += s.UploadRate
 		switch s.Status {
+		case "queued":
+			sum.Queued++
 		case "paused":
 			sum.Paused++
 		case "seeding":
 			sum.Seeding++
-		default:
+		case "downloading":
 			sum.Downloading++
 		}
 	}

--- a/internal/indexers/cardigann/engine.go
+++ b/internal/indexers/cardigann/engine.go
@@ -173,6 +173,22 @@ func (e *Engine) Test(ctx context.Context) error {
 	return nil
 }
 
+// FetchDownload implements indexers.DownloadFetcher. It reuses the
+// engine's logged-in HTTP client so tracker auth cookies, proxy routing,
+// and anti-bot headers are preserved for .torrent downloads.
+func (e *Engine) FetchDownload(ctx context.Context, rawURL string) ([]byte, error) {
+	if err := e.ensureLoggedIn(ctx); err != nil {
+		return nil, err
+	}
+	fullURL, err := e.resolveURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	headers := http.Header{}
+	headers.Set("Accept", "application/x-bittorrent, application/octet-stream, */*")
+	return e.fetch(ctx, http.MethodGet, fullURL, nil, headers)
+}
+
 // configFieldsWithDefaults merges operator-supplied config fields with
 // default values from the YAML definition's settings block. Operator
 // values always win; defaults fill gaps so templates like

--- a/internal/indexers/health_test.go
+++ b/internal/indexers/health_test.go
@@ -61,6 +61,33 @@ func TestHealthCheckerRunsAcrossRegistry(t *testing.T) {
 	}
 }
 
+func TestServiceFetchDownloadUsesLiveIndexer(t *testing.T) {
+	t.Parallel()
+
+	_, raw := openTestDB(t)
+	repo := indexers.NewSQLiteRepository(raw)
+	svc, err := indexers.NewService(indexers.ServiceOptions{
+		Repository: repo,
+		Logger:     quietLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	ix := &fakeIndexer{id: "dl", name: "dl", download: []byte("torrent-bytes")}
+	if err := svc.Registry().Replace(ix); err != nil {
+		t.Fatalf("register indexer: %v", err)
+	}
+
+	got, err := svc.FetchDownload(context.Background(), "dl", "https://tracker.example/release.torrent")
+	if err != nil {
+		t.Fatalf("FetchDownload: %v", err)
+	}
+	if string(got) != "torrent-bytes" {
+		t.Fatalf("FetchDownload bytes = %q, want %q", string(got), "torrent-bytes")
+	}
+}
+
 // failingIndexer always errors from Test() so we can verify failure
 // paths persist a "failed" status.
 type failingIndexer struct{ id string }

--- a/internal/indexers/newznab/client.go
+++ b/internal/indexers/newznab/client.go
@@ -133,6 +133,42 @@ func (c *Client) Test(ctx context.Context) error {
 	return err
 }
 
+// FetchDownload implements indexers.DownloadFetcher. It retrieves a release
+// URL through the indexer's configured HTTP client so proxy settings and
+// request headers match normal search traffic.
+func (c *Client) FetchDownload(ctx context.Context, fullURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("newznab build download request: %w", err)
+	}
+	req.Header.Set("User-Agent", c.cfg.UserAgent)
+	req.Header.Set("Accept", "application/x-bittorrent, application/octet-stream, */*")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w: %s", ErrTimeout, err.Error())
+		}
+		return nil, fmt.Errorf("%w: %s", ErrUpstream, err.Error())
+	}
+	defer resp.Body.Close()
+
+	body, rerr := io.ReadAll(resp.Body)
+	if rerr != nil {
+		return nil, fmt.Errorf("%w: read download body: %s", ErrUpstream, rerr.Error())
+	}
+	if looksLikeCloudFlare(resp, body) {
+		return nil, fmt.Errorf("%w: status %d", ErrCloudFlare, resp.StatusCode)
+	}
+	if err := classifyHTTP(resp, body); err != nil {
+		return nil, err
+	}
+	if upstream := decodeUpstreamError(body); upstream != nil {
+		return nil, upstream
+	}
+	return body, nil
+}
+
 // fetchAndStoreCaps drives the caps round-trip end-to-end: HTTP GET,
 // parse, in-memory cache, optional DB persist.
 func (c *Client) fetchAndStoreCaps(ctx context.Context) (indexers.Caps, error) {

--- a/internal/indexers/registry_test.go
+++ b/internal/indexers/registry_test.go
@@ -22,6 +22,8 @@ type fakeIndexer struct {
 	results   []indexers.Result
 	searchErr error
 	testErr   error
+	download  []byte
+	downErr   error
 	calls     atomic.Int32
 }
 
@@ -51,6 +53,20 @@ func (f *fakeIndexer) Test(ctx context.Context) error {
 		}
 	}
 	return f.testErr
+}
+
+func (f *fakeIndexer) FetchDownload(ctx context.Context, _ string) ([]byte, error) {
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.downErr != nil {
+		return nil, f.downErr
+	}
+	return append([]byte(nil), f.download...), nil
 }
 
 func TestRegistryConcurrentRegisterGet(t *testing.T) {

--- a/internal/indexers/service.go
+++ b/internal/indexers/service.go
@@ -247,6 +247,22 @@ func (s *Service) Get(ctx context.Context, id string) (Definition, error) {
 	return s.repo.Get(ctx, id)
 }
 
+// FetchDownload retrieves a release download URL through the live indexer
+// instance so tracker cookies, custom headers, and per-indexer proxies are
+// preserved. It returns an error when the indexer is missing or does not
+// implement DownloadFetcher.
+func (s *Service) FetchDownload(ctx context.Context, id, rawURL string) ([]byte, error) {
+	ix, ok := s.registry.Get(id)
+	if !ok {
+		return nil, fmt.Errorf("indexer %q not found", id)
+	}
+	df, ok := ix.(DownloadFetcher)
+	if !ok {
+		return nil, fmt.Errorf("indexer %q does not support authenticated downloads", id)
+	}
+	return df.FetchDownload(ctx, rawURL)
+}
+
 // List returns every persisted Definition with health and rate-limit
 // attached.
 func (s *Service) List(ctx context.Context) ([]DefinitionWithHealth, error) {

--- a/internal/indexers/types.go
+++ b/internal/indexers/types.go
@@ -277,6 +277,15 @@ type Indexer interface {
 	Test(ctx context.Context) error
 }
 
+// DownloadFetcher is an optional capability implemented by indexers that
+// can fetch a release download URL (for example a .torrent link) through
+// the same authenticated/proxied HTTP client they use for Search. This
+// lets downstream consumers reuse tracker cookies, per-indexer proxies,
+// and anti-bot headers instead of making an unauthenticated direct fetch.
+type DownloadFetcher interface {
+	FetchDownload(ctx context.Context, rawURL string) ([]byte, error)
+}
+
 // Definition is the persisted shape of an indexer row. It is the
 // hand-off between Repository and the rest of the package — sqlc
 // produces engine-specific types (different column kinds for booleans

--- a/web/src/lib/downloads-api.ts
+++ b/web/src/lib/downloads-api.ts
@@ -275,6 +275,7 @@ export async function grabRelease(
 
 export interface TorrentEngineSummary {
   total_torrents: number;
+  queued: number;
   downloading: number;
   seeding: number;
   paused: number;

--- a/web/src/pages/downloads.tsx
+++ b/web/src/pages/downloads.tsx
@@ -1014,8 +1014,9 @@ function TorrentEnginePanel() {
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4 lg:grid-cols-6">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4 lg:grid-cols-7">
           <StatPill label="Torrents" value={summary?.total_torrents ?? "—"} />
+          <StatPill label="Queued" value={summary?.queued ?? "—"} />
           <StatPill label="Downloading" value={summary?.downloading ?? "—"} />
           <StatPill label="Seeding" value={summary?.seeding ?? "—"} />
           <StatPill label="Paused" value={summary?.paused ?? "—"} />


### PR DESCRIPTION
## Summary
- add an optional live-indexer download fetch capability for authenticated/proxied release URL downloads
- use that capability before torrent adds so fetchable .torrent links are downloaded through the indexer client instead of a raw unauthenticated HTTP client
- keep the downloads summary honest by counting queued torrents separately from active downloads

## Why
Some grabs were reaching the built-in torrent client with a valid torrent URL, but the direct fetch path could still fail because it bypassed tracker cookies, per-indexer proxies, and anti-bot headers. That forced a fallback to magnet resolution, leaving downloads stuck queued at 0% with no metadata.

## Validation
- go test ./internal/indexers/... ./internal/autosearch ./internal/downloads/...
- go test ./...
