### PR TITLE
fix(torrent): improve infohash grabs and search IDs

### DIFF
--- a/internal/autosearch/engine.go
+++ b/internal/autosearch/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ebenderooock/loom/internal/auditlog"
 	"github.com/ebenderooock/loom/internal/customformats"
 	"github.com/ebenderooock/loom/internal/downloads"
+	torrentdl "github.com/ebenderooock/loom/internal/downloads/torrent"
 	"github.com/ebenderooock/loom/internal/indexers"
 	"github.com/ebenderooock/loom/internal/movies"
 	"github.com/ebenderooock/loom/internal/parser"
@@ -1329,18 +1330,7 @@ func buildDownloadRequest(res *indexers.Result) downloads.AddRequest {
 	if res.MagnetURI != "" {
 		req.Magnet = res.MagnetURI
 	} else if res.Infohash != "" {
-		// Construct a magnet URI with well-known public trackers so that
-		// infohash-only results (e.g. TPB via apibay.org) can find peers
-		// via tracker announces instead of relying solely on DHT.
-		req.Magnet = fmt.Sprintf(
-			"magnet:?xt=urn:btih:%s"+
-				"&tr=udp://tracker.opentrackr.org:1337/announce"+
-				"&tr=udp://open.demonii.com:1337/announce"+
-				"&tr=udp://open.tracker.cl:1337/announce"+
-				"&tr=udp://tracker.torrent.eu.org:451/announce"+
-				"&tr=udp://9.rarbg.to:2720/announce",
-			res.Infohash,
-		)
+		req.Magnet = torrentdl.BuildPublicMagnet(res.Infohash, res.Title)
 	}
 	if res.Link != "" {
 		// Some indexers (e.g. EZTV) store the magnet URI in the Link field

--- a/internal/autosearch/engine.go
+++ b/internal/autosearch/engine.go
@@ -258,6 +258,7 @@ func (e *Engine) SearchAndGrab(ctx context.Context, req SearchRequest) (*SearchR
 	if req.SearchRunID == "" {
 		req.SearchRunID = searchdebug.NewID()
 	}
+	req = e.enrichSearchRequest(ctx, req)
 
 	// Sonarr-style fallback for season/series searches.
 	if (req.MediaType == "series" || req.MediaType == "episode") && e.seriesSvc != nil && req.Episode == 0 {
@@ -265,6 +266,101 @@ func (e *Engine) SearchAndGrab(ctx context.Context, req SearchRequest) (*SearchR
 	}
 
 	return e.searchAndGrabSingle(ctx, req)
+}
+
+func (e *Engine) enrichSearchRequest(ctx context.Context, req SearchRequest) SearchRequest {
+	switch req.MediaType {
+	case "movie":
+		if e.movieSvc != nil && req.MediaID != "" {
+			if m, err := e.movieSvc.GetMovie(ctx, req.MediaID); err == nil && m != nil {
+				if req.Title == "" {
+					req.Title = m.Title
+				}
+				if req.Year == 0 {
+					req.Year = m.Year
+				}
+				if req.IMDBID == "" && m.IMDBID != nil {
+					req.IMDBID = strings.TrimSpace(*m.IMDBID)
+				}
+				if req.TMDBID == "" && m.TMDBID != nil {
+					req.TMDBID = strings.TrimSpace(*m.TMDBID)
+				}
+			}
+		}
+	case "series", "episode":
+		if e.seriesSvc == nil {
+			return req
+		}
+		var tmdbForLookup string
+		if req.MediaID != "" {
+			if s, err := e.seriesSvc.GetSeries(ctx, req.MediaID); err == nil && s != nil {
+				if req.Title == "" {
+					req.Title = s.Title
+				}
+				if req.Year == 0 {
+					req.Year = s.Year
+				}
+				if req.IMDBID == "" && s.IMDBID != nil {
+					req.IMDBID = strings.TrimSpace(*s.IMDBID)
+				}
+				if req.TVDBID == "" && s.TVDBID != nil {
+					req.TVDBID = strings.TrimSpace(*s.TVDBID)
+				}
+				if req.TMDBID == "" && s.TMDBID != nil {
+					req.TMDBID = strings.TrimSpace(*s.TMDBID)
+				}
+			}
+		}
+		if req.TMDBID != "" {
+			tmdbForLookup = req.TMDBID
+		}
+		if (req.IMDBID == "" || req.TVDBID == "") && tmdbForLookup != "" {
+			if details, err := e.seriesSvc.LookupTMDB(ctx, tmdbForLookup); err == nil {
+				if req.IMDBID == "" {
+					req.IMDBID = tmdbExternalIMDbID(details)
+				}
+				if req.TVDBID == "" {
+					req.TVDBID = tmdbExternalTVDBID(details)
+				}
+			}
+		}
+	}
+	return req
+}
+
+func tmdbExternalIMDbID(details map[string]interface{}) string {
+	extIDs, ok := details["external_ids"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if v, ok := extIDs["imdb_id"].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+func tmdbExternalTVDBID(details map[string]interface{}) string {
+	extIDs, ok := details["external_ids"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	switch v := extIDs["tvdb_id"].(type) {
+	case float64:
+		if v > 0 {
+			return fmt.Sprintf("%.0f", v)
+		}
+	case int:
+		if v > 0 {
+			return fmt.Sprintf("%d", v)
+		}
+	case int64:
+		if v > 0 {
+			return fmt.Sprintf("%d", v)
+		}
+	case string:
+		return strings.TrimSpace(v)
+	}
+	return ""
 }
 
 // searchSeriesFallback implements Sonarr-style search: try season pack first,

--- a/internal/autosearch/engine_test.go
+++ b/internal/autosearch/engine_test.go
@@ -3,6 +3,7 @@ package autosearch
 import (
 	"io"
 	"log/slog"
+	"net/url"
 	"testing"
 
 	"github.com/ebenderooock/loom/internal/customformats"
@@ -308,6 +309,27 @@ func TestInferProtocol(t *testing.T) {
 				t.Errorf("inferProtocol() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildDownloadRequest_InfohashUsesTrackerRichMagnet(t *testing.T) {
+	req := buildDownloadRequest(&indexers.Result{
+		Title:    "Off Campus S01E02 The Practice 1080p AMZN WEB-DL DDP5 1 H 264-FLUX",
+		Infohash: "4ADB30F0BCB29FD663F60E7E4EBC38A3611C4CB3",
+	})
+	if req.Magnet == "" {
+		t.Fatal("expected magnet built from infohash")
+	}
+	u, err := url.Parse(req.Magnet)
+	if err != nil {
+		t.Fatalf("parse magnet: %v", err)
+	}
+	q := u.Query()
+	if got := q.Get("dn"); got != "Off Campus S01E02 The Practice 1080p AMZN WEB-DL DDP5 1 H 264-FLUX" {
+		t.Fatalf("dn = %q", got)
+	}
+	if got := len(q["tr"]); got < 10 {
+		t.Fatalf("tracker count = %d, want >= 10", got)
 	}
 }
 

--- a/internal/autosearch/engine_test.go
+++ b/internal/autosearch/engine_test.go
@@ -333,6 +333,21 @@ func TestBuildDownloadRequest_InfohashUsesTrackerRichMagnet(t *testing.T) {
 	}
 }
 
+func TestTMDBExternalIDs(t *testing.T) {
+	details := map[string]interface{}{
+		"external_ids": map[string]interface{}{
+			"imdb_id": "tt33546863",
+			"tvdb_id": 455086.0,
+		},
+	}
+	if got := tmdbExternalIMDbID(details); got != "tt33546863" {
+		t.Fatalf("tmdbExternalIMDbID = %q", got)
+	}
+	if got := tmdbExternalTVDBID(details); got != "455086" {
+		t.Fatalf("tmdbExternalTVDBID = %q", got)
+	}
+}
+
 func TestEvaluateResult_QualityFiltering(t *testing.T) {
 	defs := []*movies.QualityDefinition{
 		{ID: "bluray-1080", Name: "Bluray-1080p", Source: "bluray", Resolution: "1080p"},

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -22,9 +22,16 @@ import (
 )
 
 // metadataTimeout is how long we wait for a magnet's metadata to
-// resolve before giving up. Sixty seconds tolerates slow swarms and
+// resolve during the initial Add. Sixty seconds tolerates slow swarms and
 // cold trackers while still failing in a reasonable time.
 const metadataTimeout = 60 * time.Second
+
+// queuedMetadataTimeout is the maximum time a torrent may remain queued
+// waiting for metadata to resolve asynchronously. Bare infohashes from
+// indexers like TPB have no trackers and rely on DHT; in containerized
+// environments (e.g. Kubernetes) they often never resolve. We fail them
+// after this timeout to avoid indefinite queuing.
+const queuedMetadataTimeout = 5 * time.Minute
 
 // defaultTrackers is a curated list of reliable public BitTorrent
 // trackers used to bootstrap peer discovery for magnet links. In
@@ -35,15 +42,18 @@ const metadataTimeout = 60 * time.Second
 // in the magnet, so injecting them is safe.
 var defaultTrackers = []string{
 	"udp://tracker.opentrackr.org:1337/announce",
-	"udp://open.tracker.cl:1337/announce",
-	"udp://open.demonii.com:1337/announce",
+	"udp://open.stealth.si:80/announce",
 	"udp://exodus.desync.com:6969/announce",
 	"udp://tracker.torrent.eu.org:451/announce",
-	"udp://open.stealth.si:80/announce",
-	"https://tracker.gbitt.info:443/announce",
-	"https://tracker.tamersunion.org:443/announce",
-	"https://opentracker.i2p.rocks:443/announce",
-	"https://tracker1.520.jp:443/announce",
+	"udp://tracker.bittor.pw:1337/announce",
+	"udp://public.popcorn-tracker.org:6969/announce",
+	"udp://tracker.dler.org:6969/announce",
+	"udp://open.demonii.com:1337/announce",
+	"udp://glotorrents.pw:6969/announce",
+	"udp://tracker.coppersurfer.tk:6969",
+	"udp://torrent.gresille.org:80/announce",
+	"udp://p4p.arenabg.com:1337",
+	"udp://tracker.internetwarriors.net:1337",
 }
 
 // defaultAnnounceList wraps each tracker in its own tier so anacrolix
@@ -125,12 +135,12 @@ type trackedTorrent struct {
 // Engine wraps a single anacrolix/torrent.Client and manages its
 // lifecycle, including a seeding supervisor goroutine.
 type Engine struct {
-	mu      sync.RWMutex
-	client  *torrent.Client
-	cfg     Config
-	logger  *slog.Logger
-	items   map[string]*trackedTorrent // keyed by lowercase infohash hex
-	cancel  context.CancelFunc
+	mu     sync.RWMutex
+	client *torrent.Client
+	cfg    Config
+	logger *slog.Logger
+	items  map[string]*trackedTorrent // keyed by lowercase infohash hex
+	cancel context.CancelFunc
 	// engineCtx is the lifecycle context started by Start(). It is used
 	// for metadata-resolution waits so they are tied to the engine's
 	// lifetime rather than to the caller's (e.g. HTTP request) context.
@@ -379,11 +389,34 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 		t.DownloadAll()
 	} else {
 		// Metadata was not available within metadataTimeout. Start the
-		// download as soon as metainfo arrives.
+		// download as soon as metainfo arrives, but give up after a longer
+		// timeout to avoid indefinitely queuing bare infohashes from indexers
+		// like TPB that have no trackers and can't find peers in NAT'd/
+		// containerized environments.
 		go func(t *torrent.Torrent) {
+			metaCtx, cancel := context.WithTimeout(e.lifecycleCtx(), queuedMetadataTimeout)
+			defer cancel()
+
 			select {
 			case <-t.GotInfo():
 				t.DownloadAll()
+			case <-metaCtx.Done():
+				// Metadata still unavailable. Drop the torrent and remove it
+				// from tracking so it won't appear as indefinitely queued.
+				hash := strings.ToLower(t.InfoHash().HexString())
+				e.mu.Lock()
+				tracked := e.items[hash]
+				delete(e.items, hash)
+				e.mu.Unlock()
+
+				t.Drop()
+				if tracked != nil {
+					e.logger.Warn("dropping queued torrent: metadata resolution timeout",
+						"hash", hash,
+						"title", tracked.title,
+						"timeout", queuedMetadataTimeout,
+					)
+				}
 			case <-e.lifecycleCtx().Done():
 			}
 		}(t)

--- a/internal/downloads/torrent/magnet.go
+++ b/internal/downloads/torrent/magnet.go
@@ -1,0 +1,27 @@
+package torrent
+
+import (
+	"net/url"
+	"strings"
+)
+
+// BuildPublicMagnet constructs a magnet URI for infohash-only releases
+// using the same tracker-rich shape TPB exposes from its detail page.
+// This is notably more reliable than a bare xt=urn:btih magnet in
+// containerized environments where DHT discovery is spotty.
+func BuildPublicMagnet(infohash, title string) string {
+	infohash = strings.TrimSpace(infohash)
+	if infohash == "" {
+		return ""
+	}
+
+	v := url.Values{}
+	v.Set("xt", "urn:btih:"+infohash)
+	if title = strings.TrimSpace(title); title != "" {
+		v.Set("dn", title)
+	}
+	for _, tr := range defaultTrackers {
+		v.Add("tr", tr)
+	}
+	return "magnet:?" + v.Encode()
+}

--- a/internal/musicsearch/engine.go
+++ b/internal/musicsearch/engine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ebenderooock/loom/internal/customformats"
 	"github.com/ebenderooock/loom/internal/downloads"
+	torrentdl "github.com/ebenderooock/loom/internal/downloads/torrent"
 	"github.com/ebenderooock/loom/internal/indexers"
 	"github.com/ebenderooock/loom/internal/music"
 )
@@ -492,7 +493,7 @@ func buildDownloadRequest(res *indexers.Result) downloads.AddRequest {
 	if res.MagnetURI != "" {
 		req.Magnet = res.MagnetURI
 	} else if res.Infohash != "" {
-		req.Magnet = fmt.Sprintf("magnet:?xt=urn:btih:%s", res.Infohash)
+		req.Magnet = torrentdl.BuildPublicMagnet(res.Infohash, res.Title)
 	}
 	if res.Link != "" {
 		switch {

--- a/internal/musicsearch/engine_test.go
+++ b/internal/musicsearch/engine_test.go
@@ -2,6 +2,7 @@ package musicsearch
 
 import (
 	"log/slog"
+	"net/url"
 	"testing"
 
 	"github.com/ebenderooock/loom/internal/customformats"
@@ -104,6 +105,13 @@ func TestBuildDownloadRequest(t *testing.T) {
 	}
 	if req.Title == "" {
 		t.Error("expected title carried through")
+	}
+	u, err := url.Parse(req.Magnet)
+	if err != nil {
+		t.Fatalf("parse magnet: %v", err)
+	}
+	if got := u.Query().Get("dn"); got != "Artist - Album [FLAC]" {
+		t.Fatalf("dn = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- build tracker-rich magnets for infohash-only torrent grabs
- hydrate missing external IDs before autosearch runs
- improve TPB-style magnet quality and EZTV lookup coverage

## Testing
- go test ./internal/movies ./internal/series ./internal/music ./internal/server