### PR TITLE
Enable rolling search by default

### DIFF
--- a/docs/platform-documentation.md
+++ b/docs/platform-documentation.md
@@ -1380,7 +1380,7 @@ Returns `{ success: true/false, items: [...], count: N }` with up to 5 preview i
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| enabled | bool | false | Whether scheduler is active |
+| enabled | bool | true | Whether scheduler is active |
 | intervalHours | int | 12 | Hours between search cycles |
 | batchSize | int | 5 | Items to search per cycle |
 | minResearchDays | int | 7 | Min days before re-searching an item |

--- a/internal/scheduler/types.go
+++ b/internal/scheduler/types.go
@@ -18,7 +18,7 @@ type RollingSearchConfig struct {
 // DefaultRollingSearchConfig returns sensible defaults.
 func DefaultRollingSearchConfig() RollingSearchConfig {
 	return RollingSearchConfig{
-		Enabled:           false,
+		Enabled:           true,
 		IntervalHours:     12,
 		BatchSize:         5,
 		MinResearchDays:   7,

--- a/internal/scheduler/types_test.go
+++ b/internal/scheduler/types_test.go
@@ -1,0 +1,42 @@
+package scheduler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func TestDefaultRollingSearchConfigEnabledByDefault(t *testing.T) {
+	cfg := DefaultRollingSearchConfig()
+
+	if !cfg.Enabled {
+		t.Fatalf("expected rolling search to be enabled by default")
+	}
+	if cfg.IntervalHours != 12 {
+		t.Fatalf("expected intervalHours default 12, got %d", cfg.IntervalHours)
+	}
+	if cfg.BatchSize != 5 {
+		t.Fatalf("expected batchSize default 5, got %d", cfg.BatchSize)
+	}
+	if cfg.MinResearchDays != 7 {
+		t.Fatalf("expected minResearchDays default 7, got %d", cfg.MinResearchDays)
+	}
+	if cfg.MaxSearchesPerDay != 100 {
+		t.Fatalf("expected maxSearchesPerDay default 100, got %d", cfg.MaxSearchesPerDay)
+	}
+}
+
+func TestUpdateConfigPreservesExplicitDisabledOverride(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rs := NewRollingSearcher(nil, nil, logger, DefaultRollingSearchConfig())
+
+	cfg := rs.Config()
+	cfg.Enabled = false
+	rs.UpdateConfig(context.Background(), cfg)
+
+	got := rs.Config()
+	if got.Enabled {
+		t.Fatalf("expected explicit enabled=false override to be preserved")
+	}
+}


### PR DESCRIPTION
## Summary
- enable rolling search in the default scheduler config for new instances
- add scheduler tests for new default values and explicit enabled=false override behavior
- update platform docs for rolling-search default config

## Validation
- go test ./internal/scheduler/...
- make build
- make lint fails on pre-existing repo-wide baseline issues unrelated to this change
- golangci-lint run --new-from-rev db8e0abd4286a33de7c010d63993dcbcb46b6f64 ./internal/scheduler/... passes (changed scope is clean)

Fixes #103