### PR TITLE
Tracing: wire otelhttp inbound/outbound and fix trace ratio default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ real values look like. Every key gets an `example:` line.
 | `log.format` | `LOOM_LOG_FORMAT` | string | `json` | **yes** | One of `json`, `text`. |
 | `telemetry.prometheus` | `LOOM_TELEMETRY_PROMETHEUS` / `LOOM_PROMETHEUS` | bool | `true` | no | Expose `/metrics`. |
 | `telemetry.profiling` | `LOOM_TELEMETRY_PROFILING` / `LOOM_PROFILING` | bool | `false` | no | Synonym kept for legacy callers; see also `debug.pprof`. |
-| `telemetry.trace_ratio` | `LOOM_TELEMETRY_TRACE_RATIO` / `LOOM_TRACE_RATIO` | float [0,1] | `0.0` | no | Sampler ratio for OTel traces. |
+| `telemetry.trace_ratio` | `LOOM_TELEMETRY_TRACE_RATIO` / `LOOM_TRACE_RATIO` | float [0,1] | `0.1` | no | Sampler ratio for OTel traces. Invalid/non-positive values fall back to `0.1`. |
 | `telemetry.otlp_endpoint` | `LOOM_TELEMETRY_OTLP_ENDPOINT` / `LOOM_OTLP_ENDPOINT` | string | `""` | no | OTLP/HTTP collector endpoint. |
 | `database.url` | `LOOM_DATABASE_URL` | string | `""` | no | Legacy-style DSN; if set and `postgres://…`, selects Postgres. |
 | `storage.engine` | `LOOM_STORAGE_ENGINE` | string | `sqlite` | no | One of `sqlite`, `postgres`. |
@@ -163,7 +163,7 @@ log:
 
 telemetry:
   prometheus: true
-  trace_ratio: 0.0
+  trace_ratio: 0.1
   otlp_endpoint: ""
 
 storage:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -109,7 +109,11 @@ example PromQL queries and tuning advice.
 
 - OpenTelemetry SDK with an OTLP/HTTP exporter.
 - Gated by `otel.enabled: true` (or `telemetry.otlp_endpoint` non-empty).
-- Sampling: `telemetry.trace_ratio` ∈ [0, 1] (parent-based).
+- Sampling: `telemetry.trace_ratio` ∈ [0, 1] (parent-based), default `0.1`.
+- Inbound HTTP spans are emitted via `otelhttp` middleware on the server mux
+  (health/readiness/liveness and `/metrics` are excluded).
+- Outbound HTTP spans are emitted via `otelhttp` transport in the shared
+  indexer/download client transport stack.
 - W3C trace-context and Baggage propagators are installed globally so
   traces stitch across hops.
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -48,6 +49,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2/v2 v2.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/dop251/goja v0.0.0-20260603143327-1f200ca63355 h1:QCZbLvvKw3vwkMubwAH
 github.com/dop251/goja v0.0.0-20260603143327-1f200ca63355/go.mod h1:YkABBhNI1qP6/NuyyPL5QqJ4L28ax4m+WAywAWr9fJk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
@@ -186,6 +188,8 @@ go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 h1:RuynHbfU8JUEw7DyONgkVYg2SVtsoF28y0LGIr69jgA=

--- a/internal/downloads/kinds.go
+++ b/internal/downloads/kinds.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/ebenderooock/loom/internal/indexers/throttle"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ebenderooock/loom/internal/indexers/throttle"
 )
 
 // Factory builds a live DownloadClient from a persisted Definition.

--- a/internal/downloads/kinds.go
+++ b/internal/downloads/kinds.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ebenderooock/loom/internal/indexers/throttle"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Factory builds a live DownloadClient from a persisted Definition.
@@ -103,7 +104,8 @@ func TransportForDefinition(def Definition) (http.RoundTripper, error) {
 			cfg = throttle.Resolve(c)
 		}
 	}
-	wrapped := throttle.Wrap(base, def.ID, string(def.Kind), cfg, throttle.Options{})
+	tracedBase := otelhttp.NewTransport(base)
+	wrapped := throttle.Wrap(tracedBase, def.ID, string(def.Kind), cfg, throttle.Options{})
 	return wrapped, err
 }
 

--- a/internal/downloads/kinds_tracing_test.go
+++ b/internal/downloads/kinds_tracing_test.go
@@ -1,0 +1,57 @@
+package downloads
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTransportForDefinitionEmitsClientSpan(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	tp.RegisterSpanProcessor(recorder)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	}()
+
+	rt, err := TransportForDefinition(Definition{ID: "dl-test", Kind: KindNull})
+	if err != nil {
+		t.Fatalf("TransportForDefinition: %v", err)
+	}
+	client := &http.Client{Transport: rt}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	spans := recorder.Ended()
+	var found bool
+	for _, span := range spans {
+		if span.SpanKind() == trace.SpanKindClient {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one client span, got %d spans", len(spans))
+	}
+}

--- a/internal/indexers/kinds.go
+++ b/internal/indexers/kinds.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/ebenderooock/loom/internal/indexers/throttle"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Factory builds a live Indexer from a persisted Definition. Each kind
@@ -136,7 +137,8 @@ func TransportForDefinition(def Definition) (http.RoundTripper, error) {
 			cfg.Burst = maxRPM
 		}
 	}
-	return throttle.Wrap(base, def.ID, string(def.Kind), cfg, throttle.Options{}), nil
+	tracedBase := otelhttp.NewTransport(base)
+	return throttle.Wrap(tracedBase, def.ID, string(def.Kind), cfg, throttle.Options{}), nil
 }
 
 // RegisterKind installs f as the factory for kind. It is idempotent;

--- a/internal/indexers/kinds.go
+++ b/internal/indexers/kinds.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/ebenderooock/loom/internal/indexers/throttle"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/ebenderooock/loom/internal/indexers/throttle"
 )
 
 // Factory builds a live Indexer from a persisted Definition. Each kind

--- a/internal/indexers/kinds_tracing_test.go
+++ b/internal/indexers/kinds_tracing_test.go
@@ -1,0 +1,57 @@
+package indexers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTransportForDefinitionEmitsClientSpan(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	tp.RegisterSpanProcessor(recorder)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	defer func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	}()
+
+	rt, err := TransportForDefinition(Definition{ID: "idx-test", Kind: KindNull})
+	if err != nil {
+		t.Fatalf("TransportForDefinition: %v", err)
+	}
+	client := &http.Client{Transport: rt}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	spans := recorder.Ended()
+	var found bool
+	for _, span := range spans {
+		if span.SpanKind() == trace.SpanKindClient {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one client span, got %d spans", len(spans))
+	}
+}

--- a/internal/kernel/config/config.go
+++ b/internal/kernel/config/config.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+// DefaultTraceRatio is the safe baseline sampler ratio used when
+// telemetry.trace_ratio is not explicitly configured.
+const DefaultTraceRatio = 0.1
+
 // Config is the root of all runtime configuration.
 type Config struct {
 	ConfigDir string `mapstructure:"config_dir"`
@@ -399,7 +403,7 @@ func applyDefaults(v *viper.Viper) {
 	v.SetDefault("log.buffer_size", 5000)
 
 	v.SetDefault("telemetry.prometheus", true)
-	v.SetDefault("telemetry.trace_ratio", 0.0)
+	v.SetDefault("telemetry.trace_ratio", DefaultTraceRatio)
 	v.SetDefault("telemetry.profiling", false)
 	v.SetDefault("telemetry.otlp_endpoint", "")
 

--- a/internal/kernel/config/config_test.go
+++ b/internal/kernel/config/config_test.go
@@ -52,6 +52,9 @@ func TestLoadDefaults(t *testing.T) {
 	if !cfg.Telemetry.Prometheus {
 		t.Errorf("prometheus should default to true")
 	}
+	if cfg.Telemetry.TraceRatio != DefaultTraceRatio {
+		t.Errorf("default telemetry.trace_ratio = %v, want %v", cfg.Telemetry.TraceRatio, DefaultTraceRatio)
+	}
 	if cfg.Auth.Mode != "forms" {
 		t.Errorf("default auth.mode = %q, want forms", cfg.Auth.Mode)
 	}

--- a/internal/kernel/telemetry/telemetry.go
+++ b/internal/kernel/telemetry/telemetry.go
@@ -119,10 +119,7 @@ func (t *Telemetry) startOTel(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	ratio := cfg.Telemetry.TraceRatio
-	if ratio <= 0 {
-		ratio = 0
-	}
+	ratio := resolveTraceRatio(cfg.Telemetry.TraceRatio)
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
 		sdktrace.WithResource(res),
@@ -167,6 +164,13 @@ func (t *Telemetry) startOTel(ctx context.Context, cfg *config.Config) error {
 	}
 
 	return nil
+}
+
+func resolveTraceRatio(ratio float64) float64 {
+	if ratio <= 0 || ratio > 1 {
+		return config.DefaultTraceRatio
+	}
+	return ratio
 }
 
 // Handler returns the Prometheus /metrics http.Handler. Always non-nil.

--- a/internal/kernel/telemetry/telemetry_test.go
+++ b/internal/kernel/telemetry/telemetry_test.go
@@ -79,3 +79,29 @@ func TestPackageAccessorsBeforeInit(t *testing.T) {
 		t.Errorf("Meter must return a no-op meter when uninitialized")
 	}
 }
+
+func TestResolveTraceRatio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{name: "positive ratio stays unchanged", in: 0.25, want: 0.25},
+		{name: "one stays unchanged", in: 1, want: 1},
+		{name: "zero falls back", in: 0, want: config.DefaultTraceRatio},
+		{name: "negative falls back", in: -0.1, want: config.DefaultTraceRatio},
+		{name: "above one falls back", in: 1.1, want: config.DefaultTraceRatio},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveTraceRatio(tt.in)
+			if got != tt.want {
+				t.Fatalf("resolveTraceRatio(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/go-chi/httprate"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/ebenderooock/loom/internal/alttitles"
 	"github.com/ebenderooock/loom/internal/analytics"
@@ -1046,7 +1047,20 @@ func (s *Server) newMux() http.Handler {
 		r.NotFound(spa.ServeHTTP)
 	}
 
-	return r
+	return otelhttp.NewHandler(r, "loom.http.server",
+		otelhttp.WithFilter(func(req *http.Request) bool {
+			return shouldTraceRoute(req.URL.Path)
+		}),
+	)
+}
+
+func shouldTraceRoute(path string) bool {
+	switch path {
+	case "/healthz", "/livez", "/readyz", "/metrics":
+		return false
+	default:
+		return true
+	}
 }
 
 func (s *Server) mountPprof(r chi.Router) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,6 +12,10 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ebenderooock/loom/internal/apikeys"
 	"github.com/ebenderooock/loom/internal/appconfig"
@@ -19,6 +23,21 @@ import (
 	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 	"github.com/ebenderooock/loom/internal/storage"
 )
+
+func installSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	tp.RegisterSpanProcessor(recorder)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return recorder
+}
 
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -158,6 +177,40 @@ func TestMetricsExposesPromText(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "go_goroutines") {
 		t.Errorf("metrics output should include process/go runtime collectors; got:\n%s", w.Body.String())
+	}
+}
+
+func TestOTelHTTPMiddlewareCreatesServerSpan(t *testing.T) {
+	s := newTestServer(t)
+	recorder := installSpanRecorder(t)
+
+	w := do(t, s.newMux(), http.MethodGet, "/api/v1/system/status")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	spans := recorder.Ended()
+	var found bool
+	for _, span := range spans {
+		if span.SpanKind() == trace.SpanKindServer {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one server span, got %d spans", len(spans))
+	}
+}
+
+func TestOTelHTTPMiddlewareSkipsProbeRoutes(t *testing.T) {
+	s := newTestServer(t)
+	recorder := installSpanRecorder(t)
+
+	w := do(t, s.newMux(), http.MethodGet, "/healthz")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if got := len(recorder.Ended()); got != 0 {
+		t.Fatalf("expected no spans for /healthz, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- wrap the server mux with `otelhttp` middleware so inbound HTTP requests emit server spans
- exclude probe/metrics routes (`/healthz`, `/livez`, `/readyz`, `/metrics`) from tracing noise
- instrument shared outbound HTTP transport composition in `indexers.TransportForDefinition` and `downloads.TransportForDefinition` with `otelhttp.NewTransport` so existing clients emit client spans
- change `telemetry.trace_ratio` default to `0.1` and add telemetry fallback to the same safe value when ratio is unset/non-positive/out-of-range
- add regression tests for inbound span emission + probe exclusion, outbound client span emission, and trace-ratio fallback/default behavior
- update observability/config docs for the new default and middleware behavior

## Validation
- `go test ./internal/kernel/config ./internal/kernel/telemetry ./internal/server ./internal/indexers ./internal/downloads`
- `go test ./...`

Fixes #89
