### PR TITLE
fix(docker): install pnpm without corepack

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,7 +2,7 @@
 
 # ---------- frontend build ----------
 FROM node:26-alpine AS web
-RUN corepack enable && corepack prepare pnpm@9 --activate
+RUN npm install -g pnpm@9
 WORKDIR /web
 COPY web/package.json web/pnpm-lock.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \


### PR DESCRIPTION
## Summary
- stop relying on `corepack` in `node:26-alpine`, where it is no longer available
- install `pnpm@9` with `npm` in the frontend build stage so Docker image builds keep working on Node 26

## Testing
- attempted local `docker build`, but the local Docker daemon was unavailable in this session