### PR TITLE
Fix mobile add UX for Movies/TV pages and expand mobile Playwright coverage

### DIFF
--- a/web/e2e/movies.spec.ts
+++ b/web/e2e/movies.spec.ts
@@ -135,9 +135,9 @@ test.describe("Movies Page", () => {
         .first();
       await expect(addMovieButton).toBeVisible({ timeout: 10000 });
       await addMovieButton.click();
-      await expect(page.getByRole("heading", { name: "Search Movies" })).toBeVisible(
-        { timeout: 10000 },
-      );
+      await expect(
+        page.getByRole("heading", { name: "Search Movies" }),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     test("empty library keeps Add Movie reachable and opens dialog", async ({
@@ -152,9 +152,9 @@ test.describe("Movies Page", () => {
         .first();
       await expect(addMovieButton).toBeVisible({ timeout: 10000 });
       await addMovieButton.click();
-      await expect(page.getByRole("heading", { name: "Search Movies" })).toBeVisible(
-        { timeout: 10000 },
-      );
+      await expect(
+        page.getByRole("heading", { name: "Search Movies" }),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     test("mobile overflow menu keeps secondary actions reachable", async ({

--- a/web/e2e/movies.spec.ts
+++ b/web/e2e/movies.spec.ts
@@ -119,4 +119,60 @@ test.describe("Movies Page", () => {
       timeout: 10000,
     });
   });
+
+  test.describe("Movies Page mobile add flow", () => {
+    test.use({ viewport: { width: 393, height: 851 } });
+
+    test("populated library keeps Add Movie reachable and opens dialog", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockMovies(page);
+      await page.goto("/movies");
+
+      const addMovieButton = page
+        .getByRole("button", { name: /^Add Movie$/i })
+        .first();
+      await expect(addMovieButton).toBeVisible({ timeout: 10000 });
+      await addMovieButton.click();
+      await expect(page.getByRole("heading", { name: "Search Movies" })).toBeVisible(
+        { timeout: 10000 },
+      );
+    });
+
+    test("empty library keeps Add Movie reachable and opens dialog", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockMovies(page, [], [SAMPLE_LIBRARY]);
+      await page.goto("/movies");
+
+      const addMovieButton = page
+        .getByRole("button", { name: /^Add Movie$/i })
+        .first();
+      await expect(addMovieButton).toBeVisible({ timeout: 10000 });
+      await addMovieButton.click();
+      await expect(page.getByRole("heading", { name: "Search Movies" })).toBeVisible(
+        { timeout: 10000 },
+      );
+    });
+
+    test("mobile overflow menu keeps secondary actions reachable", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockMovies(page);
+      await page.goto("/movies");
+
+      const menuButton = page.getByRole("button", { name: "More actions" });
+      await expect(menuButton).toBeVisible({ timeout: 10000 });
+      await menuButton.click();
+      await expect(page.getByRole("menuitem", { name: "Import" })).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.getByRole("menuitem", { name: "Rescan Libraries" }),
+      ).toBeVisible({ timeout: 10000 });
+    });
+  });
 });

--- a/web/e2e/series.spec.ts
+++ b/web/e2e/series.spec.ts
@@ -24,7 +24,7 @@ test.describe("Series Page", () => {
 
   test("shows add series button", async ({ page }) => {
     await page.goto("/series");
-    await expect(page.getByRole("button", { name: /add/i })).toBeVisible({
+    await expect(page.getByRole("button", { name: /^Add Series$/i })).toBeVisible({
       timeout: 10000,
     });
   });
@@ -44,6 +44,62 @@ test.describe("Series Page", () => {
     // Empty state shows "No series yet"
     await expect(page.getByText("No series yet")).toBeVisible({
       timeout: 10000,
+    });
+  });
+
+  test.describe("Series Page mobile add flow", () => {
+    test.use({ viewport: { width: 393, height: 851 } });
+
+    test("populated library keeps Add Series reachable and opens dialog", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockSeriesApi(page);
+      await page.goto("/series");
+
+      const addSeriesButton = page
+        .getByRole("button", { name: /^Add Series$/i })
+        .first();
+      await expect(addSeriesButton).toBeVisible({ timeout: 10000 });
+      await addSeriesButton.click();
+      await expect(page.getByRole("heading", { name: "Search Series" })).toBeVisible(
+        { timeout: 10000 },
+      );
+    });
+
+    test("empty library keeps Add Series reachable and opens dialog", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockSeriesApi(page, []);
+      await page.goto("/series");
+
+      const addSeriesButton = page
+        .getByRole("button", { name: /^Add Series$/i })
+        .first();
+      await expect(addSeriesButton).toBeVisible({ timeout: 10000 });
+      await addSeriesButton.click();
+      await expect(page.getByRole("heading", { name: "Search Series" })).toBeVisible(
+        { timeout: 10000 },
+      );
+    });
+
+    test("mobile overflow menu keeps secondary actions reachable", async ({
+      page,
+    }) => {
+      await mockBaseApp(page);
+      await mockSeriesApi(page);
+      await page.goto("/series");
+
+      const menuButton = page.getByRole("button", { name: "More actions" });
+      await expect(menuButton).toBeVisible({ timeout: 10000 });
+      await menuButton.click();
+      await expect(page.getByRole("menuitem", { name: "Organize" })).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.getByRole("menuitem", { name: "Rescan Libraries" }),
+      ).toBeVisible({ timeout: 10000 });
     });
   });
 });

--- a/web/e2e/series.spec.ts
+++ b/web/e2e/series.spec.ts
@@ -24,7 +24,9 @@ test.describe("Series Page", () => {
 
   test("shows add series button", async ({ page }) => {
     await page.goto("/series");
-    await expect(page.getByRole("button", { name: /^Add Series$/i })).toBeVisible({
+    await expect(
+      page.getByRole("button", { name: /^Add Series$/i }),
+    ).toBeVisible({
       timeout: 10000,
     });
   });
@@ -62,9 +64,9 @@ test.describe("Series Page", () => {
         .first();
       await expect(addSeriesButton).toBeVisible({ timeout: 10000 });
       await addSeriesButton.click();
-      await expect(page.getByRole("heading", { name: "Search Series" })).toBeVisible(
-        { timeout: 10000 },
-      );
+      await expect(
+        page.getByRole("heading", { name: "Search Series" }),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     test("empty library keeps Add Series reachable and opens dialog", async ({
@@ -79,9 +81,9 @@ test.describe("Series Page", () => {
         .first();
       await expect(addSeriesButton).toBeVisible({ timeout: 10000 });
       await addSeriesButton.click();
-      await expect(page.getByRole("heading", { name: "Search Series" })).toBeVisible(
-        { timeout: 10000 },
-      );
+      await expect(
+        page.getByRole("heading", { name: "Search Series" }),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     test("mobile overflow menu keeps secondary actions reachable", async ({
@@ -94,7 +96,9 @@ test.describe("Series Page", () => {
       const menuButton = page.getByRole("button", { name: "More actions" });
       await expect(menuButton).toBeVisible({ timeout: 10000 });
       await menuButton.click();
-      await expect(page.getByRole("menuitem", { name: "Organize" })).toBeVisible({
+      await expect(
+        page.getByRole("menuitem", { name: "Organize" }),
+      ).toBeVisible({
         timeout: 10000,
       });
       await expect(

--- a/web/playwright.live.config.ts
+++ b/web/playwright.live.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
       name: "live-chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "live-mobile-chrome",
+      use: { ...devices["Pixel 5"] },
+    },
   ],
   // No webServer — we connect to the remote instance directly
 });

--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -378,7 +378,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           />
         )}
 
-        <main id="main" className="min-w-0 flex-1 overflow-x-clip p-4 md:p-6">
+        <main id="main" className="min-w-0 flex-1 overflow-x-auto p-4 md:p-6">
           <div key={sectionKey} className="page-enter">
             {children ?? <Outlet />}
           </div>

--- a/web/src/components/movies/movie-toolbar.tsx
+++ b/web/src/components/movies/movie-toolbar.tsx
@@ -22,6 +22,7 @@ import {
   FolderSearch,
   FolderSync,
   Settings2,
+  MoreHorizontal,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -96,9 +97,9 @@ export function MovieToolbar({
   return (
     <div className="mb-6 space-y-3">
       {/* Main toolbar row */}
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-2">
         {/* Filter */}
-        <div className="relative min-w-[200px] max-w-sm flex-1">
+        <div className="relative w-full sm:min-w-[220px] sm:max-w-sm sm:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Filter movies..."
@@ -110,7 +111,7 @@ export function MovieToolbar({
 
         {/* Status filter */}
         <Select value={statusFilter} onValueChange={onStatusFilterChange}>
-          <SelectTrigger className="h-9 w-[140px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[140px]">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -124,7 +125,7 @@ export function MovieToolbar({
 
         {/* Quality profile filter */}
         <Select value={profileFilter} onValueChange={onProfileFilterChange}>
-          <SelectTrigger className="h-9 w-[140px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[140px]">
             <SelectValue placeholder="Profile" />
           </SelectTrigger>
           <SelectContent>
@@ -141,7 +142,7 @@ export function MovieToolbar({
 
         {/* Monitored filter */}
         <Select value={monitoredFilter} onValueChange={onMonitoredFilterChange}>
-          <SelectTrigger className="h-9 w-[130px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[130px]">
             <SelectValue placeholder="Monitored" />
           </SelectTrigger>
           <SelectContent>
@@ -162,7 +163,7 @@ export function MovieToolbar({
           value={sortKey}
           onValueChange={(v) => onSortKeyChange(v as SortKey)}
         >
-          <SelectTrigger className="h-9 w-[140px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[140px]">
             <SortAsc className="mr-1 h-3.5 w-3.5" />
             <SelectValue />
           </SelectTrigger>
@@ -176,7 +177,7 @@ export function MovieToolbar({
         </Select>
 
         {/* View toggle */}
-        <div className="flex items-center rounded-md border border-border">
+        <div className="hidden items-center rounded-md border border-border sm:flex">
           <Button
             variant={viewMode === "grid" ? "secondary" : "ghost"}
             size="sm"
@@ -195,60 +196,93 @@ export function MovieToolbar({
           </Button>
         </div>
 
-        {/* Import, Organize & Add buttons */}
-        <div className="ml-auto flex items-center gap-2">
+        {/* Add button and actions */}
+        <div className="flex w-full items-center gap-2 sm:ml-auto sm:w-auto">
           <Button
             size="sm"
-            variant="outline"
-            className="h-9 gap-1.5"
-            onClick={onRefreshAll}
-            disabled={refreshingAll}
+            className="h-9 flex-1 gap-1.5 sm:flex-none"
+            onClick={onAddMovie}
           >
-            <RefreshCw className="h-4 w-4" />
-            {refreshingAll ? "Refreshing..." : "Refresh All"}
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-9 gap-1.5"
-            onClick={onRescanLibraries}
-            disabled={rescanningLibraries}
-          >
-            <FolderSync className="h-4 w-4" />
-            {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-9 gap-1.5"
-            onClick={onImportLibrary}
-          >
-            <FolderSearch className="h-4 w-4" /> Import
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-9 gap-1.5"
-            onClick={onOrganize}
-          >
-            <FolderSync className="h-4 w-4" /> Organize
-          </Button>
-          <Button size="sm" className="h-9 gap-1.5" onClick={onAddMovie}>
             <Plus className="h-4 w-4" /> Add Movie
           </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm" variant="outline" className="h-9 px-3 sm:hidden">
+                <MoreHorizontal className="h-4 w-4" />
+                <span className="sr-only">More actions</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={4}>
+              <DropdownMenuItem onClick={onRefreshAll} disabled={refreshingAll}>
+                {refreshingAll ? "Refreshing..." : "Refresh All"}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onRescanLibraries}
+                disabled={rescanningLibraries}
+              >
+                {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onImportLibrary}>Import</DropdownMenuItem>
+              <DropdownMenuItem onClick={onOrganize}>Organize</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onViewModeChange("grid")}>
+                Grid View
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onViewModeChange("list")}>
+                List View
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <div className="hidden items-center gap-2 sm:flex">
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 gap-1.5"
+              onClick={onRefreshAll}
+              disabled={refreshingAll}
+            >
+              <RefreshCw className="h-4 w-4" />
+              {refreshingAll ? "Refreshing..." : "Refresh All"}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 gap-1.5"
+              onClick={onRescanLibraries}
+              disabled={rescanningLibraries}
+            >
+              <FolderSync className="h-4 w-4" />
+              {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 gap-1.5"
+              onClick={onImportLibrary}
+            >
+              <FolderSearch className="h-4 w-4" /> Import
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-9 gap-1.5"
+              onClick={onOrganize}
+            >
+              <FolderSync className="h-4 w-4" /> Organize
+            </Button>
+          </div>
         </div>
       </div>
 
       {/* Bulk action bar */}
       {selectMode && (
-        <div className="flex items-center gap-3 rounded-lg border border-accent/20 bg-accent/10 px-3 py-2">
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-accent/20 bg-accent/10 px-3 py-2">
           <Checkbox
             checked={allSelected}
             onCheckedChange={onToggleSelectAll}
             className="data-[state=checked]:bg-accent"
           />
           <span className="text-sm font-medium">{selectedCount} selected</span>
-          <div className="ml-auto flex gap-2">
+          <div className="flex w-full flex-wrap gap-2 sm:ml-auto sm:w-auto">
             <Button
               size="sm"
               variant="outline"

--- a/web/src/components/movies/movie-toolbar.tsx
+++ b/web/src/components/movies/movie-toolbar.tsx
@@ -207,7 +207,11 @@ export function MovieToolbar({
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button size="sm" variant="outline" className="h-9 px-3 sm:hidden">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-9 px-3 sm:hidden"
+              >
                 <MoreHorizontal className="h-4 w-4" />
                 <span className="sr-only">More actions</span>
               </Button>
@@ -222,7 +226,9 @@ export function MovieToolbar({
               >
                 {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={onImportLibrary}>Import</DropdownMenuItem>
+              <DropdownMenuItem onClick={onImportLibrary}>
+                Import
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={onOrganize}>Organize</DropdownMenuItem>
               <DropdownMenuItem onClick={() => onViewModeChange("grid")}>
                 Grid View

--- a/web/src/components/series/series-toolbar.tsx
+++ b/web/src/components/series/series-toolbar.tsx
@@ -22,6 +22,7 @@ import {
   FolderSearch,
   FolderSync,
   Settings2,
+  MoreHorizontal,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -97,9 +98,9 @@ export function SeriesToolbar({
 }) {
   return (
     <div className="mb-6 space-y-3">
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-2">
         {/* Filter */}
-        <div className="relative min-w-[200px] max-w-sm flex-1">
+        <div className="relative w-full sm:min-w-[220px] sm:max-w-sm sm:flex-1">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Filter series..."
@@ -111,7 +112,7 @@ export function SeriesToolbar({
 
         {/* Status filter */}
         <Select value={statusFilter} onValueChange={onStatusFilterChange}>
-          <SelectTrigger className="h-9 w-[140px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[140px]">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -127,7 +128,7 @@ export function SeriesToolbar({
 
         {/* Monitored filter */}
         <Select value={monitoredFilter} onValueChange={onMonitoredFilterChange}>
-          <SelectTrigger className="h-9 w-[130px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[130px]">
             <SelectValue placeholder="Monitored" />
           </SelectTrigger>
           <SelectContent>
@@ -148,7 +149,7 @@ export function SeriesToolbar({
           value={sortKey}
           onValueChange={(v) => onSortKeyChange(v as SeriesSortKey)}
         >
-          <SelectTrigger className="h-9 w-[140px] text-xs">
+          <SelectTrigger className="h-9 w-full text-xs sm:w-[140px]">
             <SortAsc className="mr-1 h-3.5 w-3.5" />
             <SelectValue />
           </SelectTrigger>
@@ -162,7 +163,7 @@ export function SeriesToolbar({
         </Select>
 
         {/* View toggle */}
-        <div className="flex items-center rounded-md border border-border">
+        <div className="hidden items-center rounded-md border border-border sm:flex">
           <Button
             variant={viewMode === "grid" ? "secondary" : "ghost"}
             size="sm"
@@ -181,64 +182,101 @@ export function SeriesToolbar({
           </Button>
         </div>
 
-        {/* Add / Import buttons */}
-        <div className="ml-auto flex items-center gap-2">
+        {/* Add button and actions */}
+        <div className="flex w-full items-center gap-2 sm:ml-auto sm:w-auto">
           <Button
-            variant="outline"
             size="sm"
-            className="h-9 gap-1.5"
-            onClick={onRefreshAll}
-            disabled={refreshingAll}
+            className="h-9 flex-1 gap-1.5 sm:flex-none"
+            onClick={onAddSeries}
           >
-            <RefreshCw className="h-4 w-4" />
-            {refreshingAll ? "Refreshing..." : "Refresh All"}
+            <Plus className="h-4 w-4" /> Add Series
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-9 gap-1.5"
-            onClick={onRescanLibraries}
-            disabled={rescanningLibraries}
-          >
-            <FolderSync className="h-4 w-4" />
-            {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
-          </Button>
-          {onImportLibrary && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button size="sm" variant="outline" className="h-9 px-3 sm:hidden">
+                <MoreHorizontal className="h-4 w-4" />
+                <span className="sr-only">More actions</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={4}>
+              <DropdownMenuItem onClick={onRefreshAll} disabled={refreshingAll}>
+                {refreshingAll ? "Refreshing..." : "Refresh All"}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onRescanLibraries}
+                disabled={rescanningLibraries}
+              >
+                {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
+              </DropdownMenuItem>
+              {onImportLibrary && (
+                <DropdownMenuItem onClick={onImportLibrary}>Import</DropdownMenuItem>
+              )}
+              <DropdownMenuItem onClick={onOrganize} disabled={organizing}>
+                {organizing ? "Organizing..." : "Organize"}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onViewModeChange("grid")}>
+                Grid View
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onViewModeChange("list")}>
+                List View
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <div className="hidden items-center gap-2 sm:flex">
             <Button
               variant="outline"
               size="sm"
               className="h-9 gap-1.5"
-              onClick={onImportLibrary}
+              onClick={onRefreshAll}
+              disabled={refreshingAll}
             >
-              <FolderSearch className="h-4 w-4" /> Import
+              <RefreshCw className="h-4 w-4" />
+              {refreshingAll ? "Refreshing..." : "Refresh All"}
             </Button>
-          )}
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-9 gap-1.5"
-            onClick={onOrganize}
-            disabled={organizing}
-          >
-            <FolderSync className="h-4 w-4" />
-            {organizing ? "Organizing..." : "Organize"}
-          </Button>
-          <Button size="sm" className="h-9 gap-1.5" onClick={onAddSeries}>
-            <Plus className="h-4 w-4" /> Add Series
-          </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-1.5"
+              onClick={onRescanLibraries}
+              disabled={rescanningLibraries}
+            >
+              <FolderSync className="h-4 w-4" />
+              {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
+            </Button>
+            {onImportLibrary && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-9 gap-1.5"
+                onClick={onImportLibrary}
+              >
+                <FolderSearch className="h-4 w-4" /> Import
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-1.5"
+              onClick={onOrganize}
+              disabled={organizing}
+            >
+              <FolderSync className="h-4 w-4" />
+              {organizing ? "Organizing..." : "Organize"}
+            </Button>
+          </div>
         </div>
       </div>
 
       {/* Bulk action bar */}
       {selectMode && (
-        <div className="flex items-center gap-3 rounded-lg border border-accent/20 bg-accent/10 px-3 py-2">
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-accent/20 bg-accent/10 px-3 py-2">
           <Checkbox
             checked={allSelected}
             onCheckedChange={onToggleSelectAll}
             className="data-[state=checked]:bg-accent"
           />
           <span className="text-sm font-medium">{selectedCount} selected</span>
-          <div className="ml-auto flex gap-2">
+          <div className="flex w-full flex-wrap gap-2 sm:ml-auto sm:w-auto">
             <Button
               size="sm"
               variant="outline"

--- a/web/src/components/series/series-toolbar.tsx
+++ b/web/src/components/series/series-toolbar.tsx
@@ -193,7 +193,11 @@ export function SeriesToolbar({
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button size="sm" variant="outline" className="h-9 px-3 sm:hidden">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-9 px-3 sm:hidden"
+              >
                 <MoreHorizontal className="h-4 w-4" />
                 <span className="sr-only">More actions</span>
               </Button>
@@ -209,7 +213,9 @@ export function SeriesToolbar({
                 {rescanningLibraries ? "Rescanning..." : "Rescan Libraries"}
               </DropdownMenuItem>
               {onImportLibrary && (
-                <DropdownMenuItem onClick={onImportLibrary}>Import</DropdownMenuItem>
+                <DropdownMenuItem onClick={onImportLibrary}>
+                  Import
+                </DropdownMenuItem>
               )}
               <DropdownMenuItem onClick={onOrganize} disabled={organizing}>
                 {organizing ? "Organizing..." : "Organize"}

--- a/web/src/pages/downloads.tsx
+++ b/web/src/pages/downloads.tsx
@@ -870,7 +870,7 @@ function ActiveDownloads() {
       >
         <SheetContent
           side="right"
-          className="w-[500px] overflow-y-auto sm:max-w-[500px]"
+          className="w-full overflow-y-auto sm:max-w-[500px]"
         >
           <SheetHeader>
             <SheetTitle className="truncate pr-8 text-sm font-medium">

--- a/web/src/pages/movies.tsx
+++ b/web/src/pages/movies.tsx
@@ -452,7 +452,7 @@ export function MoviesPage() {
   useSetPageHeader("Movies", subtitle);
 
   return (
-    <div className="px-6 pb-6 pt-2">
+    <div className="px-3 pb-6 pt-2 sm:px-6">
       {/* Toolbar */}
       {totalMovies > 0 ? (
         <MovieToolbar
@@ -510,7 +510,7 @@ export function MoviesPage() {
               ⚠️ Add a library in Settings before adding movies
             </p>
           ) : (
-            <div className="flex gap-3">
+            <div className="flex w-full max-w-md flex-col gap-3 sm:w-auto sm:max-w-none sm:flex-row">
               <Button
                 variant="outline"
                 size="lg"

--- a/web/src/pages/requests.tsx
+++ b/web/src/pages/requests.tsx
@@ -670,7 +670,7 @@ function ManageRequests() {
             ))}
           </SelectContent>
         </Select>
-        <div className="ml-auto">
+        <div className="w-full sm:ml-auto sm:w-auto">
           <ConfirmActionButton
             actionLabel="Clear History"
             title="Clear request history?"

--- a/web/src/pages/series.tsx
+++ b/web/src/pages/series.tsx
@@ -468,7 +468,7 @@ export function SeriesPage() {
   useSetPageHeader("TV Shows", subtitle);
 
   return (
-    <div className="px-6 pb-6 pt-2">
+    <div className="px-3 pb-6 pt-2 sm:px-6">
       {/* Toolbar */}
       {totalSeries > 0 ? (
         <SeriesToolbar
@@ -524,7 +524,7 @@ export function SeriesPage() {
               ⚠️ Add a library in Settings before adding series
             </p>
           ) : (
-            <div className="flex gap-3">
+            <div className="flex w-full max-w-md flex-col gap-3 sm:w-auto sm:max-w-none sm:flex-row">
               <Button
                 variant="outline"
                 size="lg"

--- a/web/src/pages/settings.tsx
+++ b/web/src/pages/settings.tsx
@@ -404,7 +404,7 @@ function AddLibraryDialog({
               <p className="text-sm text-muted-foreground">
                 What type of media will this library contain?
               </p>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <button
                   type="button"
                   onClick={() => selectType("movie")}
@@ -1274,7 +1274,7 @@ export function DownloadClientsPanel() {
                 </div>
               </div>
 
-              <div className="grid max-w-lg grid-cols-2 gap-4">
+              <div className="grid max-w-lg grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
                   <Label
                     htmlFor="stall-timeout"
@@ -2325,7 +2325,7 @@ export function DownloadSafetyPanel() {
           <p className="text-xs text-zinc-500">
             Flag releases outside this size range (in MB) as suspicious.
           </p>
-          <div className="grid max-w-sm grid-cols-2 gap-4">
+          <div className="grid max-w-sm grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
               <Label htmlFor="min-size" className="text-xs">
                 Minimum (MB)


### PR DESCRIPTION
## Summary
- Refactored Movies and Series populated-state toolbars for mobile usability: Add action is always visible, secondary actions collapse into a mobile overflow menu, and filter controls no longer force horizontal clipping on small screens.
- Applied responsive fixes discovered during the sweep in related surfaces tied to this scope: page padding and empty-state CTA stacking on Movies/Series, main layout horizontal overflow handling, Downloads detail sheet width, Requests action alignment, and Settings two-column controls that now stack on narrow screens.
- Expanded Playwright coverage for mobile add flows and responsive behavior in Movies/Series specs, and added a live-mobile Playwright project in `playwright.live.config.ts`.

## Validation
- ✅ `pnpm lint`
- ✅ `pnpm build`
- ⚠️ `pnpm test:e2e e2e/movies.spec.ts e2e/series.spec.ts --project=chromium --project=mobile-chrome` is currently blocked in this environment because `http://localhost:5173` is already occupied by another running app, and CI mode confirms Playwright cannot claim the configured port.

Fixes #127