### PR TITLE
refactor(indexers): add interface assertions and explicit attrFlavour sentinel

### DIFF
--- a/internal/indexers/cardigann/engine.go
+++ b/internal/indexers/cardigann/engine.go
@@ -31,6 +31,10 @@ const (
 	defaultTimeout   = 120 * time.Second
 )
 
+// Compile-time assertion that *Engine satisfies indexers.Indexer, so a
+// future drift in the interface method set is caught at build time.
+var _ indexers.Indexer = (*Engine)(nil)
+
 // Engine is the live indexers.Indexer for a single Cardigann
 // definition. It owns the cookie jar (so login state survives across
 // Search calls), the parsed definition, and the operator-supplied

--- a/internal/indexers/newznab/client.go
+++ b/internal/indexers/newznab/client.go
@@ -27,16 +27,28 @@ const (
 type attrFlavour int
 
 const (
-	flavourNewznab attrFlavour = iota
+	// flavourUnknown is the zero value and is never a valid flavour; it
+	// exists so an unset attrFlavour fails loudly instead of silently
+	// resolving to Newznab.
+	flavourUnknown attrFlavour = iota
+	flavourNewznab
 	flavourTorznab
 )
 
 func (f attrFlavour) kind() indexers.Kind {
-	if f == flavourTorznab {
+	switch f {
+	case flavourNewznab:
+		return KindNewznab
+	case flavourTorznab:
 		return KindTorznab
+	default:
+		panic(fmt.Sprintf("newznab: invalid attrFlavour %d", f))
 	}
-	return KindNewznab
 }
+
+// Compile-time assertion that *Client satisfies indexers.Indexer, so a
+// future drift in the interface method set is caught at build time.
+var _ indexers.Indexer = (*Client)(nil)
 
 // Client is the live Indexer for a single Newznab/Torznab endpoint.
 //


### PR DESCRIPTION
Fixes #85

Two low-risk hygiene cleanups from the design-pattern review.

## 1. Compile-time interface assertions
Added `var _ indexers.Indexer = (*Engine)(nil)` (cardigann) and
`var _ indexers.Indexer = (*Client)(nil)` (newznab), matching the pattern
the download clients already use. A future drift in the `indexers.Indexer`
method set now fails at build time instead of at the call site.

## 2. Explicit `attrFlavour` invalid sentinel
The zero value silently resolved to Newznab and `kind()` mapped every
unknown value to Newznab. Introduced `flavourUnknown` (iota 0) and switched
`kind()` to an exhaustive `switch` that panics on an invalid flavour.

No behavior change: `attrFlavour` is always set explicitly via `factoryFor`.

## Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./internal/indexers/... ./internal/parser/...` ✓ (all pass)