### PR TITLE
fix(imports): stop retry loop for unresolved infohash paths

### DIFF
--- a/internal/imports/pipeline.go
+++ b/internal/imports/pipeline.go
@@ -264,7 +264,11 @@ func (p *ImportPipeline) resolveDownloadPath(ctx context.Context, ev *downloads.
 			// Prefer ContentPath (actual on-disk location set by the
 			// download client) over the SavePath+Title heuristic.
 			if item.ContentPath != "" {
-				return p.applyRemotePathMapping(ctx, ev.ClientID, item.ContentPath), nil
+				path := p.applyRemotePathMapping(ctx, ev.ClientID, item.ContentPath)
+				if isUnresolvedContentPath(path) {
+					return "", fmt.Errorf("download metadata not resolved yet: unresolved content path %q", path)
+				}
+				return path, nil
 			}
 			if item.SavePath != "" {
 				path := filepath.Join(item.SavePath, item.Title)
@@ -279,7 +283,11 @@ func (p *ImportPipeline) resolveDownloadPath(ctx context.Context, ev *downloads.
 	if p.wfEngine != nil {
 		if wf, err := p.wfEngine.FindByDownload(ctx, ev.ClientID, ev.DownloadID); err == nil && wf != nil {
 			if cached := metadataString(wf.Metadata, "content_path"); cached != "" {
-				return p.applyRemotePathMapping(ctx, ev.ClientID, cached), nil
+				path := p.applyRemotePathMapping(ctx, ev.ClientID, cached)
+				if isUnresolvedContentPath(path) {
+					return "", fmt.Errorf("download metadata not resolved yet: unresolved content path %q", path)
+				}
+				return path, nil
 			}
 			if sp := metadataString(wf.Metadata, "save_path"); sp != "" {
 				path := filepath.Join(sp, ev.Title)
@@ -309,6 +317,11 @@ func (p *ImportPipeline) applyRemotePathMapping(ctx context.Context, clientID, p
 		return path
 	}
 	return p.remotePathStore.MapPath(ctx, clientID, path)
+}
+
+func isUnresolvedContentPath(path string) bool {
+	p := strings.ToLower(filepath.ToSlash(strings.TrimSpace(path)))
+	return strings.Contains(p, "/infohash:")
 }
 
 // processImport runs the full import pipeline for a single download.

--- a/internal/workflows/orchestrator.go
+++ b/internal/workflows/orchestrator.go
@@ -603,6 +603,7 @@ func (o *Orchestrator) classifyImportError(errMsg string) importRetryStrategy {
 		"permission denied", "access denied", "unauthorized",
 		"already been imported", "already imported",
 		"import rejected",
+		"metadata not resolved yet", "unresolved content path",
 	} {
 		if strings.Contains(lower, s) {
 			return failPermanent

--- a/internal/workflows/orchestrator_test.go
+++ b/internal/workflows/orchestrator_test.go
@@ -372,6 +372,14 @@ func TestOrchestratorImportFailure(t *testing.T) {
 	}
 }
 
+func TestClassifyImportError_MetadataNotResolvedIsPermanent(t *testing.T) {
+	orch := &Orchestrator{}
+	got := orch.classifyImportError(`download metadata not resolved yet: unresolved content path "/media/downloads/infohash:abc"`)
+	if got != failPermanent {
+		t.Fatalf("expected failPermanent, got %v", got)
+	}
+}
+
 func TestOrchestratorCancel(t *testing.T) {
 	imp := &mockImporter{paths: []string{"/media/movie.mkv"}}
 	orch, store := testOrchestrator(t, imp)


### PR DESCRIPTION
## What this fixes

Import failures were repeatedly retried for queued torrents whose  was still the placeholder .

That path is not a real filesystem path, so imports failed with , and the orchestrator classified it as transient and retried forever.

## Changes

- In import path resolution, detect unresolved  content paths and return a specific  error.
- In workflow error classification, treat that error as **permanent** (non-retriable) to stop the retry loop.
- Added test coverage for this classification.
