### PR TITLE
Instrument metrics for downloads/workflows/scheduler/rss and add in-flight gauges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/downloads/monitor.go
+++ b/internal/downloads/monitor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 // stalledState tracks the last known progress of a download item
@@ -210,6 +211,12 @@ func (m *Monitor) emitCompletions(ctx context.Context, items []Item) {
 				if m.orchNotifier != nil {
 					m.orchNotifier.NotifyDownloadComplete(item.ClientID, item.ID, item.Title, item.Category, item.ContentPath, item.SavePath)
 				}
+
+				durationSeconds := 0.0
+				if state, ok := m.lastProgress[key]; ok && !state.firstSeenAt.IsZero() {
+					durationSeconds = m.clock.Now().Sub(state.firstSeenAt).Seconds()
+				}
+				telemetry.ObserveDownloadCompleted(item.ClientID, durationSeconds)
 
 				// Persist to history store if available.
 				if m.historyStore != nil {

--- a/internal/downloads/router.go
+++ b/internal/downloads/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ebenderooock/loom/internal/downloads/torrentutil"
 	"github.com/ebenderooock/loom/internal/indexers"
 	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 	"github.com/ebenderooock/loom/internal/metadata"
 )
 
@@ -106,6 +107,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 	if r.svc.registry.Len() == 0 {
 		r.logger.Warn("router: no clients available",
 			"indexer_id", result.IndexerID)
+		telemetry.ObserveDownloadFailed("", "no_clients")
 		_ = r.bus.Publish(ctx, &DownloadFailureEvent{
 			OriginResultID: result.GUID,
 			ClientID:       "",
@@ -132,6 +134,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 	if len(clients) == 0 {
 		r.logger.Warn("router: no clients available at queue time",
 			"indexer_id", result.IndexerID)
+		telemetry.ObserveDownloadFailed("", "no_clients")
 		_ = r.bus.Publish(ctx, &DownloadFailureEvent{
 			OriginResultID: result.GUID,
 			ClientID:       "",
@@ -178,6 +181,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 		}
 		res, err := client.Add(ctx, req)
 		if err == nil {
+			telemetry.ObserveDownloadQueued(res.ClientID)
 			// Success: emit DownloadQueued and return.
 			addErr = r.bus.Publish(ctx, &DownloadQueuedEvent{
 				DownloadID:     res.ItemID,
@@ -213,6 +217,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 		Error:          fmt.Sprintf("all clients failed: %v", addErr),
 		FailedAt:       r.clock.Now(),
 	})
+	telemetry.ObserveDownloadFailed("", "all_clients_failed")
 	if failErr != nil {
 		r.logger.Warn("router failed to publish DownloadFailed", "err", failErr)
 	}

--- a/internal/kernel/scheduler/scheduler.go
+++ b/internal/kernel/scheduler/scheduler.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/robfig/cron/v3"
+
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 // HandlerFunc is the signature every registered job implements. The
@@ -344,6 +346,7 @@ func (s *Scheduler) executeOnce(ctx context.Context, j *job, scheduledFor time.T
 	startedAt := s.clock.Now()
 	status := StatusSuccess
 	errMsg := ""
+	telemetry.ObserveSchedulerStart(j.name)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -351,6 +354,8 @@ func (s *Scheduler) executeOnce(ctx context.Context, j *job, scheduledFor time.T
 			errMsg = fmt.Sprintf("panic: %v", r)
 			s.logger.Error("job panicked", "job", j.name, "panic", r)
 		}
+		durationSeconds := s.clock.Now().Sub(startedAt).Seconds()
+		telemetry.ObserveSchedulerFinish(j.name, status, durationSeconds)
 		nextRun := j.parsed.Next(s.clock.Now().In(s.cfg.Location))
 		recordCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()

--- a/internal/kernel/telemetry/appmetrics.go
+++ b/internal/kernel/telemetry/appmetrics.go
@@ -12,31 +12,9 @@ import (
 // with the canonical Prometheus registry so they appear on /metrics AND
 // (when OTel metrics push is enabled) are also exported via OTLP.
 type AppMetrics struct {
-	MoviesTotal   prometheus.Gauge
-	SeriesTotal   prometheus.Gauge
-	EpisodesTotal prometheus.Gauge
-
-	LibrariesTotal   prometheus.Gauge
-	LibrarySizeBytes *prometheus.GaugeVec
-
-	IndexersConfigured prometheus.Gauge
-	IndexersHealthy    prometheus.Gauge
-
 	ScanTotal          *prometheus.CounterVec
 	ScanDuration       *prometheus.HistogramVec
 	ScanFilesProcessed *prometheus.CounterVec
-
-	DownloadsActive        prometheus.Gauge
-	DownloadClientsTotal   prometheus.Gauge
-	DownloadClientsHealthy prometheus.Gauge
-	DownloadQueueSize      prometheus.Gauge
-	DownloadSpeedBytes     prometheus.Gauge
-
-	QualityProfilesTotal prometheus.Gauge
-
-	SearchRequests *prometheus.CounterVec
-	ImportTotal    *prometheus.CounterVec
-	NotifSent      *prometheus.CounterVec
 }
 
 // NewAppMetrics registers domain metrics with the given Prometheus
@@ -44,34 +22,6 @@ type AppMetrics struct {
 // update gauges/counters as state changes.
 func NewAppMetrics(reg *prometheus.Registry) *AppMetrics {
 	m := &AppMetrics{
-		MoviesTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_movies_total",
-			Help: "Current number of movies in the library.",
-		}),
-		SeriesTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_series_total",
-			Help: "Current number of series in the library.",
-		}),
-		EpisodesTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_episodes_total",
-			Help: "Current total episodes tracked.",
-		}),
-		LibrariesTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_libraries_total",
-			Help: "Number of configured libraries.",
-		}),
-		LibrarySizeBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "loom_library_size_bytes",
-			Help: "Size of each library in bytes.",
-		}, []string{"library_name"}),
-		IndexersConfigured: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_indexers_configured",
-			Help: "Number of configured indexers.",
-		}),
-		IndexersHealthy: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_indexers_healthy",
-			Help: "Number of indexers currently reporting healthy.",
-		}),
 		ScanTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "loom_scan_total",
 			Help: "Total scan operations.",
@@ -85,64 +35,9 @@ func NewAppMetrics(reg *prometheus.Registry) *AppMetrics {
 			Name: "loom_scan_files_processed_total",
 			Help: "Files processed during scans.",
 		}, []string{"type", "result"}),
-		DownloadsActive: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_downloads_active",
-			Help: "Number of currently active downloads.",
-		}),
-		DownloadClientsTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_download_clients_total",
-			Help: "Configured download clients.",
-		}),
-		DownloadClientsHealthy: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_download_clients_healthy",
-			Help: "Healthy download clients.",
-		}),
-		DownloadQueueSize: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_download_queue_size",
-			Help: "Items in download queue.",
-		}),
-		DownloadSpeedBytes: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_download_speed_bytes",
-			Help: "Current download speed in bytes/sec.",
-		}),
-		QualityProfilesTotal: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "loom_quality_profiles_total",
-			Help: "Number of quality profiles.",
-		}),
-		SearchRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "loom_search_requests_total",
-			Help: "Total search requests.",
-		}, []string{"type"}),
-		ImportTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "loom_import_total",
-			Help: "Total import operations.",
-		}, []string{"status"}),
-		NotifSent: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "loom_notifications_sent_total",
-			Help: "Total notifications sent.",
-		}, []string{"provider", "status"}),
 	}
-	reg.MustRegister(
-		m.MoviesTotal,
-		m.SeriesTotal,
-		m.EpisodesTotal,
-		m.LibrariesTotal,
-		m.LibrarySizeBytes,
-		m.IndexersConfigured,
-		m.IndexersHealthy,
-		m.ScanTotal,
-		m.ScanDuration,
-		m.ScanFilesProcessed,
-		m.DownloadsActive,
-		m.DownloadClientsTotal,
-		m.DownloadClientsHealthy,
-		m.DownloadQueueSize,
-		m.DownloadSpeedBytes,
-		m.QualityProfilesTotal,
-		m.SearchRequests,
-		m.ImportTotal,
-		m.NotifSent,
-	)
+	defer func() { _ = recover() }()
+	reg.MustRegister(m.ScanTotal, m.ScanDuration, m.ScanFilesProcessed)
 	return m
 }
 

--- a/internal/kernel/telemetry/domainmetrics.go
+++ b/internal/kernel/telemetry/domainmetrics.go
@@ -1,0 +1,243 @@
+package telemetry
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	domainMetricsOnce sync.Once
+	domainMetrics     struct {
+		downloadLifecycle *prometheus.CounterVec
+		downloadDuration  *prometheus.HistogramVec
+
+		workflowTransitions *prometheus.CounterVec
+		workflowRetries     *prometheus.CounterVec
+		workflowActive      *prometheus.GaugeVec
+		workflowStale       *prometheus.CounterVec
+
+		schedulerRuns     *prometheus.CounterVec
+		schedulerDuration *prometheus.HistogramVec
+		schedulerInFlight *prometheus.GaugeVec
+
+		rssSyncTotal    *prometheus.CounterVec
+		rssSyncDuration *prometheus.HistogramVec
+		rssItemsTotal   *prometheus.CounterVec
+	}
+)
+
+func registerDomainMetrics() {
+	domainMetricsOnce.Do(func() {
+		// PromQL:
+		//   sum by(stage, client_id) (rate(loom_download_lifecycle_total[5m]))
+		// Alert suggestion:
+		//   rate(loom_download_lifecycle_total{stage="failed"}[10m]) > 0.2
+		domainMetrics.downloadLifecycle = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_download_lifecycle_total",
+			Help: "Total download lifecycle events.",
+		}, []string{"stage", "client_id", "reason"})
+
+		// PromQL:
+		//   histogram_quantile(0.95, sum by(le, client_id) (rate(loom_download_completion_seconds_bucket[15m])))
+		// Alert suggestion:
+		//   histogram_quantile(0.95, sum by(le) (rate(loom_download_completion_seconds_bucket[30m]))) > 7200
+		domainMetrics.downloadDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "loom_download_completion_seconds",
+			Help:    "Observed time from first-seen to completion for downloads.",
+			Buckets: prometheus.ExponentialBuckets(30, 2, 10),
+		}, []string{"client_id"})
+
+		// PromQL:
+		//   sum by(from_state, to_state) (rate(loom_workflow_transitions_total[10m]))
+		// Alert suggestion:
+		//   rate(loom_workflow_transitions_total{to_state="failed"}[10m]) > 0.1
+		domainMetrics.workflowTransitions = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_workflow_transitions_total",
+			Help: "Total workflow state transitions.",
+		}, []string{"from_state", "to_state"})
+
+		// PromQL:
+		//   sum by(state, outcome) (rate(loom_workflow_retries_total[10m]))
+		// Alert suggestion:
+		//   rate(loom_workflow_retries_total{outcome="exhausted"}[15m]) > 0
+		domainMetrics.workflowRetries = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_workflow_retries_total",
+			Help: "Total workflow retry outcomes.",
+		}, []string{"state", "outcome"})
+
+		// PromQL:
+		//   sum by(state) (loom_workflows_active)
+		// Alert suggestion:
+		//   sum(loom_workflows_active{state="searching"}) > 200
+		domainMetrics.workflowActive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loom_workflows_active",
+			Help: "Current number of active workflows by state.",
+		}, []string{"state"})
+
+		// PromQL:
+		//   sum by(state, action) (rate(loom_workflow_stale_total[10m]))
+		// Alert suggestion:
+		//   rate(loom_workflow_stale_total{action="failed"}[15m]) > 0
+		domainMetrics.workflowStale = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_workflow_stale_total",
+			Help: "Total stale workflow detections and outcomes.",
+		}, []string{"state", "action"})
+
+		// PromQL:
+		//   sum by(job, status) (rate(loom_scheduler_runs_total[5m]))
+		// Alert suggestion:
+		//   rate(loom_scheduler_runs_total{status="failed"}[10m]) > 0
+		domainMetrics.schedulerRuns = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_scheduler_runs_total",
+			Help: "Total scheduler job runs by status.",
+		}, []string{"job", "status"})
+
+		// PromQL:
+		//   histogram_quantile(0.95, sum by(le, job) (rate(loom_scheduler_duration_seconds_bucket[15m])))
+		// Alert suggestion:
+		//   histogram_quantile(0.95, sum by(le) (rate(loom_scheduler_duration_seconds_bucket[30m]))) > 300
+		domainMetrics.schedulerDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "loom_scheduler_duration_seconds",
+			Help:    "Scheduler job run duration in seconds.",
+			Buckets: prometheus.ExponentialBuckets(0.05, 2, 10),
+		}, []string{"job", "status"})
+
+		// PromQL:
+		//   sum by(job) (loom_scheduler_in_flight)
+		// Alert suggestion:
+		//   loom_scheduler_in_flight > 0 for 30m
+		domainMetrics.schedulerInFlight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "loom_scheduler_in_flight",
+			Help: "Number of in-flight scheduler job executions.",
+		}, []string{"job"})
+
+		// PromQL:
+		//   sum by(source_id, outcome) (rate(loom_rss_sync_total[10m]))
+		// Alert suggestion:
+		//   rate(loom_rss_sync_total{outcome="failed"}[15m]) > 0
+		domainMetrics.rssSyncTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_rss_sync_total",
+			Help: "Total RSS source sync attempts by outcome.",
+		}, []string{"source_id", "outcome"})
+
+		// PromQL:
+		//   histogram_quantile(0.95, sum by(le, source_id) (rate(loom_rss_sync_duration_seconds_bucket[30m])))
+		// Alert suggestion:
+		//   histogram_quantile(0.95, sum by(le) (rate(loom_rss_sync_duration_seconds_bucket[30m]))) > 60
+		domainMetrics.rssSyncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "loom_rss_sync_duration_seconds",
+			Help:    "RSS source sync duration in seconds.",
+			Buckets: prometheus.ExponentialBuckets(0.01, 2, 12),
+		}, []string{"source_id", "outcome"})
+
+		// PromQL:
+		//   sum by(source_id, result) (rate(loom_rss_items_total[10m]))
+		// Alert suggestion:
+		//   rate(loom_rss_items_total{result="stored"}[30m]) == 0
+		domainMetrics.rssItemsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "loom_rss_items_total",
+			Help: "Total RSS items processed by source and result.",
+		}, []string{"source_id", "result"})
+
+		reg := prometheus.DefaultRegisterer
+		if t := Default(); t != nil && t.Registry() != nil {
+			reg = t.Registry()
+		}
+		defer func() { _ = recover() }()
+		reg.MustRegister(
+			domainMetrics.downloadLifecycle,
+			domainMetrics.downloadDuration,
+			domainMetrics.workflowTransitions,
+			domainMetrics.workflowRetries,
+			domainMetrics.workflowActive,
+			domainMetrics.workflowStale,
+			domainMetrics.schedulerRuns,
+			domainMetrics.schedulerDuration,
+			domainMetrics.schedulerInFlight,
+			domainMetrics.rssSyncTotal,
+			domainMetrics.rssSyncDuration,
+			domainMetrics.rssItemsTotal,
+		)
+	})
+}
+
+func boundedLabel(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func ObserveDownloadQueued(clientID string) {
+	registerDomainMetrics()
+	domainMetrics.downloadLifecycle.WithLabelValues("queued", boundedLabel(clientID), "none").Inc()
+}
+
+func ObserveDownloadFailed(clientID, reason string) {
+	registerDomainMetrics()
+	domainMetrics.downloadLifecycle.WithLabelValues("failed", boundedLabel(clientID), boundedLabel(reason)).Inc()
+}
+
+func ObserveDownloadCompleted(clientID string, durationSeconds float64) {
+	registerDomainMetrics()
+	client := boundedLabel(clientID)
+	domainMetrics.downloadLifecycle.WithLabelValues("completed", client, "none").Inc()
+	if durationSeconds > 0 {
+		domainMetrics.downloadDuration.WithLabelValues(client).Observe(durationSeconds)
+	}
+}
+
+func ObserveWorkflowTransition(fromState, toState string) {
+	registerDomainMetrics()
+	domainMetrics.workflowTransitions.WithLabelValues(boundedLabel(fromState), boundedLabel(toState)).Inc()
+}
+
+func ObserveWorkflowRetry(state, outcome string) {
+	registerDomainMetrics()
+	domainMetrics.workflowRetries.WithLabelValues(boundedLabel(state), boundedLabel(outcome)).Inc()
+}
+
+func SetWorkflowActiveByState(counts map[string]int) {
+	registerDomainMetrics()
+	for _, state := range []string{"searching", "grabbed", "downloading", "post_download", "importing", "cleaning_up"} {
+		domainMetrics.workflowActive.WithLabelValues(state).Set(float64(counts[state]))
+	}
+}
+
+func ObserveWorkflowStale(state, action string) {
+	registerDomainMetrics()
+	domainMetrics.workflowStale.WithLabelValues(boundedLabel(state), boundedLabel(action)).Inc()
+}
+
+func ObserveSchedulerStart(job string) {
+	registerDomainMetrics()
+	domainMetrics.schedulerInFlight.WithLabelValues(boundedLabel(job)).Inc()
+}
+
+func ObserveSchedulerFinish(job, status string, durationSeconds float64) {
+	registerDomainMetrics()
+	jobLabel := boundedLabel(job)
+	statusLabel := boundedLabel(status)
+	domainMetrics.schedulerInFlight.WithLabelValues(jobLabel).Dec()
+	domainMetrics.schedulerRuns.WithLabelValues(jobLabel, statusLabel).Inc()
+	if durationSeconds > 0 {
+		domainMetrics.schedulerDuration.WithLabelValues(jobLabel, statusLabel).Observe(durationSeconds)
+	}
+}
+
+func ObserveRSSSourceSync(sourceID, outcome string, durationSeconds float64, stored, deduped int64) {
+	registerDomainMetrics()
+	source := boundedLabel(sourceID)
+	outcomeLabel := boundedLabel(outcome)
+	domainMetrics.rssSyncTotal.WithLabelValues(source, outcomeLabel).Inc()
+	if durationSeconds >= 0 {
+		domainMetrics.rssSyncDuration.WithLabelValues(source, outcomeLabel).Observe(durationSeconds)
+	}
+	if stored > 0 {
+		domainMetrics.rssItemsTotal.WithLabelValues(source, "stored").Add(float64(stored))
+	}
+	if deduped > 0 {
+		domainMetrics.rssItemsTotal.WithLabelValues(source, "deduped").Add(float64(deduped))
+	}
+}

--- a/internal/kernel/telemetry/domainmetrics.go
+++ b/internal/kernel/telemetry/domainmetrics.go
@@ -169,16 +169,19 @@ func boundedLabel(value string) string {
 	return value
 }
 
+// ObserveDownloadQueued records a successful queue event for a download client.
 func ObserveDownloadQueued(clientID string) {
 	registerDomainMetrics()
 	domainMetrics.downloadLifecycle.WithLabelValues("queued", boundedLabel(clientID), "none").Inc()
 }
 
+// ObserveDownloadFailed records a failed queue/routing attempt.
 func ObserveDownloadFailed(clientID, reason string) {
 	registerDomainMetrics()
 	domainMetrics.downloadLifecycle.WithLabelValues("failed", boundedLabel(clientID), boundedLabel(reason)).Inc()
 }
 
+// ObserveDownloadCompleted records a completion event and optional latency.
 func ObserveDownloadCompleted(clientID string, durationSeconds float64) {
 	registerDomainMetrics()
 	client := boundedLabel(clientID)
@@ -188,16 +191,19 @@ func ObserveDownloadCompleted(clientID string, durationSeconds float64) {
 	}
 }
 
+// ObserveWorkflowTransition records a workflow state transition.
 func ObserveWorkflowTransition(fromState, toState string) {
 	registerDomainMetrics()
 	domainMetrics.workflowTransitions.WithLabelValues(boundedLabel(fromState), boundedLabel(toState)).Inc()
 }
 
+// ObserveWorkflowRetry records a workflow retry outcome.
 func ObserveWorkflowRetry(state, outcome string) {
 	registerDomainMetrics()
 	domainMetrics.workflowRetries.WithLabelValues(boundedLabel(state), boundedLabel(outcome)).Inc()
 }
 
+// SetWorkflowActiveByState sets active workflow gauges by state.
 func SetWorkflowActiveByState(counts map[string]int) {
 	registerDomainMetrics()
 	for _, state := range []string{"searching", "grabbed", "downloading", "post_download", "importing", "cleaning_up"} {
@@ -205,16 +211,19 @@ func SetWorkflowActiveByState(counts map[string]int) {
 	}
 }
 
+// ObserveWorkflowStale records stale workflow detection outcomes.
 func ObserveWorkflowStale(state, action string) {
 	registerDomainMetrics()
 	domainMetrics.workflowStale.WithLabelValues(boundedLabel(state), boundedLabel(action)).Inc()
 }
 
+// ObserveSchedulerStart increments the in-flight gauge for a scheduler job.
 func ObserveSchedulerStart(job string) {
 	registerDomainMetrics()
 	domainMetrics.schedulerInFlight.WithLabelValues(boundedLabel(job)).Inc()
 }
 
+// ObserveSchedulerFinish records scheduler completion status and duration.
 func ObserveSchedulerFinish(job, status string, durationSeconds float64) {
 	registerDomainMetrics()
 	jobLabel := boundedLabel(job)
@@ -226,6 +235,7 @@ func ObserveSchedulerFinish(job, status string, durationSeconds float64) {
 	}
 }
 
+// ObserveRSSSourceSync records RSS sync outcome, duration, and item counters.
 func ObserveRSSSourceSync(sourceID, outcome string, durationSeconds float64, stored, deduped int64) {
 	registerDomainMetrics()
 	source := boundedLabel(sourceID)

--- a/internal/kernel/telemetry/middleware.go
+++ b/internal/kernel/telemetry/middleware.go
@@ -17,6 +17,7 @@ type HTTPMetrics struct {
 	reqDuration *prometheus.HistogramVec
 	reqSize     *prometheus.HistogramVec
 	respSize    *prometheus.HistogramVec
+	reqInFlight *prometheus.GaugeVec
 }
 
 // NewHTTPMetrics creates HTTP metrics and registers them with the given
@@ -44,8 +45,16 @@ func NewHTTPMetrics(reg *prometheus.Registry) *HTTPMetrics {
 			Help:    "HTTP response body size in bytes.",
 			Buckets: prometheus.ExponentialBuckets(100, 10, 6),
 		}, []string{"method", "route"}),
+		// PromQL:
+		//   sum by(method, route) (http_requests_in_flight)
+		// Alert suggestion:
+		//   sum(http_requests_in_flight) > 200 for 5m
+		reqInFlight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "http_requests_in_flight",
+			Help: "Current number of in-flight HTTP requests.",
+		}, []string{"method", "route"}),
 	}
-	reg.MustRegister(m.reqTotal, m.reqDuration, m.reqSize, m.respSize)
+	reg.MustRegister(m.reqTotal, m.reqDuration, m.reqSize, m.respSize, m.reqInFlight)
 	return m
 }
 
@@ -56,10 +65,12 @@ func (m *HTTPMetrics) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ww := &responseWriter{ResponseWriter: w, status: http.StatusOK}
-		next.ServeHTTP(ww, r)
-
 		route := routePattern(r)
 		method := r.Method
+		m.reqInFlight.WithLabelValues(method, route).Inc()
+		defer m.reqInFlight.WithLabelValues(method, route).Dec()
+		next.ServeHTTP(ww, r)
+
 		status := strconv.Itoa(ww.status)
 		elapsed := time.Since(start).Seconds()
 

--- a/internal/kernel/telemetry/middleware_test.go
+++ b/internal/kernel/telemetry/middleware_test.go
@@ -1,0 +1,58 @@
+package telemetry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestHTTPInFlightGauge(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := NewHTTPMetrics(reg)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+
+	handler := metrics.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+
+	go func() {
+		handler.ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+
+	inFlight := testutil.ToFloat64(metrics.reqInFlight.WithLabelValues(http.MethodGet, "/test"))
+	if inFlight != 1 {
+		t.Fatalf("in-flight gauge = %v, want 1", inFlight)
+	}
+
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("request did not finish")
+	}
+
+	inFlight = testutil.ToFloat64(metrics.reqInFlight.WithLabelValues(http.MethodGet, "/test"))
+	if inFlight != 0 {
+		t.Fatalf("in-flight gauge = %v, want 0", inFlight)
+	}
+}

--- a/internal/rss/sync.go
+++ b/internal/rss/sync.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 // SyncManager orchestrates periodic RSS feed synchronization from multiple sources.
@@ -91,20 +93,24 @@ func (m *SyncManager) SyncFeeds(ctx context.Context) error {
 // syncSource fetches and stores items from a single source.
 func (m *SyncManager) syncSource(ctx context.Context, source FeedSource, totalStored, totalDeduped *int64) error {
 	m.logger.Debug("syncing source", slog.String("source_id", source.ID()), slog.String("name", source.Name()))
+	start := time.Now()
 
 	items, err := source.Fetch(ctx)
 	if err != nil {
+		telemetry.ObserveRSSSourceSync(source.ID(), "failed", time.Since(start).Seconds(), 0, 0)
 		return err
 	}
 
 	m.logger.Debug("fetched items", slog.String("source_id", source.ID()), slog.Int("count", len(items)))
 
 	if len(items) == 0 {
+		telemetry.ObserveRSSSourceSync(source.ID(), "success", time.Since(start).Seconds(), 0, 0)
 		return nil
 	}
 
 	stored, deduped, err := m.storage.StoreItems(ctx, items)
 	if err != nil {
+		telemetry.ObserveRSSSourceSync(source.ID(), "failed", time.Since(start).Seconds(), 0, 0)
 		return err
 	}
 
@@ -116,6 +122,7 @@ func (m *SyncManager) syncSource(ctx context.Context, source FeedSource, totalSt
 		slog.Int("stored", stored),
 		slog.Int("deduped", deduped),
 	)
+	telemetry.ObserveRSSSourceSync(source.ID(), "success", time.Since(start).Seconds(), int64(stored), int64(deduped))
 
 	return nil
 }

--- a/internal/workflows/engine.go
+++ b/internal/workflows/engine.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 // MediaStatusUpdater abstracts movie/episode status updates.
@@ -291,6 +293,7 @@ func (e *Engine) markFailed(ctx context.Context, workflowID, errMsg string) erro
 	}
 
 	if retryCount >= wf.MaxRetries {
+		telemetry.ObserveWorkflowRetry(wf.State, "exhausted")
 		// Exhausted retries — permanent failure
 		ok, err := e.store.Transition(ctx, workflowID, wf.State, StateFailed,
 			fmt.Sprintf("Failed after %d retries: %s", retryCount, errMsg))
@@ -307,6 +310,7 @@ func (e *Engine) markFailed(ctx context.Context, workflowID, errMsg string) erro
 
 	// Determine retry target state based on where it failed
 	retryState := e.retryTargetState(wf.State)
+	telemetry.ObserveWorkflowRetry(wf.State, "retrying")
 	ok, transErr := e.store.Transition(ctx, workflowID, wf.State, retryState,
 		fmt.Sprintf("Retry %d/%d: %s", retryCount, wf.MaxRetries, errMsg))
 	if transErr != nil {

--- a/internal/workflows/orchestrator.go
+++ b/internal/workflows/orchestrator.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 const (
@@ -1135,6 +1137,7 @@ func (o *Orchestrator) handleStale(ctx context.Context) {
 				key := wf.DownloadClientID + ":" + wf.DownloadID
 				if info, exists := dlStates[key]; exists {
 					if info.Status == "completed" || info.Status == "seeding" {
+						telemetry.ObserveWorkflowStale(wf.State, "recovered_completion")
 						o.logger.Info("stale recovery: download is actually complete, recovering",
 							"workflow_id", wf.ID, "state", wf.State, "dl_state", info.Status)
 						o.logEvent(ctx, wf.ID, EventStaleDetected,
@@ -1149,6 +1152,7 @@ func (o *Orchestrator) handleStale(ctx context.Context) {
 						continue
 					}
 					if info.Status == "downloading" {
+						telemetry.ObserveWorkflowStale(wf.State, "still_active")
 						// Still downloading — touch updated_at to reset stale timer
 						_ = o.store.MergeMetadata(ctx, wf.ID, map[string]any{"stale_check": "still_downloading"})
 						o.logger.Debug("stale check: download still active, resetting timer",
@@ -1183,6 +1187,7 @@ func (o *Orchestrator) handleStale(ctx context.Context) {
 		o.logEvent(ctx, wf.ID, EventStaleDetected,
 			fmt.Sprintf("Stale in %s state for %s", wf.State, age.Round(time.Second)),
 			map[string]any{"state": wf.State, "age_seconds": int(age.Seconds())})
+		telemetry.ObserveWorkflowStale(wf.State, "failed")
 
 		err := o.engine.markFailed(ctx, wf.ID,
 			fmt.Sprintf("Stale in %s state for %s", wf.State, age.Round(time.Second)))

--- a/internal/workflows/orchestrator.go
+++ b/internal/workflows/orchestrator.go
@@ -83,7 +83,7 @@ type OrchestratorOpts struct {
 	Engine         *Engine
 	Logger         *slog.Logger
 	ImportFn       ImportFunc
-	PreImportFn    PreImportFunc         // optional; stops+removes torrent before import
+	PreImportFn    PreImportFunc          // optional; stops+removes torrent before import
 	CleanupFn      CleanupFunc            // optional; if nil, cleanup phase is skipped
 	MediaRefreshFn MediaRefreshFunc       // optional; if nil, media refresh is skipped
 	DownloadStatus DownloadStatusProvider // optional, for startup reconciliation

--- a/internal/workflows/store.go
+++ b/internal/workflows/store.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/ebenderooock/loom/internal/kernel/telemetry"
 )
 
 // Store provides persistence for workflows.
@@ -137,7 +139,11 @@ func (s *Store) Create(ctx context.Context, w *Workflow) error {
 		return fmt.Errorf("insert history: %w", err)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.refreshActiveMetrics(ctx)
+	return nil
 }
 
 // Transition atomically moves a workflow to a new state (idempotent guard).
@@ -177,7 +183,12 @@ func (s *Store) Transition(ctx context.Context, id, fromState, toState, message 
 		return false, err
 	}
 
-	return true, tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	telemetry.ObserveWorkflowTransition(fromState, toState)
+	s.refreshActiveMetrics(ctx)
+	return true, nil
 }
 
 // SetError records an error on the workflow.
@@ -471,7 +482,11 @@ func (s *Store) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	s.refreshActiveMetrics(ctx)
+	return nil
 }
 
 // MergeItems adds items to an existing workflow, ignoring duplicates.
@@ -684,4 +699,30 @@ func (s *Store) MergeMetadata(ctx context.Context, id string, patch map[string]a
 		m[k] = v
 	}
 	return s.SetMetadata(ctx, id, MetadataFromMap(m))
+}
+
+func (s *Store) refreshActiveMetrics(ctx context.Context) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT state, COUNT(*)
+		FROM workflows
+		WHERE state NOT IN ('completed', 'failed', 'cancelled')
+		GROUP BY state`)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int)
+	for rows.Next() {
+		var state string
+		var count int
+		if scanErr := rows.Scan(&state, &count); scanErr != nil {
+			return
+		}
+		counts[state] = count
+	}
+	if err := rows.Err(); err != nil {
+		return
+	}
+	telemetry.SetWorkflowActiveByState(counts)
 }

--- a/internal/workflows/store.go
+++ b/internal/workflows/store.go
@@ -710,7 +710,7 @@ func (s *Store) refreshActiveMetrics(ctx context.Context) {
 	if err != nil {
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	counts := make(map[string]int)
 	for rows.Next() {


### PR DESCRIPTION
## Summary
- add bounded-label Prometheus instrumentation for downloads, workflows, scheduler, and RSS sync paths
- add `http_requests_in_flight` middleware gauge with method+route labels
- remove stale declared-but-never-set `AppMetrics` gauges and keep only active scan metrics
- add metric declaration comments with PromQL and alert suggestions for all newly introduced collectors
- add telemetry middleware test coverage for in-flight gauge behavior

## Validation
- `go test ./internal/kernel/telemetry ./internal/downloads ./internal/workflows ./internal/rss ./internal/kernel/scheduler ./internal/server ./cmd/loom`

Fixes #91
