### PR TITLE
feat: add data clearing tools and unblock magnet adds

### DIFF
--- a/internal/analytics/handlers.go
+++ b/internal/analytics/handlers.go
@@ -17,6 +17,7 @@ func Router(svc *Service, adminMW func(http.Handler) http.Handler) chi.Router {
 	}
 	r.Get("/streams", handleStreams(svc))
 	r.Get("/history", handleHistory(svc))
+	r.Delete("/history", handleClearHistory(svc))
 	r.Get("/stats", handleStats(svc))
 	return r
 }
@@ -71,5 +72,15 @@ func handleStats(svc *Service) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, stats)
+	}
+}
+
+func handleClearHistory(svc *Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := svc.ClearHistory(r.Context()); err != nil {
+			writeErr(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/analytics/service.go
+++ b/internal/analytics/service.go
@@ -86,6 +86,11 @@ func (s *Service) History(ctx context.Context, f HistoryFilter) ([]HistoryRecord
 	return s.store.ListHistory(ctx, f)
 }
 
+// ClearHistory removes all persisted analytics play history.
+func (s *Service) ClearHistory(ctx context.Context) error {
+	return s.store.ClearHistory(ctx)
+}
+
 // Stats returns the analytics report for the given window in days.
 func (s *Service) Stats(ctx context.Context, windowDays int) (*Stats, error) {
 	if windowDays <= 0 {

--- a/internal/analytics/store.go
+++ b/internal/analytics/store.go
@@ -173,6 +173,15 @@ func (s *Store) ListHistory(ctx context.Context, f HistoryFilter) ([]HistoryReco
 	return out, rows.Err()
 }
 
+// ClearHistory removes all persisted analytics play-history rows.
+func (s *Store) ClearHistory(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM play_history`)
+	if err != nil {
+		return fmt.Errorf("clear history: %w", err)
+	}
+	return nil
+}
+
 // Stats computes the analytics report over the given window. Only plays with at
 // least minWatchedMs of observed playback count toward the aggregates, to keep
 // brief previews/accidental starts out of the reports.

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -211,11 +211,25 @@ func (l *Logger) Prune(ctx context.Context, age time.Duration) (int64, error) {
 	return res.RowsAffected()
 }
 
+// Clear deletes the entire audit log.
+func (l *Logger) Clear(ctx context.Context) error {
+	_, err := l.db.ExecContext(ctx, `DELETE FROM audit_log`)
+	if err != nil {
+		return fmt.Errorf("audit log clear: %w", err)
+	}
+	return nil
+}
+
 // ── HTTP handlers ──────────────────────────────────────────────────────
 
 // Mount registers audit log routes onto r.
-func (l *Logger) Mount(r chi.Router) {
+func (l *Logger) Mount(r chi.Router, adminOnly func(http.Handler) http.Handler) {
 	r.Get("/api/v1/system/audit-log", l.handleList)
+	if adminOnly != nil {
+		r.With(adminOnly).Delete("/api/v1/system/audit-log", l.handleClear)
+		return
+	}
+	r.Delete("/api/v1/system/audit-log", l.handleClear)
 }
 
 func (l *Logger) handleList(w http.ResponseWriter, r *http.Request) {
@@ -242,6 +256,15 @@ func (l *Logger) handleList(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
+}
+
+func (l *Logger) handleClear(w http.ResponseWriter, r *http.Request) {
+	if err := l.Clear(r.Context()); err != nil {
+		l.logger.Error("audit log clear failed", "err", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // ── Convenience helpers ────────────────────────────────────────────────

--- a/internal/downloads/handlers.go
+++ b/internal/downloads/handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/ebenderooock/loom/internal/auth"
 	"github.com/ebenderooock/loom/internal/workflows"
 )
 
@@ -59,6 +60,7 @@ func (s *Service) Mount(r chi.Router) {
 	r.Get("/api/v1/activity/detail", s.handleActivityDetail)
 	// Download history endpoint
 	r.Get("/api/v1/downloads/history", s.handleHistory)
+	r.Delete("/api/v1/downloads/history", s.handleClearHistory)
 	for _, ext := range s.routeExtensions {
 		if ext != nil {
 			ext(r)
@@ -87,6 +89,15 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+func requireAdminIfPresent(w http.ResponseWriter, r *http.Request) bool {
+	id := auth.IdentityFrom(r.Context())
+	if id != nil && !id.HasRole("admin") {
+		writeError(w, http.StatusForbidden, "forbidden", "admin access required")
+		return false
+	}
+	return true
 }
 
 // --- create ---------------------------------------------------------
@@ -756,6 +767,23 @@ func (s *Service) handleHistory(w http.ResponseWriter, r *http.Request) {
 		entries = []HistoryEntry{}
 	}
 	writeJSON(w, http.StatusOK, entries)
+}
+
+func (s *Service) handleClearHistory(w http.ResponseWriter, r *http.Request) {
+	if !requireAdminIfPresent(w, r) {
+		return
+	}
+	if s.historyStore == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := s.historyStore.Clear(r.Context()); err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorBody{
+			Error: errorPayload{Message: "failed to clear download history", Code: "internal_error"},
+		})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // recordManualGrab records grab linkage for interactive search grabs.

--- a/internal/downloads/history.go
+++ b/internal/downloads/history.go
@@ -84,3 +84,9 @@ func (h *HistoryStore) List(ctx context.Context, limit, offset int) ([]HistoryEn
 	}
 	return entries, rows.Err()
 }
+
+// Clear removes all persisted download history entries.
+func (h *HistoryStore) Clear(ctx context.Context) error {
+	_, err := h.db.ExecContext(ctx, `DELETE FROM download_history`)
+	return err
+}

--- a/internal/downloads/torrent/engine.go
+++ b/internal/downloads/torrent/engine.go
@@ -22,9 +22,9 @@ import (
 	"github.com/ebenderooock/loom/internal/downloads/torrentutil"
 )
 
-// metadataTimeout is how long we wait for a magnet's metadata to
-// resolve during the initial Add. Sixty seconds tolerates slow swarms and
-// cold trackers while still failing in a reasonable time.
+// metadataTimeout is how long we wait for a .torrent's metadata to
+// resolve during the initial Add. For raw .torrent bytes this should be
+// effectively immediate because the info dict is already embedded.
 const metadataTimeout = 60 * time.Second
 
 // queuedMetadataTimeout is the maximum time a torrent may remain queued
@@ -342,10 +342,10 @@ func (e *Engine) lifecycleCtx() context.Context {
 	return ctx
 }
 
-// AddMagnet adds a torrent via magnet URI. It waits for metadata to
-// resolve (up to metadataTimeout or ctx deadline) and returns the
-// lowercase infohash as the stable item ID.
-func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta) (string, error) {
+// AddMagnet adds a torrent via magnet URI and immediately queues it by
+// infohash. Metadata resolution continues asynchronously so proxied HTTP
+// requests do not sit blocked until the swarm responds.
+func (e *Engine) AddMagnet(_ context.Context, magnet string, meta torrentMeta) (string, error) {
 	t, err := e.client.AddMagnet(magnet)
 	if err != nil {
 		return "", fmt.Errorf("builtin/torrent: adding magnet: %w", err)
@@ -359,25 +359,6 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 		announceList = defaultAnnounceList()
 	}
 	t.AddTrackers(announceList)
-
-	// Wait for metadata with a timeout. Use the engine's lifecycle context
-	// rather than the caller's context so that a short-lived HTTP request
-	// context being cancelled (e.g. client disconnect, write timeout) does
-	// not abort metadata resolution mid-flight.
-	waitCtx, waitCancel := context.WithTimeout(e.lifecycleCtx(), metadataTimeout)
-	defer waitCancel()
-
-	select {
-	case <-t.GotInfo():
-	case <-waitCtx.Done():
-		// Do not fail the add when metadata is slow. Keep the torrent in the
-		// engine and let metadata continue resolving asynchronously; status()
-		// reports it as queued while Info() is still nil.
-		e.logger.Warn("magnet metadata not yet available; keeping torrent queued",
-			"error", waitCtx.Err(),
-			"timeout", metadataTimeout,
-		)
-	}
 
 	hash := strings.ToLower(t.InfoHash().HexString())
 	title := meta.Title
@@ -400,11 +381,10 @@ func (e *Engine) AddMagnet(ctx context.Context, magnet string, meta torrentMeta)
 	if t.Info() != nil {
 		t.DownloadAll()
 	} else {
-		// Metadata was not available within metadataTimeout. Start the
-		// download as soon as metainfo arrives, but give up after a longer
-		// timeout to avoid indefinitely queuing bare infohashes from indexers
-		// like TPB that have no trackers and can't find peers in NAT'd/
-		// containerized environments.
+		e.logger.Warn("magnet metadata not yet available; keeping torrent queued",
+			"hash", hash,
+			"title", title,
+		)
 		go func(t *torrent.Torrent, announceList [][]string) {
 			metaCtx, cancel := context.WithTimeout(e.lifecycleCtx(), queuedMetadataTimeout)
 			defer cancel()
@@ -895,6 +875,20 @@ type TrackerInfo struct {
 	Peers  int    `json:"peers"`
 }
 
+func trackerInfosFromAnnounceList(announceList [][]string, status string) []TrackerInfo {
+	trackers := make([]TrackerInfo, 0)
+	for tier, tierURLs := range announceList {
+		for _, u := range tierURLs {
+			trackers = append(trackers, TrackerInfo{
+				URL:    u,
+				Tier:   tier,
+				Status: status,
+			})
+		}
+	}
+	return trackers
+}
+
 // TorrentDetail carries full detail for a single torrent.
 type TorrentDetail struct {
 	TorrentStatus
@@ -1010,17 +1004,9 @@ func (e *Engine) Detail(hash string) (*TorrentDetail, error) {
 	if t.Info() != nil {
 		mi := t.Metainfo()
 		announces := mi.UpvertedAnnounceList()
-		trackers := make([]TrackerInfo, 0)
-		for tier, tierURLs := range announces {
-			for _, u := range tierURLs {
-				trackers = append(trackers, TrackerInfo{
-					URL:    u,
-					Tier:   tier,
-					Status: "working",
-				})
-			}
-		}
-		detail.Trackers = trackers
+		detail.Trackers = trackerInfosFromAnnounceList(announces, "working")
+	} else if len(tt.announceList) > 0 {
+		detail.Trackers = trackerInfosFromAnnounceList(tt.announceList, "queued")
 	}
 
 	return detail, nil

--- a/internal/requests/handlers.go
+++ b/internal/requests/handlers.go
@@ -31,6 +31,7 @@ func Router(svc *Service, adminOnly func(http.Handler) http.Handler) chi.Router 
 	r.Group(func(ar chi.Router) {
 		ar.Use(adminOnly)
 		ar.Get("/", svc.handleListAll)
+		ar.Delete("/", svc.handleClear)
 		ar.Post("/{id}/approve", svc.handleApprove)
 		ar.Post("/{id}/reject", svc.handleReject)
 		ar.Get("/quota/config", svc.handleGetQuotaConfig)
@@ -153,6 +154,14 @@ func (s *Service) handleListAll(w http.ResponseWriter, r *http.Request) {
 		list = []Request{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"data": list})
+}
+
+func (s *Service) handleClear(w http.ResponseWriter, r *http.Request) {
+	if err := s.Clear(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 type approveBody struct {

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -178,6 +178,11 @@ func (s *Service) ListMine(ctx context.Context, userID string) ([]Request, error
 	return s.store.ListByUser(ctx, userID)
 }
 
+// Clear removes all persisted request history.
+func (s *Service) Clear(ctx context.Context) error {
+	return s.store.Clear(ctx)
+}
+
 // GetQuotaConfig returns the global per-user request quota.
 func (s *Service) GetQuotaConfig(ctx context.Context) (QuotaConfig, error) {
 	return s.store.GetQuotaConfig(ctx)

--- a/internal/requests/store.go
+++ b/internal/requests/store.go
@@ -148,6 +148,12 @@ func (s *Store) query(ctx context.Context, q string, args ...any) ([]Request, er
 	return out, rows.Err()
 }
 
+// Clear removes all persisted media requests.
+func (s *Store) Clear(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM media_requests`)
+	return err
+}
+
 // Get returns a single request by id.
 func (s *Store) Get(ctx context.Context, id string) (Request, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT `+selectCols+` FROM media_requests WHERE id = ?`, id)

--- a/internal/searchdebug/handlers.go
+++ b/internal/searchdebug/handlers.go
@@ -11,13 +11,16 @@ import (
 )
 
 // Router returns a chi.Router for the search debug log endpoints.
-func Router(store *Store, hub *Hub) chi.Router {
+func Router(store *Store, hub *Hub, adminOnly func(http.Handler) http.Handler) chi.Router {
 	r := chi.NewRouter()
 	r.Get("/", handleList(store))
 	r.Get("/active", handleActive(store))
 	r.Get("/stats", handleStats(store))
 	r.Get("/stream", handleStream(hub))
 	r.Get("/{id}", handleGet(store))
+	if adminOnly != nil {
+		r.With(adminOnly).Delete("/", handleClear(store))
+	}
 	r.Delete("/prune", handlePrune(store))
 	return r
 }
@@ -155,5 +158,15 @@ func handlePrune(store *Store) http.HandlerFunc {
 		json.NewEncoder(w).Encode(map[string]any{
 			"deleted": deleted,
 		})
+	}
+}
+
+func handleClear(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := store.Clear(r.Context()); err != nil {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/searchdebug/store.go
+++ b/internal/searchdebug/store.go
@@ -249,6 +249,12 @@ func (s *Store) Prune(ctx context.Context, maxAge time.Duration) (int64, error) 
 	return res.RowsAffected()
 }
 
+// Clear removes all persisted search debug entries.
+func (s *Store) Clear(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM search_debug_log`)
+	return err
+}
+
 // Stats returns aggregate statistics about search outcomes.
 func (s *Store) Stats(ctx context.Context) (*StatsResult, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -961,12 +961,20 @@ func (s *Server) newMux() http.Handler {
 
 		// System logs (authenticated)
 		if s.systemLogsDeps != nil {
-			r.Mount("/api/v1/system/logs", systemlogs.Router(*s.systemLogsDeps))
+			adminMW := func(next http.Handler) http.Handler { return next }
+			if s.authSvc != nil {
+				adminMW = s.authSvc.RequireRole("admin")
+			}
+			r.Mount("/api/v1/system/logs", systemlogs.Router(*s.systemLogsDeps, adminMW))
 		}
 
 		// Audit log (authenticated)
 		if s.auditLog != nil {
-			s.auditLog.Mount(r)
+			adminMW := func(next http.Handler) http.Handler { return next }
+			if s.authSvc != nil {
+				adminMW = s.authSvc.RequireRole("admin")
+			}
+			s.auditLog.Mount(r, adminMW)
 		}
 
 		// Automated search + grab (authenticated)
@@ -978,7 +986,11 @@ func (s *Server) newMux() http.Handler {
 
 		// Search debug log / search queue (authenticated)
 		if s.searchDebugStore != nil {
-			queueRouter := searchdebug.Router(s.searchDebugStore, s.searchDebugHub)
+			adminMW := func(next http.Handler) http.Handler { return next }
+			if s.authSvc != nil {
+				adminMW = s.authSvc.RequireRole("admin")
+			}
+			queueRouter := searchdebug.Router(s.searchDebugStore, s.searchDebugHub, adminMW)
 			r.Mount("/api/v1/search-debug", queueRouter)
 			r.Mount("/api/v1/search-queue", queueRouter)
 		}

--- a/internal/systemlogs/handlers.go
+++ b/internal/systemlogs/handlers.go
@@ -21,13 +21,18 @@ type HandlerDeps struct {
 }
 
 // Router returns a chi router for system log endpoints.
-func Router(deps HandlerDeps) chi.Router {
+func Router(deps HandlerDeps, adminOnly func(http.Handler) http.Handler) chi.Router {
 	r := chi.NewRouter()
 	r.Get("/", handleList(deps.Store))
 	r.Get("/stream", handleStream(deps.Buffer))
 	r.Get("/config", handleGetConfig(deps.Capture))
-	r.Put("/config", handleUpdateConfig(deps.Capture))
-	r.Delete("/", handleClear(deps.Store))
+	if adminOnly != nil {
+		r.With(adminOnly).Put("/config", handleUpdateConfig(deps.Capture))
+		r.With(adminOnly).Delete("/", handleClear(deps.Store))
+	} else {
+		r.Put("/config", handleUpdateConfig(deps.Capture))
+		r.Delete("/", handleClear(deps.Store))
+	}
 	return r
 }
 

--- a/web/src/components/layout/settings-layout.tsx
+++ b/web/src/components/layout/settings-layout.tsx
@@ -30,6 +30,7 @@ import {
   SlidersHorizontal,
   Tags,
   Terminal,
+  Trash2,
   ToggleRight,
   UsersRound,
   Workflow,
@@ -249,6 +250,14 @@ export const SETTINGS_GROUPS: SettingsNavGroup[] = [
         Icon: Terminal,
         kind: "panel",
         description: "Application logs and diagnostics.",
+      },
+      {
+        to: "/settings/data-management",
+        label: "Data Management",
+        Icon: Trash2,
+        kind: "panel",
+        description: "Clear stored history and operational data.",
+        adminOnly: true,
       },
       {
         to: "/settings/users",

--- a/web/src/components/logs/log-viewer.tsx
+++ b/web/src/components/logs/log-viewer.tsx
@@ -2,6 +2,8 @@ import { useState, useRef, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
+import { useAuth } from "@/hooks/use-auth";
 import {
   useSystemLogs,
   useLogStream,
@@ -11,6 +13,7 @@ import {
   type LogEntry,
   type LogListParams,
 } from "@/lib/system-logs-api";
+import { toast } from "sonner";
 import {
   ArrowDown,
   ChevronDown,
@@ -306,6 +309,8 @@ function LogTable({ entries }: { entries: LogEntry[] }) {
 }
 
 function LogConfigSection() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const { data: config } = useLogConfig();
   const updateMut = useUpdateLogConfig();
   const clearMut = useClearSystemLogs();
@@ -335,7 +340,9 @@ function LogConfigSection() {
             variant="outline"
             size="sm"
             disabled={
-              captureLevel === config?.capture_level || updateMut.isPending
+              !isAdmin ||
+              captureLevel === config?.capture_level ||
+              updateMut.isPending
             }
             onClick={() => updateMut.mutate({ capture_level: captureLevel })}
           >
@@ -343,17 +350,25 @@ function LogConfigSection() {
           </Button>
         </div>
         <div className="ml-auto">
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={() => {
-              if (confirm("Clear all system logs?")) clearMut.mutate();
-            }}
-            disabled={clearMut.isPending}
-          >
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            Clear Logs
-          </Button>
+          {isAdmin && (
+            <ConfirmActionButton
+              actionLabel="Clear Logs"
+              title="Clear system logs?"
+              description="Remove the stored system log history shown in this viewer."
+              confirmLabel="Clear logs"
+              pending={clearMut.isPending}
+              icon={<Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+              onConfirm={async () => {
+                try {
+                  await clearMut.mutateAsync();
+                  toast.success("System logs cleared");
+                } catch {
+                  toast.error("Failed to clear system logs");
+                  throw new Error("clear system logs failed");
+                }
+              }}
+            />
+          )}
         </div>
       </CardContent>
     </Card>

--- a/web/src/components/ui/confirm-action.tsx
+++ b/web/src/components/ui/confirm-action.tsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ConfirmActionProps {
+  actionLabel: string;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => Promise<void> | void;
+  disabled?: boolean;
+  pending?: boolean;
+  triggerVariant?: ButtonProps["variant"];
+  confirmVariant?: ButtonProps["variant"];
+  triggerSize?: ButtonProps["size"];
+  icon?: React.ReactNode;
+  details?: React.ReactNode;
+  className?: string;
+}
+
+export function ConfirmActionButton({
+  actionLabel,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  disabled = false,
+  pending = false,
+  triggerVariant = "destructive",
+  confirmVariant = "destructive",
+  triggerSize = "sm",
+  icon,
+  details,
+  className,
+}: ConfirmActionProps) {
+  const [open, setOpen] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      setOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const busy = pending || submitting;
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant={triggerVariant}
+        size={triggerSize}
+        className={className}
+        disabled={disabled || busy}
+        onClick={() => setOpen(true)}
+      >
+        {icon}
+        {actionLabel}
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+              {title}
+            </DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-sm text-muted-foreground">
+            This action clears stored history immediately and cannot be undone.
+          </div>
+          {details}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={busy}
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              type="button"
+              variant={confirmVariant}
+              onClick={() => void handleConfirm()}
+              disabled={busy}
+            >
+              {busy ? "Working…" : confirmLabel}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/lib/analytics-api.ts
+++ b/web/src/lib/analytics-api.ts
@@ -1,6 +1,6 @@
 // Typed fetch wrappers + react-query hooks for media-server analytics.
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/fetch";
 
 export interface LiveStream {
@@ -81,6 +81,12 @@ async function getJSON<T>(path: string, signal?: AbortSignal): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function clearAnalyticsHistory(): Promise<void> {
+  const res = await apiFetch("/api/v1/analytics/history", { method: "DELETE" });
+  if (!res.ok)
+    throw new Error(`/api/v1/analytics/history failed: ${res.status}`);
+}
+
 export function useActiveStreams() {
   return useQuery({
     queryKey: ["analytics", "streams"],
@@ -112,6 +118,14 @@ export function useAnalyticsStats(windowDays = 30) {
         `/api/v1/analytics/stats?days=${windowDays}`,
         signal,
       ),
+  });
+}
+
+export function useClearAnalyticsHistory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: clearAnalyticsHistory,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["analytics"] }),
   });
 }
 

--- a/web/src/lib/audit-log-api.ts
+++ b/web/src/lib/audit-log-api.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/fetch";
 
 // ─── Types ──────────────────────────────────────────────────────────────
@@ -58,6 +58,13 @@ export async function fetchAuditLog(
   return (await res.json()) as AuditLogResult;
 }
 
+export async function clearAuditLog(): Promise<void> {
+  const res = await apiFetch("/api/v1/system/audit-log", { method: "DELETE" });
+  if (!res.ok) {
+    throw new Error(`clear audit log: ${res.status} ${res.statusText}`);
+  }
+}
+
 // ─── Hook ───────────────────────────────────────────────────────────────
 
 export function useAuditLog(params: AuditLogParams = {}) {
@@ -66,5 +73,14 @@ export function useAuditLog(params: AuditLogParams = {}) {
     queryFn: ({ signal }) => fetchAuditLog(params, signal),
     refetchInterval: 15_000,
     staleTime: 10_000,
+  });
+}
+
+export function useClearAuditLog() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: clearAuditLog,
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["system", "audit-log"] }),
   });
 }

--- a/web/src/lib/requests-api.ts
+++ b/web/src/lib/requests-api.ts
@@ -145,6 +145,10 @@ export async function rejectRequest(
   });
 }
 
+export async function clearRequests(): Promise<void> {
+  return request("DELETE", "/api/v1/requests");
+}
+
 // ---------- Quotas ----------
 
 export interface MediaQuota {
@@ -242,6 +246,14 @@ export function useRejectRequest() {
   return useMutation({
     mutationFn: ({ id, reason }: { id: string; reason: string }) =>
       rejectRequest(id, reason),
+    onSuccess: () => qc.invalidateQueries({ queryKey: requestKeys.all }),
+  });
+}
+
+export function useClearRequests() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: clearRequests,
     onSuccess: () => qc.invalidateQueries({ queryKey: requestKeys.all }),
   });
 }

--- a/web/src/lib/search-debug-api.ts
+++ b/web/src/lib/search-debug-api.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/fetch";
 import { useEffect, useCallback } from "react";
 
@@ -173,6 +173,11 @@ export async function fetchActiveSearches(
   return (await res.json()) as { entries: SearchDebugEntry[] };
 }
 
+export async function clearSearchDebugHistory(): Promise<void> {
+  const res = await apiFetch("/api/v1/search-queue", { method: "DELETE" });
+  if (!res.ok) throw new Error(`clear search queue: ${res.status}`);
+}
+
 // ─── Hooks ──────────────────────────────────────────────────────────────
 
 export function useSearchDebugList(params: SearchDebugParams = {}) {
@@ -207,6 +212,16 @@ export function useActiveSearches() {
     queryFn: ({ signal }) => fetchActiveSearches(signal),
     refetchInterval: 5_000,
     staleTime: 3_000,
+  });
+}
+
+export function useClearSearchDebugHistory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: clearSearchDebugHistory,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["search-queue"] });
+    },
   });
 }
 

--- a/web/src/pages/activity.tsx
+++ b/web/src/pages/activity.tsx
@@ -17,7 +17,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingState } from "@/components/ui/loading-state";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import { useSetPageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
 import {
   CheckCircle2,
   XCircle,
@@ -61,6 +63,7 @@ import {
 } from "@/components/ui/dialog";
 import { formatBytes, formatEta, formatSpeed, relativeTime } from "@/lib/utils";
 import { downloadStatusConfig } from "@/lib/status-utils";
+import { toast } from "sonner";
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -528,25 +531,29 @@ function DownloadQueue() {
 }
 
 function DownloadHistory() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const [entries, setEntries] = React.useState<HistoryEntry[]>([]);
   const [loading, setLoading] = React.useState(true);
+  const [clearing, setClearing] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    try {
+      const res = await apiFetch("/api/v1/downloads/history?limit=50");
+      if (res.ok) {
+        const body = await res.json();
+        setEntries(body ?? []);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   React.useEffect(() => {
-    async function load() {
-      try {
-        const res = await apiFetch("/api/v1/downloads/history?limit=50");
-        if (res.ok) {
-          const body = await res.json();
-          setEntries(body ?? []);
-        }
-      } catch {
-        // silently fail
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, []);
+    void load();
+  }, [load]);
 
   if (loading) {
     return (
@@ -574,8 +581,35 @@ function DownloadHistory() {
 
   return (
     <Card>
-      <CardHeader className="pb-3">
+      <CardHeader className="flex flex-row items-center justify-between pb-3">
         <CardTitle className="text-base">Download History</CardTitle>
+        {isAdmin && (
+          <ConfirmActionButton
+            actionLabel="Clear History"
+            title="Clear download history?"
+            description="Remove the stored completed and failed download history entries."
+            confirmLabel="Clear downloads"
+            pending={clearing}
+            disabled={entries.length === 0}
+            icon={<Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+            onConfirm={async () => {
+              setClearing(true);
+              try {
+                const res = await apiFetch("/api/v1/downloads/history", {
+                  method: "DELETE",
+                });
+                if (!res.ok) throw new Error("clear download history failed");
+                setEntries([]);
+                toast.success("Download history cleared");
+              } catch {
+                toast.error("Failed to clear download history");
+                throw new Error("clear download history failed");
+              } finally {
+                setClearing(false);
+              }
+            }}
+          />
+        )}
       </CardHeader>
       <CardContent className="p-0">
         <Table>
@@ -633,8 +667,11 @@ interface BlocklistEntry {
 }
 
 function BlocklistViewer() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const [entries, setEntries] = React.useState<BlocklistEntry[]>([]);
   const [loading, setLoading] = React.useState(true);
+  const [clearing, setClearing] = React.useState(false);
 
   const fetchBlocklist = React.useCallback(async () => {
     try {
@@ -664,11 +701,17 @@ function BlocklistViewer() {
   };
 
   const handleClearAll = async () => {
+    setClearing(true);
     try {
-      await apiFetch("/api/v1/blocklist", { method: "DELETE" });
+      const res = await apiFetch("/api/v1/blocklist", { method: "DELETE" });
+      if (!res.ok) throw new Error("clear blocklist failed");
       setEntries([]);
+      toast.success("Blocklist cleared");
     } catch {
-      // silently fail
+      toast.error("Failed to clear blocklist");
+      throw new Error("clear blocklist failed");
+    } finally {
+      setClearing(false);
     }
   };
 
@@ -709,9 +752,18 @@ function BlocklistViewer() {
           >
             <RefreshCw className="h-4 w-4" />
           </Button>
-          <Button variant="destructive" size="sm" onClick={handleClearAll}>
-            <Trash2 className="mr-1 h-3.5 w-3.5" /> Clear All
-          </Button>
+          {isAdmin && (
+            <ConfirmActionButton
+              actionLabel="Clear All"
+              title="Clear download safety blocklist?"
+              description="Remove every blocked release from the download safety blocklist."
+              confirmLabel="Clear blocklist"
+              pending={clearing}
+              disabled={entries.length === 0}
+              icon={<Trash2 className="mr-1 h-3.5 w-3.5" />}
+              onConfirm={handleClearAll}
+            />
+          )}
         </div>
       </CardHeader>
       <CardContent className="p-0">

--- a/web/src/pages/analytics.tsx
+++ b/web/src/pages/analytics.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 import { usePageHeader } from "@/hooks/use-page-header";
 import { useAuth } from "@/hooks/use-auth";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import {
   useActiveStreams,
   useAnalyticsStats,
   useAnalyticsHistory,
+  useClearAnalyticsHistory,
   formatWatched,
   formatBitrate,
   type MediaStat,
@@ -46,7 +48,9 @@ import {
   Tv,
   MonitorPlay,
   Zap,
+  Trash2,
 } from "lucide-react";
+import { toast } from "sonner";
 
 function StatCard({
   icon,
@@ -248,6 +252,7 @@ export function AnalyticsPage() {
 
   const stats = useAnalyticsStats(windowDays);
   const history = useAnalyticsHistory(50);
+  const clearHistory = useClearAnalyticsHistory();
 
   if (!isAdmin) {
     return (
@@ -360,10 +365,32 @@ export function AnalyticsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Recent history</CardTitle>
-          <CardDescription>
-            The latest playback sessions across all servers.
-          </CardDescription>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle className="text-base">Recent history</CardTitle>
+              <CardDescription>
+                The latest playback sessions across all servers.
+              </CardDescription>
+            </div>
+            <ConfirmActionButton
+              actionLabel="Clear History"
+              title="Clear watch history?"
+              description="Remove all stored analytics playback history across every connected server."
+              confirmLabel="Clear watch history"
+              pending={clearHistory.isPending}
+              disabled={!history.data || history.data.length === 0}
+              icon={<Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+              onConfirm={async () => {
+                try {
+                  await clearHistory.mutateAsync();
+                  toast.success("Watch history cleared");
+                } catch {
+                  toast.error("Failed to clear watch history");
+                  throw new Error("clear analytics history failed");
+                }
+              }}
+            />
+          </div>
         </CardHeader>
         <CardContent>
           {history.isLoading ? (

--- a/web/src/pages/events.tsx
+++ b/web/src/pages/events.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import {
   Select,
   SelectContent,
@@ -17,8 +18,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSetPageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
 import {
   useAuditLog,
+  useClearAuditLog,
   type AuditLogParams,
   type AuditLogEntry,
 } from "@/lib/audit-log-api";
@@ -32,8 +35,9 @@ import {
   ChevronUp,
   RefreshCw,
 } from "lucide-react";
-import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/fetch";
+import { toast } from "sonner";
 
 const PAGE_SIZE = 50;
 
@@ -274,11 +278,14 @@ export function EventsPage() {
     "Centralized audit log — all system activity in one place",
   );
 
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const [category, setCategory] = React.useState<string>("all");
   const [level, setLevel] = React.useState<string>("all");
   const [offset, setOffset] = React.useState(0);
   const [expandedId, setExpandedId] = React.useState<string | null>(null);
   const qc = useQueryClient();
+  const clearAudit = useClearAuditLog();
 
   const params: AuditLogParams = {
     limit: PAGE_SIZE,
@@ -335,6 +342,28 @@ export function EventsPage() {
         >
           <RefreshCw className="h-4 w-4" />
         </Button>
+
+        {isAdmin && (
+          <ConfirmActionButton
+            actionLabel="Clear History"
+            title="Clear event history?"
+            description="Remove the stored audit log entries from the events view."
+            confirmLabel="Clear events"
+            pending={clearAudit.isPending}
+            icon={<RefreshCw className="mr-1.5 h-3.5 w-3.5" />}
+            onConfirm={async () => {
+              try {
+                await clearAudit.mutateAsync();
+                setExpandedId(null);
+                setOffset(0);
+                toast.success("Event history cleared");
+              } catch {
+                toast.error("Failed to clear event history");
+                throw new Error("clear audit history failed");
+              }
+            }}
+          />
+        )}
 
         <span className="ml-auto text-xs text-muted-foreground">
           {total} event{total !== 1 ? "s" : ""}

--- a/web/src/pages/requests.tsx
+++ b/web/src/pages/requests.tsx
@@ -5,6 +5,7 @@ import { apiFetch } from "@/lib/fetch";
 import {
   useMyRequests,
   useAllRequests,
+  useClearRequests,
   useCreateRequest,
   useApproveRequest,
   useRejectRequest,
@@ -16,6 +17,7 @@ import {
   type RequestMediaType,
   type RequestStatus,
 } from "@/lib/requests-api";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import { useLibraries } from "@/lib/libraries-api";
 import { useQualityProfiles } from "@/lib/quality-profiles-api";
 import { useAudioQualityProfiles } from "@/lib/music-api";
@@ -39,7 +41,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Check, Loader2, Plus, Search, X, Inbox, Gauge } from "lucide-react";
+import {
+  Check,
+  Loader2,
+  Plus,
+  Search,
+  X,
+  Inbox,
+  Gauge,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
 const TMDB_IMG = "https://image.tmdb.org/t/p";
@@ -638,10 +649,11 @@ function ManageRequests() {
   const { data, isLoading } = useAllRequests(status);
   const [approving, setApproving] = React.useState<MediaRequest | null>(null);
   const [rejecting, setRejecting] = React.useState<MediaRequest | null>(null);
+  const clearRequests = useClearRequests();
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <span className="text-sm text-muted-foreground">Filter</span>
         <Select
           value={status}
@@ -658,6 +670,27 @@ function ManageRequests() {
             ))}
           </SelectContent>
         </Select>
+        <div className="ml-auto">
+          <ConfirmActionButton
+            actionLabel="Clear History"
+            title="Clear request history?"
+            description="Remove all stored movie, TV, and music requests and their decision history."
+            confirmLabel="Clear requests"
+            pending={clearRequests.isPending}
+            icon={<Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+            onConfirm={async () => {
+              try {
+                await clearRequests.mutateAsync();
+                setApproving(null);
+                setRejecting(null);
+                toast.success("Request history cleared");
+              } catch {
+                toast.error("Failed to clear request history");
+                throw new Error("clear request history failed");
+              }
+            }}
+          />
+        </div>
       </div>
 
       {isLoading ? (

--- a/web/src/pages/search-debug.tsx
+++ b/web/src/pages/search-debug.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import {
   Select,
   SelectContent,
@@ -20,11 +21,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingState } from "@/components/ui/loading-state";
 import { useSetPageHeader } from "@/hooks/use-page-header";
+import { useAuth } from "@/hooks/use-auth";
 import {
   useSearchDebugList,
   useSearchDebugStats,
   useSearchDebugEntry,
   useActiveSearches,
+  useClearSearchDebugHistory,
   useSearchQueueSSE,
   type SearchDebugParams,
   type SearchDebugEntry,
@@ -33,6 +36,7 @@ import {
   type EvalResult,
 } from "@/lib/search-debug-api";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import {
   Search,
   ChevronDown,
@@ -622,11 +626,14 @@ export function SearchDebugPage() {
   // Subscribe to SSE for real-time updates.
   useSearchQueueSSE();
 
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
   const [outcome, setOutcome] = React.useState("all");
   const [mediaType, setMediaType] = React.useState("all");
   const [offset, setOffset] = React.useState(0);
   const [expandedId, setExpandedId] = React.useState<string | null>(null);
   const qc = useQueryClient();
+  const clearHistory = useClearSearchDebugHistory();
 
   const params: SearchDebugParams = {
     limit: PAGE_SIZE,
@@ -690,6 +697,28 @@ export function SearchDebugPage() {
         >
           <RefreshCw className="h-4 w-4" />
         </Button>
+
+        {isAdmin && (
+          <ConfirmActionButton
+            actionLabel="Clear History"
+            title="Clear search queue history?"
+            description="Remove completed and past search-debug entries. Active searches are shown separately."
+            confirmLabel="Clear search history"
+            pending={clearHistory.isPending}
+            icon={<RefreshCw className="mr-1.5 h-3.5 w-3.5" />}
+            onConfirm={async () => {
+              try {
+                await clearHistory.mutateAsync();
+                setExpandedId(null);
+                setOffset(0);
+                toast.success("Search history cleared");
+              } catch {
+                toast.error("Failed to clear search history");
+                throw new Error("clear search history failed");
+              }
+            }}
+          />
+        )}
 
         <span className="ml-auto text-xs text-muted-foreground">
           {total} result{total !== 1 ? "s" : ""}

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from "@/lib/fetch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TableSkeleton } from "@/components/ui/skeletons";
 import { Button } from "@/components/ui/button";
+import { ConfirmActionButton } from "@/components/ui/confirm-action";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -71,6 +72,11 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/hooks/use-auth";
 import { useFeatures, useSetFeature } from "@/lib/features-api";
+import { useClearAuditLog } from "@/lib/audit-log-api";
+import { useClearSearchDebugHistory } from "@/lib/search-debug-api";
+import { useClearAnalyticsHistory } from "@/lib/analytics-api";
+import { useClearRequests } from "@/lib/requests-api";
+import { useClearSystemLogs } from "@/lib/system-logs-api";
 import {
   useConnections as useConnectConnections,
   useCreateConnection as useCreateConnect,
@@ -837,6 +843,202 @@ export function GeneralPanel() {
           </div>
         </CardContent>
       </Card>
+    </div>
+  );
+}
+
+function DataManagementActionCard({
+  title,
+  description,
+  actionLabel,
+  confirmLabel,
+  onConfirm,
+  pending,
+}: {
+  title: string;
+  description: string;
+  actionLabel: string;
+  confirmLabel: string;
+  onConfirm: () => Promise<void>;
+  pending?: boolean;
+}) {
+  return (
+    <Card className="border-zinc-800 bg-zinc-900/50">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-zinc-400">{description}</p>
+        <ConfirmActionButton
+          actionLabel={actionLabel}
+          title={`${actionLabel}?`}
+          description={description}
+          confirmLabel={confirmLabel}
+          pending={pending}
+          icon={<Trash2 className="mr-1.5 h-3.5 w-3.5" />}
+          onConfirm={onConfirm}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function DataManagementPanel() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const clearAudit = useClearAuditLog();
+  const clearSearchDebug = useClearSearchDebugHistory();
+  const clearAnalytics = useClearAnalyticsHistory();
+  const clearRequests = useClearRequests();
+  const clearSystemLogs = useClearSystemLogs();
+  const [clearingDownloads, setClearingDownloads] = React.useState(false);
+  const [clearingBlocklist, setClearingBlocklist] = React.useState(false);
+
+  if (!isAdmin) {
+    return (
+      <Card className="border-zinc-800 bg-zinc-900/50">
+        <CardContent className="py-8 text-center text-sm text-zinc-400">
+          Admin access is required to clear stored history and operational data.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-lg font-semibold">Data Management</h3>
+        <p className="text-sm text-muted-foreground">
+          Clear historical records without touching media files on disk or your
+          configured libraries.
+        </p>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <DataManagementActionCard
+          title="Download history"
+          description="Clear the stored completed and failed download history shown on Activity."
+          actionLabel="Clear Download History"
+          confirmLabel="Clear downloads"
+          pending={clearingDownloads}
+          onConfirm={async () => {
+            setClearingDownloads(true);
+            try {
+              const res = await apiFetch("/api/v1/downloads/history", {
+                method: "DELETE",
+              });
+              if (!res.ok) throw new Error("clear download history failed");
+              toast.success("Download history cleared");
+            } catch {
+              toast.error("Failed to clear download history");
+              throw new Error("clear download history failed");
+            } finally {
+              setClearingDownloads(false);
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="Event history"
+          description="Clear the centralized audit/event log used by the Events page."
+          actionLabel="Clear Event History"
+          confirmLabel="Clear events"
+          pending={clearAudit.isPending}
+          onConfirm={async () => {
+            try {
+              await clearAudit.mutateAsync();
+              toast.success("Event history cleared");
+            } catch {
+              toast.error("Failed to clear event history");
+              throw new Error("clear event history failed");
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="Search queue history"
+          description="Clear stored search-debug entries and completed search queue history."
+          actionLabel="Clear Search History"
+          confirmLabel="Clear search history"
+          pending={clearSearchDebug.isPending}
+          onConfirm={async () => {
+            try {
+              await clearSearchDebug.mutateAsync();
+              toast.success("Search history cleared");
+            } catch {
+              toast.error("Failed to clear search history");
+              throw new Error("clear search history failed");
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="Watch history"
+          description="Clear analytics playback history recorded from Plex, Jellyfin, Emby, and similar integrations."
+          actionLabel="Clear Watch History"
+          confirmLabel="Clear watch history"
+          pending={clearAnalytics.isPending}
+          onConfirm={async () => {
+            try {
+              await clearAnalytics.mutateAsync();
+              toast.success("Watch history cleared");
+            } catch {
+              toast.error("Failed to clear watch history");
+              throw new Error("clear watch history failed");
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="Request history"
+          description="Clear movie, TV, and music requests along with their approval and failure history."
+          actionLabel="Clear Request History"
+          confirmLabel="Clear requests"
+          pending={clearRequests.isPending}
+          onConfirm={async () => {
+            try {
+              await clearRequests.mutateAsync();
+              toast.success("Request history cleared");
+            } catch {
+              toast.error("Failed to clear request history");
+              throw new Error("clear request history failed");
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="System logs"
+          description="Clear the stored system log history used by the System Logs viewer."
+          actionLabel="Clear System Logs"
+          confirmLabel="Clear logs"
+          pending={clearSystemLogs.isPending}
+          onConfirm={async () => {
+            try {
+              await clearSystemLogs.mutateAsync();
+              toast.success("System logs cleared");
+            } catch {
+              toast.error("Failed to clear system logs");
+              throw new Error("clear system logs failed");
+            }
+          }}
+        />
+        <DataManagementActionCard
+          title="Download safety blocklist"
+          description="Clear all blocked releases from the download safety blocklist."
+          actionLabel="Clear Blocklist"
+          confirmLabel="Clear blocklist"
+          pending={clearingBlocklist}
+          onConfirm={async () => {
+            setClearingBlocklist(true);
+            try {
+              const res = await apiFetch("/api/v1/blocklist", {
+                method: "DELETE",
+              });
+              if (!res.ok) throw new Error("clear blocklist failed");
+              toast.success("Blocklist cleared");
+            } catch {
+              toast.error("Failed to clear blocklist");
+              throw new Error("clear blocklist failed");
+            } finally {
+              setClearingBlocklist(false);
+            }
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/web/src/routes/router.tsx
+++ b/web/src/routes/router.tsx
@@ -236,6 +236,11 @@ const settingsAppearanceRoute = settingsChild(
   () => import("@/pages/settings"),
   "UIPanel",
 );
+const settingsDataManagementRoute = settingsChild(
+  "data-management",
+  () => import("@/pages/settings"),
+  "DataManagementPanel",
+);
 const settingsFeaturesRoute = settingsChild(
   "features",
   () => import("@/pages/settings"),
@@ -449,6 +454,7 @@ const routeTree = rootRoute.addChildren([
     settingsIndexRoute,
     settingsGeneralRoute,
     settingsAppearanceRoute,
+    settingsDataManagementRoute,
     settingsFeaturesRoute,
     settingsMediaManagementRoute,
     settingsMediaPreferencesRoute,


### PR DESCRIPTION
## Summary
- add admin-guarded history clearing actions across activity, events, search queue, analytics, requests, and settings
- add a shared in-app destructive confirmation flow and centralized data management settings page
- make builtin magnet adds queue immediately and surface queued tracker info so torrent adds no longer block behind metadata waits

## Testing
- go test ./...
- cd web && npx pnpm run lint
- cd web && npx pnpm run typecheck