### PR TITLE
fix(torrent): reannounce queued magnet trackers

### DIFF
--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -56,6 +56,40 @@ func magnetHasTrackers(magnet string) bool {
 	return len(u.Query()["tr"]) > 0
 }
 
+func announceListFromMagnet(magnet string) [][]string {
+	u, err := url.Parse(magnet)
+	if err != nil {
+		return nil
+	}
+	values := u.Query()["tr"]
+	if len(values) == 0 {
+		return nil
+	}
+	list := make([][]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, tr := range values {
+		tr = strings.TrimSpace(tr)
+		if tr == "" {
+			continue
+		}
+		if _, ok := seen[tr]; ok {
+			continue
+		}
+		seen[tr] = struct{}{}
+		list = append(list, []string{tr})
+	}
+	return list
+}
+
+func (e *Engine) nudgePeerDiscovery(t *torrent.Torrent, announceList [][]string) {
+	if len(announceList) > 0 {
+		t.AddTrackers(announceList)
+	}
+	for _, s := range e.client.DhtServers() {
+		_, _, _ = t.AnnounceToDht(s)
+	}
+}
+
 // seedCheckInterval controls how often the seeding supervisor scans
 // all tracked torrents to enforce ratio/time policies.
 const seedCheckInterval = 30 * time.Second
@@ -91,17 +125,16 @@ type torrentMeta struct {
 
 // trackedTorrent pairs the anacrolix torrent handle with Loom metadata.
 type trackedTorrent struct {
-	t           *torrent.Torrent
-	title       string
-	category    string
-	savePath    string
-	addedAt     time.Time
-	seedStartAt *time.Time
-	seedPolicy  SeedPolicy
-	paused      bool
-	movedToDest bool  // true once files have been moved from IncompleteDir → DownloadDir
-	downloaded  int64 // snapshot for ratio calculation
-	uploaded    int64
+	t            *torrent.Torrent
+	title        string
+	category     string
+	savePath     string
+	announceList [][]string
+	addedAt      time.Time
+	seedStartAt  *time.Time
+	seedPolicy   SeedPolicy
+	paused       bool
+	movedToDest  bool // true once files have been moved from IncompleteDir → DownloadDir
 
 	// Speed tracking — computed from byte deltas between Status() calls.
 	lastSpeedSampleAt time.Time
@@ -318,15 +351,14 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 		return "", fmt.Errorf("builtin/torrent: adding magnet: %w", err)
 	}
 
-	// When a magnet carries no trackers it can only find peers via DHT,
-	// which is slow or unreachable behind NAT/in containers and is the
-	// usual cause of metadata-resolution timeouts. Inject public trackers
-	// in that case. Magnets that already list trackers (including all
-	// private-tracker magnets) are left untouched so we never announce a
-	// private infohash to public trackers.
-	if !magnetHasTrackers(magnet) {
-		t.AddTrackers(defaultAnnounceList())
+	announceList := announceListFromMagnet(magnet)
+	// Feed tracker URIs into the client explicitly. This wakes the regular
+	// tracker announcers immediately for tracker-bearing magnets, and falls
+	// back to a public bootstrap set for infohash-only magnets.
+	if len(announceList) == 0 {
+		announceList = defaultAnnounceList()
 	}
+	t.AddTrackers(announceList)
 
 	// Wait for metadata with a timeout. Use the engine's lifecycle context
 	// rather than the caller's context so that a short-lived HTTP request
@@ -355,12 +387,13 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 
 	e.mu.Lock()
 	e.items[hash] = &trackedTorrent{
-		t:          t,
-		title:      title,
-		category:   meta.Category,
-		savePath:   meta.SavePath,
-		addedAt:    time.Now(),
-		seedPolicy: meta.SeedPolicy,
+		t:            t,
+		title:        title,
+		category:     meta.Category,
+		savePath:     meta.SavePath,
+		announceList: announceList,
+		addedAt:      time.Now(),
+		seedPolicy:   meta.SeedPolicy,
 	}
 	e.mu.Unlock()
 
@@ -372,33 +405,42 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 		// timeout to avoid indefinitely queuing bare infohashes from indexers
 		// like TPB that have no trackers and can't find peers in NAT'd/
 		// containerized environments.
-		go func(t *torrent.Torrent) {
+		go func(t *torrent.Torrent, announceList [][]string) {
 			metaCtx, cancel := context.WithTimeout(e.lifecycleCtx(), queuedMetadataTimeout)
 			defer cancel()
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
 
-			select {
-			case <-t.GotInfo():
-				t.DownloadAll()
-			case <-metaCtx.Done():
-				// Metadata still unavailable. Drop the torrent and remove it
-				// from tracking so it won't appear as indefinitely queued.
-				hash := strings.ToLower(t.InfoHash().HexString())
-				e.mu.Lock()
-				tracked := e.items[hash]
-				delete(e.items, hash)
-				e.mu.Unlock()
+			for {
+				select {
+				case <-t.GotInfo():
+					t.DownloadAll()
+					return
+				case <-metaCtx.Done():
+					// Metadata still unavailable. Drop the torrent and remove it
+					// from tracking so it won't appear as indefinitely queued.
+					hash := strings.ToLower(t.InfoHash().HexString())
+					e.mu.Lock()
+					tracked := e.items[hash]
+					delete(e.items, hash)
+					e.mu.Unlock()
 
-				t.Drop()
-				if tracked != nil {
-					e.logger.Warn("dropping queued torrent: metadata resolution timeout",
-						"hash", hash,
-						"title", tracked.title,
-						"timeout", queuedMetadataTimeout,
-					)
+					t.Drop()
+					if tracked != nil {
+						e.logger.Warn("dropping queued torrent: metadata resolution timeout",
+							"hash", hash,
+							"title", tracked.title,
+							"timeout", queuedMetadataTimeout,
+						)
+					}
+					return
+				case <-e.lifecycleCtx().Done():
+					return
+				case <-ticker.C:
+					e.nudgePeerDiscovery(t, announceList)
 				}
-			case <-e.lifecycleCtx().Done():
 			}
-		}(t)
+		}(t, announceList)
 	}
 
 	e.logger.Info("magnet added",
@@ -810,10 +852,7 @@ func (e *Engine) Reannounce(hashes ...string) error {
 		if !ok {
 			return fmt.Errorf("%w: %s", ErrTorrentNotFound, h)
 		}
-		// Announce to all DHT servers attached to the client.
-		for _, s := range e.client.DhtServers() {
-			_, _, _ = tt.t.AnnounceToDht(s)
-		}
+		e.nudgePeerDiscovery(tt.t, tt.announceList)
 	}
 	return nil
 }

--- a/internal/downloads/torrent/engine_test.go
+++ b/internal/downloads/torrent/engine_test.go
@@ -316,3 +316,20 @@ func TestDefaultAnnounceList(t *testing.T) {
 		}
 	}
 }
+
+func TestAnnounceListFromMagnet(t *testing.T) {
+	t.Parallel()
+	got := announceListFromMagnet("magnet:?xt=urn:btih:abc&tr=udp%3A%2F%2Ftracker.one%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.two%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.one%3A1337%2Fannounce")
+	want := [][]string{
+		{"udp://tracker.one:1337/announce"},
+		{"udp://tracker.two:6969/announce"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d tiers, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if len(got[i]) != 1 || got[i][0] != want[i][0] {
+			t.Fatalf("tier %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- explicitly seed anacrolix tracker announcers from magnet `tr=` params on add
- keep nudging queued torrents with tracker + DHT peer discovery while metadata is unresolved
- make the built-in reannounce action re-seed tracker announcers instead of only poking DHT

## Why
Live Off Campus grabs were landing in the built-in client but staying at `queued`, `size=0`, `peers=0`, `seeds=0` with unresolved metadata even though EZTV provided tracker-bearing magnets.

## Validation
- go test ./internal/downloads/torrent
- golangci-lint run --new-from-rev=277311faa4adbead805c6825cf3d051cb5e3cc59 ./...