### PR TITLE
fix: unify monitoring searches with manual/auto series path

### DIFF
--- a/cmd/loom/wire_downloads.go
+++ b/cmd/loom/wire_downloads.go
@@ -328,9 +328,18 @@ func (g *autoSearchGrabber) Grab(ctx context.Context, c scheduler.SearchCandidat
 	if g.engine == nil {
 		return nil
 	}
+	mediaType := c.MediaType
+	mediaID := c.MediaID
+	// Align scheduler episode searches with manual/regular series searches:
+	// search as series + S/E targeting, while still tracking episode state
+	// separately in scheduler.search_state.
+	if c.MediaType == "episode" && c.SeriesID != "" {
+		mediaType = "series"
+		mediaID = c.SeriesID
+	}
 	req := autosearch.SearchRequest{
-		MediaType:        c.MediaType,
-		MediaID:          c.MediaID,
+		MediaType:        mediaType,
+		MediaID:          mediaID,
 		Title:            c.Title,
 		Year:             c.Year,
 		QualityProfileID: c.QualityProfileID,

--- a/internal/scheduler/rolling_search.go
+++ b/internal/scheduler/rolling_search.go
@@ -61,6 +61,9 @@ func (rs *RollingSearcher) Start(ctx context.Context) {
 	next := time.Now().Add(rs.interval())
 	rs.nextRun = &next
 
+	// Kick off one run immediately on startup so newly-aired/released media
+	// is processed without waiting for the first full interval.
+	go rs.runOnce(childCtx)
 	go rs.loop(childCtx)
 	rs.logger.Info("rolling search started", "interval_h", rs.config.IntervalHours, "batch", rs.config.BatchSize)
 }

--- a/internal/scheduler/rolling_search.go
+++ b/internal/scheduler/rolling_search.go
@@ -175,22 +175,59 @@ func (rs *RollingSearcher) runOnce(ctx context.Context) {
 	rs.logger.Info("rolling search run starting")
 	now := time.Now()
 
-	half := cfg.BatchSize / 2
-	if half < 1 {
-		half = 1
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1
 	}
-	epHalf := cfg.BatchSize - half
+	targetMovies := batchSize / 2
+	if targetMovies < 1 {
+		targetMovies = 1
+	}
+	targetEpisodes := batchSize - targetMovies
+	if targetEpisodes < 1 {
+		targetEpisodes = 1
+	}
 
-	movieCandidates, err := rs.store.GetCandidates(ctx, "movie", half, cfg.MinResearchDays)
+	// Fetch up to the full batch for each type so we can fill unused slots from
+	// the other queue. The target split remains a preference, not a hard cap.
+	movieCandidates, err := rs.store.GetCandidates(ctx, "movie", batchSize, cfg.MinResearchDays)
 	if err != nil {
 		rs.logger.Error("get movie candidates", "err", err)
 	}
-	epCandidates, err := rs.store.GetCandidates(ctx, "episode", epHalf, cfg.MinResearchDays)
+	epCandidates, err := rs.store.GetCandidates(ctx, "episode", batchSize, cfg.MinResearchDays)
 	if err != nil {
 		rs.logger.Error("get episode candidates", "err", err)
 	}
 
-	candidates := append(movieCandidates, epCandidates...)
+	candidates := make([]SearchCandidate, 0, batchSize)
+	added := make(map[string]struct{}, batchSize)
+	add := func(c SearchCandidate) {
+		if len(candidates) >= batchSize {
+			return
+		}
+		key := c.MediaType + ":" + c.MediaID
+		if _, exists := added[key]; exists {
+			return
+		}
+		added[key] = struct{}{}
+		candidates = append(candidates, c)
+	}
+
+	// First pass: honor preferred split.
+	for i := 0; i < len(movieCandidates) && i < targetMovies; i++ {
+		add(movieCandidates[i])
+	}
+	for i := 0; i < len(epCandidates) && i < targetEpisodes; i++ {
+		add(epCandidates[i])
+	}
+	// Second pass: fill remaining slots from either queue.
+	for i := targetMovies; i < len(movieCandidates) && len(candidates) < batchSize; i++ {
+		add(movieCandidates[i])
+	}
+	for i := targetEpisodes; i < len(epCandidates) && len(candidates) < batchSize; i++ {
+		add(epCandidates[i])
+	}
+
 	count := 0
 	for _, c := range candidates {
 		if ctx.Err() != nil {

--- a/internal/scheduler/store.go
+++ b/internal/scheduler/store.go
@@ -32,7 +32,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 		query = `
 			SELECT m.id, m.title, m.year,
 			       COALESCE(m.imdb_id, ''), COALESCE(m.tvdb_id, ''), COALESCE(m.tmdb_id, ''),
-			       0, 0, COALESCE(m.quality_profile_id, '')
+			       0, 0, COALESCE(m.quality_profile_id, ''), ''
 			FROM movies m
 			LEFT JOIN search_state ss ON ss.media_type = 'movie' AND ss.media_id = m.id
 			WHERE (
@@ -47,7 +47,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 		query = `
 			SELECT e.id, COALESCE(NULLIF(s.title, ''), e.title), 0,
 			       COALESCE(s.imdb_id, ''), COALESCE(s.tvdb_id, ''), COALESCE(s.tmdb_id, ''),
-			       se.season_number, e.episode_number, COALESCE(s.quality_profile_id, '')
+			       se.season_number, e.episode_number, COALESCE(s.quality_profile_id, ''), s.id
 			FROM episodes e
 			JOIN series s ON e.series_id = s.id
 			JOIN seasons se ON e.season_id = se.id AND se.series_id = e.series_id
@@ -75,7 +75,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 		var c SearchCandidate
 		c.MediaType = mediaType
 		if err := rows.Scan(&c.MediaID, &c.Title, &c.Year,
-			&c.IMDBID, &c.TVDBID, &c.TMDBID, &c.Season, &c.Episode, &c.QualityProfileID); err != nil {
+			&c.IMDBID, &c.TVDBID, &c.TMDBID, &c.Season, &c.Episode, &c.QualityProfileID, &c.SeriesID); err != nil {
 			return nil, err
 		}
 		c.Priority = pri

--- a/internal/scheduler/store.go
+++ b/internal/scheduler/store.go
@@ -37,7 +37,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 			LEFT JOIN search_state ss ON ss.media_type = 'movie' AND ss.media_id = m.id
 			WHERE (
 			        m.status = 'missing'
-			        OR (m.status = 'unreleased' AND m.release_date != '' AND m.release_date <= date('now'))
+			        OR (m.status = 'unreleased' AND m.release_date != '' AND date(m.release_date) <= date('now'))
 			      )
 			  AND m.monitoring_status = 'monitored'
 			  AND (ss.last_searched_at IS NULL OR ss.last_searched_at < ?)
@@ -55,7 +55,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 			WHERE e.has_file = 0
 			  AND e.monitored = 1
 			  AND s.monitoring_status NOT IN ('none', 'unmonitored', 'archived')
-			  AND (e.air_date != '' AND e.air_date <= date('now'))
+			  AND (e.air_date != '' AND date(e.air_date) <= date('now'))
 			  AND (ss.last_searched_at IS NULL OR ss.last_searched_at < ?)
 			ORDER BY e.air_date DESC, e.created_at DESC
 			LIMIT ?`
@@ -108,7 +108,7 @@ func (s *Store) QueueSize(ctx context.Context, minResearchDays int) (int, error)
 		LEFT JOIN search_state ss ON ss.media_type = 'movie' AND ss.media_id = m.id
 		WHERE (
 		        m.status = 'missing'
-		        OR (m.status = 'unreleased' AND m.release_date != '' AND m.release_date <= date('now'))
+		        OR (m.status = 'unreleased' AND m.release_date != '' AND date(m.release_date) <= date('now'))
 		      )
 		  AND m.monitoring_status = 'monitored'
 		  AND (ss.last_searched_at IS NULL OR ss.last_searched_at < ?)`, cutoff)
@@ -124,7 +124,7 @@ func (s *Store) QueueSize(ctx context.Context, minResearchDays int) (int, error)
 		WHERE e.has_file = 0
 		  AND e.monitored = 1
 		  AND s.monitoring_status NOT IN ('none', 'unmonitored', 'archived')
-		  AND (e.air_date != '' AND e.air_date <= date('now'))
+		  AND (e.air_date != '' AND date(e.air_date) <= date('now'))
 		  AND (ss.last_searched_at IS NULL OR ss.last_searched_at < ?)`, cutoff)
 	if err := row.Scan(&epCount); err != nil {
 		return count, err

--- a/internal/scheduler/store.go
+++ b/internal/scheduler/store.go
@@ -45,7 +45,7 @@ func (s *Store) GetCandidates(ctx context.Context, mediaType string, limit int, 
 			LIMIT ?`
 	case "episode":
 		query = `
-			SELECT e.id, e.title, 0,
+			SELECT e.id, COALESCE(NULLIF(s.title, ''), e.title), 0,
 			       COALESCE(s.imdb_id, ''), COALESCE(s.tvdb_id, ''), COALESCE(s.tmdb_id, ''),
 			       se.season_number, e.episode_number, COALESCE(s.quality_profile_id, '')
 			FROM episodes e

--- a/internal/scheduler/types.go
+++ b/internal/scheduler/types.go
@@ -30,6 +30,7 @@ func DefaultRollingSearchConfig() RollingSearchConfig {
 type SearchCandidate struct {
 	MediaType        string     `json:"mediaType"` // "movie" or "episode"
 	MediaID          string     `json:"mediaId"`
+	SeriesID         string     `json:"seriesId,omitempty"`
 	Title            string     `json:"title"`
 	Year             int        `json:"year,omitempty"`
 	IMDBID           string     `json:"imdbId,omitempty"`


### PR DESCRIPTION
## Summary

This follow-up unifies rolling monitoring episode searches with the same effective search path used by manual/regular auto search for series.

### Included fixes
- trigger an immediate rolling-search run on startup
- avoid episode starvation in mixed movie/episode batches
- use `series.title` for episode candidate query text (fallback to episode title)
- carry `series_id` in scheduler candidates
- route scheduler episode grabs as `media_type=series` + `series_id` + season/episode targeting (same as manual/auto flow)
- normalize date checks with `date(...)` for release/air-date comparisons

## Why

Monitoring was still deviating from manual/regular search in edge cases, which caused successful manual grabs but rejected/ineffective monitoring searches for the same content.

## Validation

- `go test ./internal/scheduler/... ./cmd/loom/... ./internal/autosearch/...`
- `go test ./...`