### PR TITLE
Consolidate Activity/Downloads surfaces and capture failed history

### DIFF
--- a/internal/downloads/history.go
+++ b/internal/downloads/history.go
@@ -30,29 +30,51 @@ func NewHistoryStore(db *sql.DB) *HistoryStore {
 	return &HistoryStore{db: db}
 }
 
-// RecordCompletion inserts a new history row from a DownloadCompletedEvent.
+// RecordCompletion inserts a new completed-history row from a DownloadCompletedEvent.
 func (h *HistoryStore) RecordCompletion(ctx context.Context, event *DownloadCompletedEvent) error {
-	id := uuid.New().String()
-	completedAt := event.CompletedAt.UTC().Format(time.RFC3339)
+	return h.record(ctx, event.DownloadID, event.ClientID, event.Title, event.Category, "completed", event.CompletedAt)
+}
 
-	_, err := h.db.ExecContext(ctx,
-		`INSERT INTO download_history (id, download_id, client_id, title, category, status, completed_at)
-		 VALUES (?, ?, ?, ?, ?, 'completed', ?)`,
-		id, event.DownloadID, event.ClientID, event.Title, event.Category, completedAt,
-	)
-	return err
+// RecordFailure inserts a new failed-history row for a failed download.
+func (h *HistoryStore) RecordFailure(
+	ctx context.Context,
+	clientID, downloadID, title, category string,
+	failedAt time.Time,
+) error {
+	return h.record(ctx, downloadID, clientID, title, category, "failed", failedAt)
 }
 
 // WasCompleted checks whether a download was already emitted as completed.
 // Used for idempotency across process restarts — prevents re-importing
 // a download that was already handled in a previous session.
 func (h *HistoryStore) WasCompleted(ctx context.Context, clientID, downloadID string) bool {
+	return h.WasRecorded(ctx, clientID, downloadID, "completed")
+}
+
+// WasRecorded checks whether a download has already been persisted with
+// the given history status.
+func (h *HistoryStore) WasRecorded(ctx context.Context, clientID, downloadID, status string) bool {
 	var count int
 	err := h.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM download_history WHERE client_id = ? AND download_id = ? AND status = 'completed'`,
-		clientID, downloadID,
+		`SELECT COUNT(*) FROM download_history WHERE client_id = ? AND download_id = ? AND status = ?`,
+		clientID, downloadID, status,
 	).Scan(&count)
 	return err == nil && count > 0
+}
+
+func (h *HistoryStore) record(
+	ctx context.Context,
+	downloadID, clientID, title, category, status string,
+	at time.Time,
+) error {
+	id := uuid.New().String()
+	completedAt := at.UTC().Format(time.RFC3339)
+	_, err := h.db.ExecContext(ctx,
+		`INSERT INTO download_history (id, download_id, client_id, title, category, status, completed_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, downloadID, clientID, title, category, status, completedAt,
+	)
+	return err
 }
 
 // List returns history entries ordered by completed_at descending.

--- a/internal/downloads/history_test.go
+++ b/internal/downloads/history_test.go
@@ -1,0 +1,71 @@
+package downloads
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/kernel/config"
+	"github.com/ebenderooock/loom/internal/storage"
+)
+
+func openHistoryTestStore(t *testing.T) *HistoryStore {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := config.StorageConfig{
+		Engine: "sqlite",
+		SQLite: config.SQLiteConfig{Path: filepath.Join(dir, "loom.db")},
+	}
+	db, err := storage.Open(context.Background(), cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("open storage: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate storage: %v", err)
+	}
+	return NewHistoryStore(db.DB())
+}
+
+func TestHistoryStoreRecordsCompletedAndFailed(t *testing.T) {
+	t.Parallel()
+	store := openHistoryTestStore(t)
+	ctx := context.Background()
+
+	completedAt := time.Date(2026, 7, 24, 2, 0, 0, 0, time.UTC)
+	if err := store.RecordCompletion(ctx, &DownloadCompletedEvent{
+		DownloadID:  "dl-complete-1",
+		ClientID:    "client-1",
+		Title:       "Completed Download",
+		Category:    "movies",
+		CompletedAt: completedAt,
+	}); err != nil {
+		t.Fatalf("record completion: %v", err)
+	}
+
+	failedAt := completedAt.Add(5 * time.Minute)
+	if err := store.RecordFailure(ctx, "client-1", "dl-failed-1", "Failed Download", "tv", failedAt); err != nil {
+		t.Fatalf("record failure: %v", err)
+	}
+
+	if !store.WasCompleted(ctx, "client-1", "dl-complete-1") {
+		t.Fatalf("expected completed download to be recorded")
+	}
+	if store.WasCompleted(ctx, "client-1", "dl-failed-1") {
+		t.Fatalf("failed download should not be treated as completed")
+	}
+	if !store.WasRecorded(ctx, "client-1", "dl-failed-1", "failed") {
+		t.Fatalf("expected failed download to be recorded with failed status")
+	}
+
+	entries, err := store.List(ctx, 50, 0)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 history entries, got %d", len(entries))
+	}
+}

--- a/internal/downloads/monitor.go
+++ b/internal/downloads/monitor.go
@@ -245,6 +245,12 @@ func (m *Monitor) detectStalled(ctx context.Context, items []Item) {
 
 		// Handle failed items immediately.
 		if item.Status == StatusItemFailed {
+			if m.historyStore != nil && !m.historyStore.WasRecorded(ctx, item.ClientID, item.ID, "failed") {
+				if err := m.historyStore.RecordFailure(ctx, item.ClientID, item.ID, item.Title, item.Category, now); err != nil {
+					m.logger.Warn("monitor: failed to record failed history entry",
+						"item_id", item.ID, "client_id", item.ClientID, "error", err)
+				}
+			}
 			if !m.stalledEmitted[key] {
 				m.stalledEmitted[key] = true
 				if m.stallHandler != nil {

--- a/internal/downloads/monitor_test.go
+++ b/internal/downloads/monitor_test.go
@@ -174,6 +174,40 @@ func TestMonitorRunSchedules(t *testing.T) {
 	}
 }
 
+func TestMonitorRecordsFailedDownloadsInHistory(t *testing.T) {
+	t.Parallel()
+
+	bus := &eventbusStub{capturingBusForMonitor: capturingBusForMonitor{events: []eventbus.Event{}}}
+	monitor := newTestMonitor(t, bus)
+	monitor.historyStore = openHistoryTestStore(t)
+
+	items := []Item{
+		{
+			ID:       "failed-1",
+			ClientID: "client-1",
+			Title:    "Failed Item",
+			Category: "movies",
+			Status:   StatusItemFailed,
+			Message:  "disk full",
+		},
+	}
+
+	monitor.detectStalled(context.Background(), items)
+	monitor.detectStalled(context.Background(), items)
+
+	if !monitor.historyStore.WasRecorded(context.Background(), "client-1", "failed-1", "failed") {
+		t.Fatalf("expected failed item to be recorded in history")
+	}
+
+	entries, err := monitor.historyStore.List(context.Background(), 50, 0)
+	if err != nil {
+		t.Fatalf("list history: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 failed history entry, got %d", len(entries))
+	}
+}
+
 // fakeClientWithStatus returns fixed status results.
 type fakeClientWithStatus struct {
 	id    string

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -70,13 +70,13 @@ const navItems: NavItem[] = [
   {
     label: "Activity",
     to: "/activity",
-    keywords: "history queue",
+    keywords: "history blocklist reviews",
     Icon: ListTodo,
   },
   {
     label: "Downloads",
     to: "/downloads",
-    keywords: "torrents clients",
+    keywords: "active queue imports cleanup torrents clients",
     Icon: Download,
   },
   {

--- a/web/src/pages/__tests__/activity-page.test.tsx
+++ b/web/src/pages/__tests__/activity-page.test.tsx
@@ -31,6 +31,8 @@ describe("ActivityPage consolidation", () => {
     expect(await screen.findByRole("tab", { name: /History/i })).toBeVisible();
     expect(screen.getByRole("tab", { name: /Blocklist/i })).toBeVisible();
     expect(screen.getByRole("tab", { name: /Reviews/i })).toBeVisible();
-    expect(screen.queryByRole("tab", { name: /^Queue$/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: /^Queue$/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/__tests__/activity-page.test.tsx
+++ b/web/src/pages/__tests__/activity-page.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ActivityPage } from "../activity";
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { role: "admin" } }),
+}));
+
+vi.mock("@/lib/fetch", () => ({
+  apiFetch: vi.fn(async (url: string) => {
+    if (url.startsWith("/api/v1/reviews/count")) {
+      return { ok: true, json: async () => ({ count: 0 }) };
+    }
+    if (url.startsWith("/api/v1/downloads/history")) {
+      return { ok: true, json: async () => [] };
+    }
+    if (url.startsWith("/api/v1/blocklist")) {
+      return { ok: true, json: async () => ({ data: [] }) };
+    }
+    if (url.startsWith("/api/v1/reviews")) {
+      return { ok: true, json: async () => ({ data: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }),
+}));
+
+describe("ActivityPage consolidation", () => {
+  it("shows history-focused tabs without queue entry", async () => {
+    render(<ActivityPage />);
+
+    expect(await screen.findByRole("tab", { name: /History/i })).toBeVisible();
+    expect(screen.getByRole("tab", { name: /Blocklist/i })).toBeVisible();
+    expect(screen.getByRole("tab", { name: /Reviews/i })).toBeVisible();
+    expect(screen.queryByRole("tab", { name: /^Queue$/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/activity.tsx
+++ b/web/src/pages/activity.tsx
@@ -918,7 +918,7 @@ function ReviewQueue() {
 }
 
 export function ActivityPage() {
-  useSetPageHeader("Activity");
+  useSetPageHeader("Activity", "History, blocklist, and manual reviews");
 
   const [reviewCount, setReviewCount] = React.useState(0);
 
@@ -931,9 +931,14 @@ export function ActivityPage() {
 
   return (
     <div className="space-y-6">
-      <Tabs defaultValue="queue">
+      <Card className="border-dashed">
+        <CardContent className="py-3 text-sm text-muted-foreground">
+          Active queue controls live on <strong>Downloads → Active</strong>. This
+          page now focuses on history and review workflows.
+        </CardContent>
+      </Card>
+      <Tabs defaultValue="history">
         <TabsList>
-          <TabsTrigger value="queue">Queue</TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
           <TabsTrigger value="blocklist">Blocklist</TabsTrigger>
           <TabsTrigger value="reviews" className="flex items-center gap-1.5">
@@ -948,7 +953,7 @@ export function ActivityPage() {
             )}
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="queue">
+        <TabsContent value="queue" className="hidden">
           <DownloadQueue />
         </TabsContent>
         <TabsContent value="history">

--- a/web/src/pages/activity.tsx
+++ b/web/src/pages/activity.tsx
@@ -933,8 +933,8 @@ export function ActivityPage() {
     <div className="space-y-6">
       <Card className="border-dashed">
         <CardContent className="py-3 text-sm text-muted-foreground">
-          Active queue controls live on <strong>Downloads → Active</strong>. This
-          page now focuses on history and review workflows.
+          Active queue controls live on <strong>Downloads → Active</strong>.
+          This page now focuses on history and review workflows.
         </CardContent>
       </Card>
       <Tabs defaultValue="history">


### PR DESCRIPTION
## Summary
- remove the redundant Activity queue tab from the Activity tab strip and make History the default tab
- add a callout on Activity that directs live queue operations to Downloads → Active
- persist failed download outcomes in `download_history` so history now includes both completed and failed states
- update command palette navigation keywords so Activity maps to history/review and Downloads maps to active/imports/cleanup
- add tests covering failed-history recording and Activity tab consolidation

## Validation
- `GOWORK=off go test ./internal/downloads/...`
- `cd web && pnpm test -- src/pages/__tests__/activity-page.test.tsx`
- `cd web && pnpm lint`
- `cd web && pnpm build`
- `GOWORK=off go build -tags 'nosqlite' ./cmd/loom`

Fixes #104