### PR TITLE
feat(downloads): gate built-in torrent behind builtin_torrent feature flag (build-tag default)

### DIFF
--- a/cmd/loom/wire_downloads.go
+++ b/cmd/loom/wire_downloads.go
@@ -68,6 +68,7 @@ func wireDownloads(
 
 	downloadSvc.SetWorkflowEngine(wfEngine)
 	downloadSvc.SetMovieStatusUpdater(movieStatusAdapter{moviesSvc})
+	downloadSvc.SetBuiltinTorrentEnabled(srv.Features().EnabledFunc(featureflags.KeyBuiltinTorrent))
 	srv.SetWorkflowEngine(wfEngine)
 
 	// Workflow orchestrator — unified state coordinator (created early so callers can reference it)

--- a/internal/downloads/handlers.go
+++ b/internal/downloads/handlers.go
@@ -100,6 +100,19 @@ func requireAdminIfPresent(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
+// rejectDisabledKind writes a 400 and returns false when kind is the built-in
+// torrent (Rain) kind but the builtin_torrent feature flag is disabled. It
+// mirrors how unknown kinds are rejected so disabled kinds never reach the
+// registry. Returns true when the kind is allowed.
+func (s *Service) rejectDisabledKind(w http.ResponseWriter, kind Kind) bool {
+	if kind == KindBuiltinTorrent && !s.builtinTorrentAllowed() {
+		writeError(w, http.StatusBadRequest, "kind_disabled",
+			"the built-in torrent (Rain) download kind is disabled on this server")
+		return false
+	}
+	return true
+}
+
 // --- create ---------------------------------------------------------
 
 type createRequest struct {
@@ -137,6 +150,9 @@ func (s *Service) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(req.Name) == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "name is required")
+		return
+	}
+	if !s.rejectDisabledKind(w, req.Kind) {
 		return
 	}
 	if req.ID == "" {
@@ -237,6 +253,9 @@ func (s *Service) handleReplace(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Kind == "" || req.Name == "" || req.Protocol == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "kind, name, and protocol are required")
+		return
+	}
+	if !s.rejectDisabledKind(w, req.Kind) {
 		return
 	}
 	def := Definition{
@@ -374,6 +393,9 @@ func (s *Service) handleTestConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Kind == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "kind is required")
+		return
+	}
+	if !s.rejectDisabledKind(w, req.Kind) {
 		return
 	}
 

--- a/internal/downloads/handlers_test.go
+++ b/internal/downloads/handlers_test.go
@@ -127,6 +127,79 @@ func TestHandlersGetNotFound(t *testing.T) {
 	}
 }
 
+// When the builtin_torrent predicate reports disabled, the create, replace and
+// test-config handlers must reject the builtin/torrent kind with HTTP 400 and a
+// kind_disabled error, while other kinds keep working.
+func TestHandlersRejectBuiltinTorrentWhenDisabled(t *testing.T) {
+	t.Parallel()
+	svc := newServiceForTest(t)
+	svc.SetBuiltinTorrentEnabled(func() bool { return false })
+	r := chi.NewMux()
+	svc.Mount(r)
+
+	decodeCode := func(t *testing.T, b []byte) string {
+		t.Helper()
+		var env struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(b, &env); err != nil {
+			t.Fatalf("decode err: %v", err)
+		}
+		return env.Error.Code
+	}
+
+	post := func(t *testing.T, path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// create rejected
+	rr := post(t, "/api/v1/download-clients/",
+		`{"id":"t1","name":"Rain","kind":"builtin/torrent","protocol":"torrent"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("create status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := decodeCode(t, rr.Body.Bytes()); got != "kind_disabled" {
+		t.Fatalf("create error code=%q want kind_disabled", got)
+	}
+
+	// test-config rejected
+	rr = post(t, "/api/v1/download-clients/test",
+		`{"name":"Rain","kind":"builtin/torrent","protocol":"torrent"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("test-config status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := decodeCode(t, rr.Body.Bytes()); got != "kind_disabled" {
+		t.Fatalf("test-config error code=%q want kind_disabled", got)
+	}
+
+	// replace rejected
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/download-clients/t1",
+		strings.NewReader(`{"name":"Rain","kind":"builtin/torrent","protocol":"torrent"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("replace status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := decodeCode(t, rr.Body.Bytes()); got != "kind_disabled" {
+		t.Fatalf("replace error code=%q want kind_disabled", got)
+	}
+
+	// a non-torrent kind is unaffected
+	rr = post(t, "/api/v1/download-clients/",
+		`{"id":"n1","name":"Null","kind":"builtin/null","protocol":"torrent"}`)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create null status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestHandlersCategoriesAndFreeSpaceAndItems(t *testing.T) {
 	t.Parallel()
 	r, svc := newRouterForTest(t)

--- a/internal/downloads/service.go
+++ b/internal/downloads/service.go
@@ -49,6 +49,10 @@ type ServiceOptions struct {
 	HistoryStore       *HistoryStore
 	WorkflowEngine     *workflows.Engine
 	MovieStatusUpdater MovieStatusUpdater
+	// BuiltinTorrentEnabled reports whether the built-in torrent (Rain
+	// sidecar) download kind is available. A nil func is treated as enabled,
+	// preserving behaviour for callers that do not wire feature flags.
+	BuiltinTorrentEnabled func() bool
 }
 
 // Service is the orchestrator that the HTTP layer depends on. It owns
@@ -67,6 +71,7 @@ type Service struct {
 	wfEngine           *workflows.Engine
 	orchestrator       *workflows.Orchestrator
 	movieStatusUpdater MovieStatusUpdater
+	builtinTorrentOn   func() bool
 
 	mu sync.RWMutex
 }
@@ -106,6 +111,7 @@ func NewService(opts ServiceOptions) (*Service, error) {
 		historyStore:       opts.HistoryStore,
 		wfEngine:           opts.WorkflowEngine,
 		movieStatusUpdater: opts.MovieStatusUpdater,
+		builtinTorrentOn:   opts.BuiltinTorrentEnabled,
 	}, nil
 }
 
@@ -127,6 +133,28 @@ func (s *Service) SetOrchestrator(o *workflows.Orchestrator) {
 	s.mu.Lock()
 	s.orchestrator = o
 	s.mu.Unlock()
+}
+
+// SetBuiltinTorrentEnabled installs the predicate used to decide whether the
+// built-in torrent (Rain sidecar) download kind is currently available. A nil
+// predicate is treated as "enabled".
+func (s *Service) SetBuiltinTorrentEnabled(fn func() bool) {
+	s.mu.Lock()
+	s.builtinTorrentOn = fn
+	s.mu.Unlock()
+}
+
+// builtinTorrentAllowed reports whether the built-in torrent kind may be used.
+// It defaults to true when no predicate has been wired so that test and
+// embedding callers keep working without feature-flag plumbing.
+func (s *Service) builtinTorrentAllowed() bool {
+	s.mu.RLock()
+	fn := s.builtinTorrentOn
+	s.mu.RUnlock()
+	if fn == nil {
+		return true
+	}
+	return fn()
 }
 
 // SetMovieStatusUpdater sets the movie status updater for the service.

--- a/internal/featureflags/default_builtin_torrent_off.go
+++ b/internal/featureflags/default_builtin_torrent_off.go
@@ -1,0 +1,9 @@
+//go:build no_builtin_torrent
+
+package featureflags
+
+// builtinTorrentDefault is the registry default for the built-in torrent
+// (Rain sidecar) flag. This OFF variant is selected by -tags no_builtin_torrent
+// so single-binary distributions (e.g. Synology spksrc) default the built-in
+// torrent OFF. The ON variant lives in default_builtin_torrent_on.go.
+const builtinTorrentDefault = false

--- a/internal/featureflags/default_builtin_torrent_off_test.go
+++ b/internal/featureflags/default_builtin_torrent_off_test.go
@@ -1,0 +1,26 @@
+//go:build no_builtin_torrent
+
+package featureflags
+
+import "testing"
+
+// When built with -tags no_builtin_torrent the built-in torrent flag must
+// default OFF so single-binary distros (e.g. Synology) never offer it.
+func TestBuiltinTorrentDefaultsOffWithTag(t *testing.T) {
+	if builtinTorrentDefault != false { //nolint:gosimple // explicit for clarity
+		t.Fatalf("builtinTorrentDefault = %v, want false with no_builtin_torrent tag", builtinTorrentDefault)
+	}
+	d, ok := definition(KeyBuiltinTorrent)
+	if !ok {
+		t.Fatalf("builtin_torrent flag not registered in Definitions")
+	}
+	if d.Default {
+		t.Fatalf("builtin_torrent FlagDef.Default = true, want false with tag")
+	}
+
+	svc, db := newTestService(t)
+	defer db.Close()
+	if svc.Enabled(KeyBuiltinTorrent) {
+		t.Fatalf("expected builtin_torrent disabled by default with tag")
+	}
+}

--- a/internal/featureflags/default_builtin_torrent_on.go
+++ b/internal/featureflags/default_builtin_torrent_on.go
@@ -1,0 +1,10 @@
+//go:build !no_builtin_torrent
+
+package featureflags
+
+// builtinTorrentDefault is the registry default for the built-in torrent
+// (Rain sidecar) flag. Normal builds default it ON so K8s/Docker behaviour is
+// unchanged. Building with -tags no_builtin_torrent selects the OFF variant in
+// default_builtin_torrent_off.go (single-binary distros such as Synology that
+// have no Rain sidecar).
+const builtinTorrentDefault = true

--- a/internal/featureflags/default_builtin_torrent_on_test.go
+++ b/internal/featureflags/default_builtin_torrent_on_test.go
@@ -1,0 +1,37 @@
+//go:build !no_builtin_torrent
+
+package featureflags
+
+import (
+	"context"
+	"testing"
+)
+
+// In a normal build (no no_builtin_torrent tag) the built-in torrent flag must
+// default ON so K8s/Docker behaviour is unchanged.
+func TestBuiltinTorrentDefaultsOnWithoutTag(t *testing.T) {
+	if builtinTorrentDefault != true { //nolint:gosimple // explicit for clarity
+		t.Fatalf("builtinTorrentDefault = %v, want true without no_builtin_torrent tag", builtinTorrentDefault)
+	}
+	d, ok := definition(KeyBuiltinTorrent)
+	if !ok {
+		t.Fatalf("builtin_torrent flag not registered in Definitions")
+	}
+	if !d.Default {
+		t.Fatalf("builtin_torrent FlagDef.Default = false, want true without tag")
+	}
+
+	svc, db := newTestService(t)
+	defer db.Close()
+	if !svc.Enabled(KeyBuiltinTorrent) {
+		t.Fatalf("expected builtin_torrent enabled by default without tag")
+	}
+
+	// An explicit override still wins over the build-tag default.
+	if err := svc.Set(context.Background(), KeyBuiltinTorrent, false); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if svc.Enabled(KeyBuiltinTorrent) {
+		t.Fatalf("expected override to disable builtin_torrent")
+	}
+}

--- a/internal/featureflags/types.go
+++ b/internal/featureflags/types.go
@@ -28,6 +28,14 @@ const (
 	// incomplete: when off, the Music API routes are not mounted. Flip on once
 	// the Music milestones and UI are ready.
 	KeyMusic = "music"
+
+	// KeyBuiltinTorrent toggles the built-in torrent ("Rain sidecar") download
+	// kind. Its default comes from a build-tag-controlled value
+	// (builtinTorrentDefault): ON for normal builds (K8s/Docker) and OFF when
+	// built with -tags no_builtin_torrent (single-binary distros such as
+	// Synology that ship no Rain sidecar). When off, the builtin/torrent kind is
+	// hidden in the UI and rejected by the download-client handlers.
+	KeyBuiltinTorrent = "builtin_torrent"
 )
 
 // FlagDef is the static, in-code definition of a feature toggle.
@@ -75,6 +83,13 @@ var Definitions = []FlagDef{
 		Description: "Enable the Music capability: manage artists, albums and tracks, scan music libraries, acquire releases, and request artists via the requests portal and chat bots. When off, the Music API is not exposed.",
 		Category:    "Media",
 		Default:     true,
+	},
+	{
+		Key:         KeyBuiltinTorrent,
+		Label:       "Built-in Torrent (Rain)",
+		Description: "Offer the built-in torrent download kind, which talks to a Rain sidecar over its RPC endpoint (deployed alongside Loom by the Helm chart). When off, the built-in torrent kind is hidden in the UI and rejected by the download-client API. Default is build-dependent: on for container builds, off for single-binary distributions built without a Rain sidecar.",
+		Category:    "Downloads",
+		Default:     builtinTorrentDefault,
 	},
 }
 

--- a/web/src/components/downloads/download-form.tsx
+++ b/web/src/components/downloads/download-form.tsx
@@ -13,6 +13,7 @@ import type {
   DownloadProtocol,
 } from "@/lib/downloads-api";
 import { useTestDownloadConfig, useTestDownload } from "@/lib/downloads-api";
+import { useFeatureEnabled } from "@/lib/features-api";
 
 const DOWNLOAD_KINDS: {
   value: DownloadKind;
@@ -141,8 +142,26 @@ export function DownloadForm({
 }: DownloadFormProps) {
   const isEdit = Boolean(initial);
 
+  // Built-in torrent (Rain) is gated behind the builtin_torrent feature flag.
+  // Fallback=true keeps current behaviour (K8s/Docker) during the initial load.
+  const builtinTorrentEnabled = useFeatureEnabled("builtin_torrent", true);
+
+  // Kinds offered for selection. The built-in torrent is removed when the flag
+  // is off, but an existing client of that kind is still shown when editing so
+  // the select renders its label instead of an empty value.
+  const availableKinds = React.useMemo(
+    () =>
+      builtinTorrentEnabled
+        ? DOWNLOAD_KINDS
+        : DOWNLOAD_KINDS.filter((k) => k.value !== "builtin/torrent"),
+    [builtinTorrentEnabled],
+  );
+  const defaultKind: DownloadKind = builtinTorrentEnabled
+    ? "builtin/torrent"
+    : availableKinds[0]?.value ?? "qbittorrent";
+
   const [values, setValues] = React.useState<DownloadFormValues>(() => {
-    const kind = (initial?.kind as DownloadKind) ?? "builtin/torrent";
+    const kind = (initial?.kind as DownloadKind) ?? defaultKind;
     const kindDef = DOWNLOAD_KINDS.find((k) => k.value === kind);
     const isBuiltin = BUILTIN_KINDS.has(kind);
     return {
@@ -253,6 +272,16 @@ export function DownloadForm({
 
   const isBuiltinKind = BUILTIN_KINDS.has(values.kind);
 
+  // If the flag resolves to off after the initial paint (e.g. single-binary
+  // builds) and we're creating a new client still defaulted to the built-in
+  // torrent, fall back to the first available kind so the form stays valid.
+  React.useEffect(() => {
+    if (!builtinTorrentEnabled && !isEdit && values.kind === "builtin/torrent") {
+      handleKindChange(availableKinds[0]?.value ?? "qbittorrent");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [builtinTorrentEnabled, isEdit]);
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const errs = validateDownloadForm(values);
@@ -265,6 +294,21 @@ export function DownloadForm({
 
   const kindHelper =
     DOWNLOAD_KINDS.find((k) => k.value === values.kind)?.helper ?? "";
+
+  // Options shown in the kind <select>. When editing a client whose kind is no
+  // longer selectable (e.g. a disabled built-in torrent), keep its entry so the
+  // disabled select still renders the correct label.
+  const kindOptions = React.useMemo(() => {
+    if (
+      isEdit &&
+      values.kind &&
+      !availableKinds.some((k) => k.value === values.kind)
+    ) {
+      const current = DOWNLOAD_KINDS.find((k) => k.value === values.kind);
+      if (current) return [current, ...availableKinds];
+    }
+    return availableKinds;
+  }, [availableKinds, isEdit, values.kind]);
 
   return (
     <form
@@ -291,7 +335,7 @@ export function DownloadForm({
           onChange={(e) => handleKindChange(e.target.value as DownloadKind)}
           className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {DOWNLOAD_KINDS.map((k) => (
+          {kindOptions.map((k) => (
             <option key={k.value} value={k.value}>
               {k.label}
             </option>


### PR DESCRIPTION
## Summary

Adds a new `builtin_torrent` feature flag that gates Loom's built-in torrent ("Rain sidecar") download kind. The flag's **default is controlled by a build tag**:

- **Normal builds (K8s/Docker): default ON** — behaviour is unchanged.
- **`-tags no_builtin_torrent`: default OFF** — for single-binary distributions (e.g. Synology spksrc) that ship no Rain sidecar.

This unblocks the single-binary Synology build, which must not offer the built-in torrent.

## Build tag

Use this exact build-tag string to flip the default OFF:

```
no_builtin_torrent
```

e.g. `go build -tags no_builtin_torrent ./...`

## Changes

**Feature flag (`internal/featureflags`)**
- New `KeyBuiltinTorrent = "builtin_torrent"` const + `FlagDef` (Category "Downloads").
- `Default` comes from a build-tag-controlled package const `builtinTorrentDefault`:
  - `default_builtin_torrent_on.go` (`//go:build !no_builtin_torrent`) → `true`
  - `default_builtin_torrent_off.go` (`//go:build no_builtin_torrent`) → `false`

**Backend gating (`internal/downloads`)**
- `Service` gains an optional `BuiltinTorrentEnabled func() bool` predicate (nil = enabled, preserving existing callers/tests).
- The create, replace, and test-config handlers **reject** `kind == "builtin/torrent"` with HTTP 400 `kind_disabled` when the flag is off, mirroring how unknown kinds are rejected.
- `BuildPublicMagnet` and the torrent package `init()` registration are untouched — autosearch/musicsearch keep compiling and working regardless of the flag.
- Wired via `srv.Features().EnabledFunc(featureflags.KeyBuiltinTorrent)` in `cmd/loom/wire_downloads.go`.

**Frontend (`web`)**
- `download-form.tsx` hides the "Rain (Sidecar)" option when `useFeatureEnabled("builtin_torrent", true)` is false, defaults the selected kind to the first available kind (qBittorrent), and still renders the label when editing an existing built-in torrent client. Fallback=true keeps K8s behaviour during initial load.

## Verification

- `gofmt -l` clean on changed Go files.
- `go build ./...` and `go build -tags no_builtin_torrent ./...` both succeed.
- `go test ./internal/featureflags/... ./internal/downloads/...` passes (default build).
- `go test -tags no_builtin_torrent ./internal/featureflags/...` passes (asserts default OFF under the tag).
- New Go tests: flag default ON without tag / OFF with tag; downloads handlers reject `builtin/torrent` when disabled.
- `cd web && pnpm install --frozen-lockfile && pnpm run build` succeeds; `pnpm run lint` clean; existing `download-form` vitest suite passes.

Note: no release tag cut here — v0.2.1 to be cut after merge.