### PR TITLE
fix(media): satisfy lint for bulk actions

### DIFF
--- a/internal/movies/handlers.go
+++ b/internal/movies/handlers.go
@@ -223,14 +223,14 @@ func refreshAllMovies(svc Service) http.HandlerFunc {
 			}
 		}
 
-		go func(movieIDs []string) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, movieIDs []string) {
 			for _, id := range movieIDs {
 				if err := svc.RefreshMovie(ctx, id); err != nil {
 					slog.Warn("movies: bulk refresh failed", "movie_id", id, "error", err)
 				}
 			}
-		}(ids)
+		}(ctx, ids)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
@@ -263,15 +263,15 @@ func rescanAllMovieLibraries(
 			}
 		}
 
-		go func(libs []libraries.Library) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, libs []libraries.Library) {
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
 					slog.Warn("movies: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
-		}(movieLibraries)
+		}(ctx, movieLibraries)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)

--- a/internal/music/handlers.go
+++ b/internal/music/handlers.go
@@ -45,6 +45,7 @@ type artistRouterConfig struct {
 	}
 }
 
+// ArtistRouterOption configures optional artist router dependencies.
 type ArtistRouterOption func(*artistRouterConfig)
 
 // WithLibraryRescan enables page-level rescan of all music libraries.
@@ -209,14 +210,14 @@ func handleRefreshAllArtists(svc Service) http.HandlerFunc {
 			ids = append(ids, artist.ID)
 		}
 
-		go func(artistIDs []string) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, artistIDs []string) {
 			for _, id := range artistIDs {
 				if _, err := svc.RefreshArtistAlbums(ctx, id); err != nil {
 					slog.Warn("music: bulk refresh failed", "artist_id", id, "error", err)
 				}
 			}
-		}(ids)
+		}(ctx, ids)
 
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"message": "artist refresh started",
@@ -247,15 +248,15 @@ func handleRescanAllArtistLibraries(
 			}
 		}
 
-		go func(libs []libraries.Library) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, libs []libraries.Library) {
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
 					slog.Warn("music: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
-		}(musicLibraries)
+		}(ctx, musicLibraries)
 
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"message":      "music library rescan started",

--- a/internal/series/handlers.go
+++ b/internal/series/handlers.go
@@ -176,14 +176,14 @@ func refreshAllSeries(svc Service) http.HandlerFunc {
 			ids = append(ids, item.ID)
 		}
 
-		go func(seriesIDs []string) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, seriesIDs []string) {
 			for _, id := range seriesIDs {
 				if err := svc.RefreshSeries(ctx, id); err != nil {
 					slog.Warn("series: bulk refresh failed", "series_id", id, "error", err)
 				}
 			}
-		}(ids)
+		}(ctx, ids)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
@@ -216,15 +216,15 @@ func rescanAllSeriesLibraries(
 			}
 		}
 
-		go func(libs []libraries.Library) {
-			ctx := context.Background()
+		ctx := context.WithoutCancel(r.Context())
+		go func(ctx context.Context, libs []libraries.Library) {
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
 					slog.Warn("series: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
-		}(seriesLibraries)
+		}(ctx, seriesLibraries)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
## Summary
- replace request-independent background contexts with `context.WithoutCancel(r.Context())`
- keep bulk refresh and rescan jobs detached from client disconnects without tripping gosec G118
- add the missing doc comment for `ArtistRouterOption`

## Validation
- golangci-lint run --new-from-rev=60882a844a713280a23c6592838118157011191c ./...
- go test ./internal/movies ./internal/series ./internal/music ./internal/server