### PR TITLE
fix(music): make BuildTrackPath tests OS-agnostic for Windows path separators

### DIFF
--- a/internal/music/organizer_test.go
+++ b/internal/music/organizer_test.go
@@ -1,6 +1,9 @@
 package music
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestBuildTrackPath_SingleDisc(t *testing.T) {
 	artist := &Artist{Name: "Pink Floyd"}
@@ -8,7 +11,7 @@ func TestBuildTrackPath_SingleDisc(t *testing.T) {
 	track := &Track{Title: "Money", TrackNumber: 6, DiscNumber: 1}
 
 	got := BuildTrackPath(artist, album, track, false, ".flac")
-	want := "Pink Floyd/The Dark Side of the Moon (1973)/06 - Money.flac"
+	want := filepath.FromSlash("Pink Floyd/The Dark Side of the Moon (1973)/06 - Money.flac")
 	if got != want {
 		t.Fatalf("BuildTrackPath = %q, want %q", got, want)
 	}
@@ -20,7 +23,7 @@ func TestBuildTrackPath_MultiDisc(t *testing.T) {
 	track := &Track{Title: "Helter Skelter", TrackNumber: 4, DiscNumber: 2}
 
 	got := BuildTrackPath(artist, album, track, true, ".mp3")
-	want := "The Beatles/The Beatles (1968)/2-04 - Helter Skelter.mp3"
+	want := filepath.FromSlash("The Beatles/The Beatles (1968)/2-04 - Helter Skelter.mp3")
 	if got != want {
 		t.Fatalf("BuildTrackPath = %q, want %q", got, want)
 	}
@@ -32,7 +35,7 @@ func TestBuildTrackPath_SanitizesIllegalChars(t *testing.T) {
 	track := &Track{Title: "What Do You Do for Money: Honey?", TrackNumber: 2, DiscNumber: 1}
 
 	got := BuildTrackPath(artist, album, track, false, ".flac")
-	want := "AC-DC/Back in Black/02 - What Do You Do for Money - Honey.flac"
+	want := filepath.FromSlash("AC-DC/Back in Black/02 - What Do You Do for Money - Honey.flac")
 	if got != want {
 		t.Fatalf("BuildTrackPath = %q, want %q", got, want)
 	}
@@ -40,7 +43,7 @@ func TestBuildTrackPath_SanitizesIllegalChars(t *testing.T) {
 
 func TestBuildTrackPath_MissingMetadataFallbacks(t *testing.T) {
 	got := BuildTrackPath(nil, nil, nil, false, "")
-	want := "Unknown Artist/Unknown Album/00 - Unknown Track"
+	want := filepath.FromSlash("Unknown Artist/Unknown Album/00 - Unknown Track")
 	if got != want {
 		t.Fatalf("BuildTrackPath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Problem

The `ci` workflow's full OS matrix (which only runs on tags) fails on `windows-latest` in `internal/music`:

```
--- FAIL: TestBuildTrackPath_SingleDisc
  organizer_test.go:13: BuildTrackPath = "Pink Floyd\\The Dark Side of the Moon (1973)\\06 - Money.flac", want "Pink Floyd/The Dark Side of the Moon (1973)/06 - Money.flac"
```
(plus `TestBuildTrackPath_MultiDisc`, `_SanitizesIllegalChars`, `_MissingMetadataFallbacks`)

## Root cause

`BuildTrackPath` returns `filepath.Join(...)`, which yields OS-native separators (backslashes on Windows). That behavior is **correct** — these are real filesystem paths. The tests were wrong: they hard-coded forward slashes in their `want` literals, so they only passed on Unix.

## Fix (tests only)

Wrap the expected path literals for the `BuildTrackPath` tests in `filepath.FromSlash(...)`, the standard Go cross-platform idiom (a no-op on Unix, converts `/`→`\` on Windows), and add the `path/filepath` import. `organizer.go` behavior is unchanged.

This unblocks the tag/release OS matrix CI.

## Verification

- `gofmt -l internal/music/organizer_test.go` — no output
- `go test ./internal/music/...` — passes
- `go vet ./internal/music/...` — clean