### PR TITLE
feat(logging): context-aware logging, trace correlation, fix log-and-return anti-pattern

### DIFF
--- a/cmd/loom/cleanup.go
+++ b/cmd/loom/cleanup.go
@@ -87,7 +87,7 @@ func buildCleanupService(
 					}
 				}
 			} else {
-				logger.Warn("cleanup: import history lookup failed", "err", err)
+				logger.Warn("cleanup: import history lookup failed", "error", err)
 			}
 		}
 		return paths, nil

--- a/cmd/loom/downloads.go
+++ b/cmd/loom/downloads.go
@@ -42,7 +42,7 @@ func buildDownloadService(ctx context.Context, cfg *config.Config, db storage.DB
 	}
 
 	if err := svc.HydrateAll(ctx); err != nil {
-		logger.Warn("download client hydrate failed", "err", err)
+		logger.Warn("download client hydrate failed", "error", err)
 	}
 	return svc, nil
 }

--- a/cmd/loom/indexers.go
+++ b/cmd/loom/indexers.go
@@ -71,13 +71,13 @@ func buildIndexerService(ctx context.Context, cfg *config.Config, db storage.DB,
 	diskDefs, loadErrs := cardLoader.Reload()
 	if len(loadErrs) > 0 {
 		for _, lerr := range loadErrs {
-			logger.Warn("cardigann definition skipped", "err", lerr)
+			logger.Warn("cardigann definition skipped", "error", lerr)
 		}
 	}
 	embDefs, embErrs := cardLoader.LoadEmbedded(cardigann.BundledFS())
 	if len(embErrs) > 0 {
 		for _, lerr := range embErrs {
-			logger.Warn("bundled cardigann definition skipped", "err", lerr)
+			logger.Warn("bundled cardigann definition skipped", "error", lerr)
 		}
 	}
 	logger.Info("cardigann definitions loaded", "disk", len(diskDefs), "bundled", len(embDefs))
@@ -101,7 +101,7 @@ func buildIndexerService(ctx context.Context, cfg *config.Config, db storage.DB,
 	}
 
 	if err := svc.HydrateAll(ctx); err != nil {
-		logger.Warn("indexer hydrate failed", "err", err)
+		logger.Warn("indexer hydrate failed", "error", err)
 	}
 	// Wire the rate-limit provider after the service exists so the
 	// throttle transport can resolve per-indexer overrides.

--- a/cmd/loom/requests.go
+++ b/cmd/loom/requests.go
@@ -110,7 +110,7 @@ func (f *requestsFulfiller) FulfillMovie(ctx context.Context, tmdbID, qualityPro
 	if m.TMDBID != nil {
 		req.TMDBID = *m.TMDBID
 	}
-	f.grab(req)
+	f.grab(ctx, req)
 	return m.ID, nil
 }
 
@@ -140,7 +140,7 @@ func (f *requestsFulfiller) FulfillSeries(ctx context.Context, tmdbID, qualityPr
 	if sr.TVDBID != nil {
 		req.TVDBID = *sr.TVDBID
 	}
-	f.grab(req)
+	f.grab(ctx, req)
 	return sr.ID, nil
 }
 
@@ -186,7 +186,7 @@ func (f *requestsFulfiller) grabArtist(ctx context.Context, artistID string) {
 		ctx := context.WithoutCancel(ctx)
 		albums, err := f.music.ListAlbumsByArtist(ctx, artistID)
 		if err != nil {
-			f.logger.Warn("requests: list albums for grab failed", "artist", artistID, "err", err)
+			f.logger.WarnContext(ctx, "requests: list albums for grab failed", "artist", artistID, "error", err)
 			return
 		}
 		const maxAlbums = 25
@@ -199,7 +199,7 @@ func (f *requestsFulfiller) grabArtist(ctx context.Context, artistID string) {
 				continue
 			}
 			if _, err := f.musicEngine.SearchAlbum(ctx, al.ID); err != nil {
-				f.logger.Debug("requests: album search failed", "album", al.ID, "err", err)
+				f.logger.DebugContext(ctx, "requests: album search failed", "album", al.ID, "error", err)
 			}
 			searched++
 		}
@@ -208,17 +208,17 @@ func (f *requestsFulfiller) grabArtist(ctx context.Context, artistID string) {
 
 // grab launches a detached search-and-grab; failures are logged, never block
 // the approval response.
-func (f *requestsFulfiller) grab(req autosearch.SearchRequest) {
+func (f *requestsFulfiller) grab(ctx context.Context, req autosearch.SearchRequest) {
 	if f.engine == nil {
 		return
 	}
-	go func() {
-		ctx := context.WithoutCancel(context.Background())
+	go func(ctx context.Context) {
+		ctx = context.WithoutCancel(ctx)
 		if _, err := f.engine.SearchAndGrab(ctx, req); err != nil {
-			f.logger.Warn("requests: search-and-grab failed",
-				"media_type", req.MediaType, "media_id", req.MediaID, "err", err)
+			f.logger.WarnContext(ctx, "requests: search-and-grab failed",
+				"media_type", req.MediaType, "media_id", req.MediaID, "error", err)
 		}
-	}()
+	}(ctx)
 }
 
 // requestsValidator implements requests.LibraryValidator using the quality

--- a/cmd/loom/serve.go
+++ b/cmd/loom/serve.go
@@ -162,7 +162,7 @@ func cmdServe(ctx context.Context, args []string) error {
 	}
 	defer func() {
 		if err := downloadSvc.Close(); err != nil {
-			logger.Warn("downloads close failed", "err", err)
+			logger.Warn("downloads close failed", "error", err)
 		}
 	}()
 	if err := registerDownloadHealthJob(ctx, sched, cfg, downloadSvc); err != nil {
@@ -240,7 +240,7 @@ func cmdServe(ctx context.Context, args []string) error {
 	if dlWiring.router != nil {
 		defer func() {
 			if err := dlWiring.router.Shutdown(); err != nil {
-				logger.Warn("downloads router shutdown failed", "err", err)
+				logger.Warn("downloads router shutdown failed", "error", err)
 			}
 		}()
 	}
@@ -272,7 +272,7 @@ func cmdServe(ctx context.Context, args []string) error {
 	botsRouter, botsSupervisor := buildBots(db, requestsSvc, metadataSvc, media.musicSvc, botAuthStore, authSvc.RequireRole("admin"), logger)
 	wiring.BotsRouter = botsRouter
 	if err := botsSupervisor.Start(ctx); err != nil {
-		logger.Error("bots: initial start failed", "err", err)
+		logger.Error("bots: initial start failed", "error", err)
 	}
 	defer botsSupervisor.Shutdown()
 
@@ -324,11 +324,10 @@ func cmdServe(ctx context.Context, args []string) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Error("graceful shutdown failed", "err", err)
-		return err
+		return fmt.Errorf("graceful shutdown: %w", err)
 	}
 	if err := tel.Shutdown(shutdownCtx); err != nil {
-		logger.Error("telemetry shutdown failed", "err", err)
+		logger.Error("telemetry shutdown failed", "error", err)
 	}
 	logger.Info("stopped cleanly")
 	return nil

--- a/internal/anime/handlers.go
+++ b/internal/anime/handlers.go
@@ -37,7 +37,7 @@ func getPreferences(store *Store) http.HandlerFunc {
 		}
 		prefs, err := store.GetPreferences(r.Context(), seriesID)
 		if err != nil {
-			slog.Error("anime: get preferences", "err", err, "seriesId", seriesID)
+			slog.ErrorContext(r.Context(), "anime: get preferences", "error", err, "seriesId", seriesID)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -72,7 +72,7 @@ func putPreferences(store *Store) http.HandlerFunc {
 		}
 
 		if err := store.UpsertPreferences(r.Context(), &prefs); err != nil {
-			slog.Error("anime: upsert preferences", "err", err, "seriesId", seriesID)
+			slog.ErrorContext(r.Context(), "anime: upsert preferences", "error", err, "seriesId", seriesID)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -89,7 +89,7 @@ func getMappings(store *Store) http.HandlerFunc {
 		}
 		mappings, err := store.GetMappings(r.Context(), seriesID)
 		if err != nil {
-			slog.Error("anime: get mappings", "err", err, "seriesId", seriesID)
+			slog.ErrorContext(r.Context(), "anime: get mappings", "error", err, "seriesId", seriesID)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -125,7 +125,7 @@ func putMappings(store *Store) http.HandlerFunc {
 		}
 
 		if err := store.ReplaceMappings(r.Context(), seriesID, req.Mappings); err != nil {
-			slog.Error("anime: replace mappings", "err", err, "seriesId", seriesID)
+			slog.ErrorContext(r.Context(), "anime: replace mappings", "error", err, "seriesId", seriesID)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}

--- a/internal/apikeys/handlers.go
+++ b/internal/apikeys/handlers.go
@@ -72,7 +72,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.logger.Info("api key created", "id", k.ID, "name", k.Name)
+	h.logger.InfoContext(r.Context(), "api key created", "id", k.ID, "name", k.Name)
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"id":         k.ID,
 		"name":       k.Name,
@@ -92,7 +92,7 @@ func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("api key revoked", "id", id)
+	h.logger.InfoContext(r.Context(), "api key revoked", "id", id)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -104,7 +104,7 @@ func (l *Logger) Log(ctx context.Context, e Entry) {
 		e.Detail, e.EntityType, e.EntityID, e.EntityName, e.Level, e.Source,
 	)
 	if err != nil {
-		l.logger.Error("audit log insert failed", "error", err)
+		l.logger.ErrorContext(ctx, "audit log insert failed", "error", err)
 		if m := telemetry.App(); m != nil {
 			m.InternalWriteFailures.WithLabelValues("audit_log").Inc()
 		}
@@ -254,7 +254,7 @@ func (l *Logger) handleList(w http.ResponseWriter, r *http.Request) {
 		Until:      q.Get("until"),
 	})
 	if err != nil {
-		l.logger.Error("audit log list failed", "err", err)
+		l.logger.ErrorContext(r.Context(), "audit log list failed", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -265,7 +265,7 @@ func (l *Logger) handleList(w http.ResponseWriter, r *http.Request) {
 
 func (l *Logger) handleClear(w http.ResponseWriter, r *http.Request) {
 	if err := l.Clear(r.Context()); err != nil {
-		l.logger.Error("audit log clear failed", "err", err)
+		l.logger.ErrorContext(r.Context(), "audit log clear failed", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -135,7 +135,7 @@ func (s *Service) handleInitialize(w http.ResponseWriter, r *http.Request) {
 		s.appConfig.SetupComplete = false
 		s.appConfig.Admin.Username = ""
 		s.appConfig.Admin.PasswordHash = ""
-		s.logger.Error("failed to save app config", "err", err)
+		s.logger.ErrorContext(r.Context(), "failed to save app config", "error", err)
 		writeAuthError(w, http.StatusInternalServerError, "save config")
 		return
 	}
@@ -143,7 +143,7 @@ func (s *Service) handleInitialize(w http.ResponseWriter, r *http.Request) {
 	// Reconcile admin user in database (upsert: preserves user ID and API keys)
 	u, err := s.ReconcileAdmin(r.Context())
 	if err != nil {
-		s.logger.Error("failed to reconcile admin user", "err", err)
+		s.logger.ErrorContext(r.Context(), "failed to reconcile admin user", "error", err)
 		writeAuthError(w, http.StatusInternalServerError, "create user")
 		return
 	}

--- a/internal/auth/invites.go
+++ b/internal/auth/invites.go
@@ -194,14 +194,14 @@ func (s *Service) AcceptInvite(ctx context.Context, token, username, password st
 	u, err := s.CreateUserAccount(ctx, username, password, inv.Email, inv.Role)
 	if err != nil {
 		if relErr := s.invites.Release(ctx, token); relErr != nil {
-			s.logger.Error("failed to release invite after signup error", "token_id", inv.ID, "err", relErr)
+			s.logger.Error("failed to release invite after signup error", "token_id", inv.ID, "error", relErr)
 		}
 		return User{}, err
 	}
 	if finErr := s.invites.Finalize(ctx, token, u.ID); finErr != nil {
 		// The account exists and the invite is consumed; only the audit link is
 		// missing. Log rather than fail the redemption.
-		s.logger.Error("failed to finalize invite used_by", "token_id", inv.ID, "user_id", u.ID, "err", finErr)
+		s.logger.Error("failed to finalize invite used_by", "token_id", inv.ID, "user_id", u.ID, "error", finErr)
 	}
 	s.logger.Info("invite redeemed", "id", inv.ID, "user_id", u.ID, "role", inv.Role)
 	return u, nil

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -131,7 +131,7 @@ func (s *Service) identityFromAPIKey(ctx context.Context, presented string) (*Id
 		bg, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		if err := s.store.TouchAPIKey(bg, k.ID); err != nil && s.logger != nil {
-			s.logger.Debug("auth: touch api key failed", "err", err, "key_id", k.ID)
+			s.logger.Debug("auth: touch api key failed", "error", err, "key_id", k.ID)
 		}
 	}()
 	return &Identity{

--- a/internal/autosearch/handlers.go
+++ b/internal/autosearch/handlers.go
@@ -48,7 +48,7 @@ func (h *Handler) HandleAutoSearch(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.engine.SearchAndGrab(r.Context(), req)
 	if err != nil {
-		h.logger.Error("autosearch failed", "error", err, "title", req.Title)
+		h.logger.ErrorContext(r.Context(), "autosearch failed", "error", err, "title", req.Title)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
@@ -76,7 +76,7 @@ func (h *Handler) HandleEvaluate(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.engine.Evaluate(r.Context(), req)
 	if err != nil {
-		h.logger.Error("evaluate failed", "error", err)
+		h.logger.ErrorContext(r.Context(), "evaluate failed", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})

--- a/internal/bots/discord/discord.go
+++ b/internal/bots/discord/discord.go
@@ -103,7 +103,7 @@ func (b *Bot) registerGlobalCommands(s *discordgo.Session) {
 	appID := s.State.User.ID
 	for _, c := range slashCommands {
 		if _, err := s.ApplicationCommandCreate(appID, "", c); err != nil {
-			b.logger.Warn("discord bot: register global command", "cmd", c.Name, "err", err)
+			b.logger.Warn("discord bot: register global command", "cmd", c.Name, "error", err)
 		}
 	}
 }
@@ -112,7 +112,7 @@ func (b *Bot) registerGuildCommands(s *discordgo.Session, guildID string) {
 	appID := s.State.User.ID
 	for _, c := range slashCommands {
 		if _, err := s.ApplicationCommandCreate(appID, guildID, c); err != nil {
-			b.logger.Warn("discord bot: register guild command", "guild", guildID, "cmd", c.Name, "err", err)
+			b.logger.Warn("discord bot: register guild command", "guild", guildID, "cmd", c.Name, "error", err)
 		}
 	}
 }
@@ -132,7 +132,7 @@ func (b *Bot) onInteraction(ctx context.Context, s *discordgo.Session, i *discor
 		},
 	}
 	if err := s.InteractionRespond(i.Interaction, resp); err != nil {
-		b.logger.Warn("discord bot: respond failed", "err", err)
+		b.logger.Warn("discord bot: respond failed", "error", err)
 	}
 }
 

--- a/internal/bots/service.go
+++ b/internal/bots/service.go
@@ -180,7 +180,7 @@ func (s *Service) cmdLink(ctx context.Context, cmd Command) Reply {
 	}
 	lc, err := s.store.CreateLinkCode(ctx, cmd.Platform, cmd.ExternalID, cmd.ExternalUsername)
 	if err != nil {
-		s.logger.Error("bots: create link code", "err", err)
+		s.logger.Error("bots: create link code", "error", err)
 		return Reply{Text: "Sorry, I couldn't create a link code. Try again later."}
 	}
 	return Reply{Text: "🔗 Your link code is:\n\n*" + lc.Code + "*\n\n" +
@@ -199,15 +199,15 @@ func (s *Service) cmdSearch(ctx context.Context, cmd Command, query string) Repl
 	}
 	movies, err := s.search.SearchMovies(ctx, query)
 	if err != nil {
-		s.logger.Warn("bots: movie search", "err", err)
+		s.logger.Warn("bots: movie search", "error", err)
 	}
 	series, err := s.search.SearchSeries(ctx, query)
 	if err != nil {
-		s.logger.Warn("bots: series search", "err", err)
+		s.logger.Warn("bots: series search", "error", err)
 	}
 	artists, err := s.search.SearchArtists(ctx, query)
 	if err != nil {
-		s.logger.Warn("bots: artist search", "err", err)
+		s.logger.Warn("bots: artist search", "error", err)
 	}
 	results := interleave(movies, series, artists, s.maxResults)
 	if len(results) == 0 {
@@ -230,7 +230,7 @@ func (s *Service) cmdStatus(ctx context.Context, cmd Command) Reply {
 	}
 	list, err := s.requests.ListMine(ctx, caller.userID)
 	if err != nil {
-		s.logger.Error("bots: list mine", "err", err)
+		s.logger.Error("bots: list mine", "error", err)
 		return Reply{Text: "Sorry, I couldn't load your requests."}
 	}
 	if len(list) == 0 {
@@ -258,7 +258,7 @@ func (s *Service) cmdPending(ctx context.Context, cmd Command) Reply {
 	}
 	list, err := s.requests.ListAll(ctx, requests.StatusPending)
 	if err != nil {
-		s.logger.Error("bots: list pending", "err", err)
+		s.logger.Error("bots: list pending", "error", err)
 		return Reply{Text: "Sorry, I couldn't load pending requests."}
 	}
 	if len(list) == 0 {
@@ -320,7 +320,7 @@ func (s *Service) callbackRequest(ctx context.Context, cmd Command, mt requests.
 		return Reply{Text: "Unsupported media type."}
 	}
 	if err != nil || res == nil {
-		s.logger.Warn("bots: refetch metadata", "tmdb", tmdbID, "err", err)
+		s.logger.Warn("bots: refetch metadata", "tmdb", tmdbID, "error", err)
 		return Reply{Text: "Sorry, I couldn't look that title up. Try /search again."}
 	}
 
@@ -343,7 +343,7 @@ func (s *Service) callbackRequest(ctx context.Context, cmd Command, mt requests.
 	case errors.Is(err, requests.ErrDuplicate):
 		return Reply{Text: "↻ You already have an open request for *" + res.Title + "*."}
 	default:
-		s.logger.Error("bots: create request", "err", err)
+		s.logger.Error("bots: create request", "error", err)
 		return Reply{Text: "Sorry, something went wrong submitting that request."}
 	}
 }
@@ -368,7 +368,7 @@ func (s *Service) callbackDecision(ctx context.Context, cmd Command, reqID strin
 
 	if !approve {
 		if _, err := s.requests.Reject(ctx, reqID, "rejected via chat", caller.username); err != nil {
-			s.logger.Error("bots: reject", "err", err)
+			s.logger.Error("bots: reject", "error", err)
 			return Reply{Text: "Sorry, I couldn't reject that request."}
 		}
 		return Reply{Text: "❌ Rejected *" + existing.Title + "*."}
@@ -380,7 +380,7 @@ func (s *Service) callbackDecision(ctx context.Context, cmd Command, reqID strin
 			"Set chat-approval defaults in Settings → Request Bots, or approve in the web UI."}
 	}
 	if _, err := s.requests.Approve(ctx, reqID, qp, lib, caller.username); err != nil {
-		s.logger.Error("bots: approve", "err", err)
+		s.logger.Error("bots: approve", "error", err)
 		return Reply{Text: "Sorry, I couldn't approve that request: " + err.Error()}
 	}
 	return Reply{Text: "✅ Approved *" + existing.Title + "* — searching now."}
@@ -432,7 +432,7 @@ type caller struct {
 func (s *Service) requireLinked(ctx context.Context, cmd Command) (caller, bool) {
 	link, err := s.store.GetLink(ctx, cmd.Platform, cmd.ExternalID)
 	if err != nil {
-		s.logger.Error("bots: get link", "err", err)
+		s.logger.Error("bots: get link", "error", err)
 		return caller{}, false
 	}
 	if link == nil {
@@ -440,7 +440,7 @@ func (s *Service) requireLinked(ctx context.Context, cmd Command) (caller, bool)
 	}
 	name, isAdmin, err := s.users.Lookup(ctx, link.UserID)
 	if err != nil {
-		s.logger.Warn("bots: resolve user", "user_id", link.UserID, "err", err)
+		s.logger.Warn("bots: resolve user", "user_id", link.UserID, "error", err)
 		return caller{}, false
 	}
 	return caller{

--- a/internal/bots/supervisor.go
+++ b/internal/bots/supervisor.go
@@ -105,7 +105,7 @@ func (s *Supervisor) reconcile(cur **running, name, token string, factory Transp
 	go func() {
 		defer close(done)
 		if err := tr.Run(ctx); err != nil && ctx.Err() == nil {
-			s.logger.Warn("bots: transport exited unexpectedly", "platform", name, "err", err)
+			s.logger.Warn("bots: transport exited unexpectedly", "platform", name, "error", err)
 		}
 	}()
 	*cur = r

--- a/internal/bots/telegram/telegram.go
+++ b/internal/bots/telegram/telegram.go
@@ -72,7 +72,7 @@ func (b *Bot) Run(ctx context.Context) error {
 				return ctx.Err()
 			}
 			b.setErr(err.Error())
-			b.logger.Warn("telegram bot: getUpdates failed", "err", err)
+			b.logger.Warn("telegram bot: getUpdates failed", "error", err)
 			if !sleep(ctx, backoff) {
 				return ctx.Err()
 			}
@@ -153,7 +153,7 @@ func (b *Bot) send(ctx context.Context, chatID int64, reply bots.Reply) {
 		payload["reply_markup"] = map[string]any{"inline_keyboard": rows}
 	}
 	if err := b.call(ctx, "sendMessage", payload, nil); err != nil {
-		b.logger.Warn("telegram bot: sendMessage failed", "err", err)
+		b.logger.Warn("telegram bot: sendMessage failed", "error", err)
 	}
 }
 

--- a/internal/cleanup/scanner.go
+++ b/internal/cleanup/scanner.go
@@ -131,7 +131,7 @@ func (s *Service) scanLocked(ctx context.Context) (int, error) {
 		}
 		entries, err := os.ReadDir(rootPath)
 		if err != nil {
-			s.logger.Warn("cleanup: cannot read download root", "root", rootPath, "err", err)
+			s.logger.Warn("cleanup: cannot read download root", "root", rootPath, "error", err)
 			continue
 		}
 		for _, e := range entries {
@@ -161,13 +161,13 @@ func (s *Service) scanLocked(ctx context.Context) (int, error) {
 				Root:      rootPath,
 				SizeBytes: entrySize(full),
 			}); err != nil {
-				s.logger.Warn("cleanup: upsert orphan failed", "path", full, "err", err)
+				s.logger.Warn("cleanup: upsert orphan failed", "path", full, "error", err)
 			}
 		}
 	}
 
 	if err := s.store.ResolveStalePending(ctx, seen); err != nil {
-		s.logger.Warn("cleanup: resolving stale orphans failed", "err", err)
+		s.logger.Warn("cleanup: resolving stale orphans failed", "error", err)
 	}
 	return found, nil
 }
@@ -199,7 +199,7 @@ func (s *Service) AutoDelete(ctx context.Context) (int, error) {
 		}
 		ok, err := s.removeLocked(ctx, o)
 		if err != nil {
-			s.logger.Warn("cleanup: auto-delete failed", "path", o.Path, "err", err)
+			s.logger.Warn("cleanup: auto-delete failed", "path", o.Path, "error", err)
 			continue
 		}
 		if ok {

--- a/internal/commands/handlers.go
+++ b/internal/commands/handlers.go
@@ -45,7 +45,7 @@ func (h *cmdHandler) create(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("command queued", "id", cmd.ID, "name", cmd.Name)
+	h.logger.InfoContext(r.Context(), "command queued", "id", cmd.ID, "name", cmd.Name)
 	writeJSON(w, http.StatusCreated, cmd)
 }
 
@@ -85,7 +85,7 @@ func (h *cmdHandler) cancel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("command cancelled", "id", id)
+	h.logger.InfoContext(r.Context(), "command cancelled", "id", id)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/compat/prowlarrv1/handler.go
+++ b/internal/compat/prowlarrv1/handler.go
@@ -78,7 +78,7 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 func (h *Handler) listIndexers(w http.ResponseWriter, r *http.Request) {
 	defs, err := h.svc.List(r.Context())
 	if err != nil {
-		h.logger.Error("list indexers", "err", err)
+		h.logger.ErrorContext(r.Context(), "list indexers", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -108,7 +108,7 @@ func (h *Handler) getIndexer(w http.ResponseWriter, r *http.Request) {
 
 	defs, err := h.svc.List(r.Context())
 	if err != nil {
-		h.logger.Error("get indexer: list", "err", err)
+		h.logger.ErrorContext(r.Context(), "get indexer: list", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -166,7 +166,7 @@ func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
 		// Prowlarr sends numeric IDs; translate back to string UUIDs.
 		defs, err := h.svc.List(r.Context())
 		if err != nil {
-			h.logger.Error("search: list for id mapping", "err", err)
+			h.logger.ErrorContext(r.Context(), "search: list for id mapping", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -326,7 +326,7 @@ func (h *Handler) allowedIndexerIDs(r *http.Request) map[string]struct{} {
 	}
 	ids, err := h.syncStore.FilteredIndexerIDs(r.Context(), profileID)
 	if err != nil {
-		h.logger.Warn("sync profile filter failed, allowing all", "profileId", profileID, "err", err)
+		h.logger.WarnContext(r.Context(), "sync profile filter failed, allowing all", "profileId", profileID, "error", err)
 		return nil
 	}
 	m := make(map[string]struct{}, len(ids))

--- a/internal/compat/sonarrv3/handler.go
+++ b/internal/compat/sonarrv3/handler.go
@@ -112,7 +112,7 @@ func (h *Handler) tvLibs(ctx context.Context) ([]libraries.Library, error) {
 func (h *Handler) listSeries(w http.ResponseWriter, r *http.Request) {
 	list, err := h.svc.ListSeries(r.Context())
 	if err != nil {
-		h.logger.Error("list series", "err", err)
+		h.logger.ErrorContext(r.Context(), "list series", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -149,7 +149,7 @@ func (h *Handler) getSeries(w http.ResponseWriter, r *http.Request) {
 
 	s, err := h.svc.GetSeries(r.Context(), uuid)
 	if err != nil {
-		h.logger.Error("get series", "err", err)
+		h.logger.ErrorContext(r.Context(), "get series", "error", err)
 		writeError(w, http.StatusNotFound, "series not found")
 		return
 	}
@@ -213,7 +213,7 @@ func (h *Handler) addSeries(w http.ResponseWriter, r *http.Request) {
 
 	created, err := h.svc.AddSeries(r.Context(), addReq)
 	if err != nil {
-		h.logger.Error("add series", "err", err)
+		h.logger.ErrorContext(r.Context(), "add series", "error", err)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to add series: %v", err))
 		return
 	}
@@ -266,7 +266,7 @@ func (h *Handler) updateSeries(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.svc.UpdateSeries(r.Context(), existing); err != nil {
-		h.logger.Error("update series", "err", err)
+		h.logger.ErrorContext(r.Context(), "update series", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update series")
 		return
 	}
@@ -293,7 +293,7 @@ func (h *Handler) deleteSeries(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.svc.DeleteSeries(r.Context(), uuid); err != nil {
-		h.logger.Error("delete series", "err", err)
+		h.logger.ErrorContext(r.Context(), "delete series", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete series")
 		return
 	}
@@ -310,7 +310,7 @@ func (h *Handler) lookupSeries(w http.ResponseWriter, r *http.Request) {
 
 	results, err := h.svc.SearchTMDB(r.Context(), term)
 	if err != nil {
-		h.logger.Error("lookup series", "err", err)
+		h.logger.ErrorContext(r.Context(), "lookup series", "error", err)
 		writeError(w, http.StatusInternalServerError, "search failed")
 		return
 	}
@@ -349,7 +349,7 @@ func (h *Handler) listEpisodes(w http.ResponseWriter, r *http.Request) {
 
 	episodes, err := h.svc.ListEpisodes(r.Context(), uuid, nil)
 	if err != nil {
-		h.logger.Error("list episodes", "err", err)
+		h.logger.ErrorContext(r.Context(), "list episodes", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -408,7 +408,7 @@ func (h *Handler) getEpisode(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listRootFolders(w http.ResponseWriter, r *http.Request) {
 	libs, err := h.tvLibs(r.Context())
 	if err != nil {
-		h.logger.Error("list root folders", "err", err)
+		h.logger.ErrorContext(r.Context(), "list root folders", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
@@ -423,7 +423,7 @@ func (h *Handler) listRootFolders(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listQualityProfiles(w http.ResponseWriter, r *http.Request) {
 	profiles, err := h.qp.List(r.Context())
 	if err != nil {
-		h.logger.Error("list quality profiles", "err", err)
+		h.logger.ErrorContext(r.Context(), "list quality profiles", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}

--- a/internal/customformats/handlers.go
+++ b/internal/customformats/handlers.go
@@ -68,7 +68,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("custom format created", "id", cf.ID, "name", cf.Name)
+	h.logger.InfoContext(r.Context(), "custom format created", "id", cf.ID, "name", cf.Name)
 	h.writeJSON(w, http.StatusCreated, cf)
 }
 
@@ -88,7 +88,7 @@ func (h *handler) update(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("custom format updated", "id", cf.ID)
+	h.logger.InfoContext(r.Context(), "custom format updated", "id", cf.ID)
 	h.writeJSON(w, http.StatusOK, cf)
 }
 
@@ -102,7 +102,7 @@ func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("custom format deleted", "id", id)
+	h.logger.InfoContext(r.Context(), "custom format deleted", "id", id)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/downloads/handlers.go
+++ b/internal/downloads/handlers.go
@@ -511,7 +511,7 @@ func (s *Service) handleAdd(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Normalize()
 	if req.Magnet == "" && req.TorrentURL == "" && req.NZBURL == "" && len(req.RawBytes) == 0 {
-		slog.Warn("handleAdd: empty download request after normalize",
+		slog.WarnContext(r.Context(), "handleAdd: empty download request after normalize",
 			"client_id", id, "title", req.Title,
 			"magnet", req.Magnet, "torrent_url", req.TorrentURL,
 			"infohash", req.Infohash)
@@ -828,9 +828,9 @@ func (s *Service) recordManualGrab(ctx context.Context, res AddResult, req AddRe
 		}
 	}
 	if err != nil {
-		s.logger.Warn("failed to create manual grab workflow",
+		s.logger.WarnContext(ctx, "failed to create manual grab workflow",
 			"client_id", res.ClientID, "item_id", res.ItemID,
-			"media_type", req.MediaType, "err", err)
+			"media_type", req.MediaType, "error", err)
 		return
 	}
 	if wf != nil {
@@ -844,7 +844,7 @@ func (s *Service) recordManualGrab(ctx context.Context, res AddResult, req AddRe
 			SeedRatioLimit:       req.SeedRatioLimit,
 			SeedTimeLimitMinutes: req.SeedTimeLimitMinutes,
 		})
-		s.logger.Info("recorded manual grab workflow",
+		s.logger.InfoContext(ctx, "recorded manual grab workflow",
 			"workflow_id", wf.ID, "client_id", res.ClientID, "item_id", res.ItemID,
 			"media_type", req.MediaType)
 	}
@@ -1019,7 +1019,7 @@ func (s *Service) handleTorrentSpeedLimits(w http.ResponseWriter, r *http.Reques
 	// blob so they are re-applied on a cold start. A failure here does not
 	// undo the live change.
 	if err := s.persistTorrentSpeedLimits(r.Context(), id, req.DownloadLimit, req.UploadLimit); err != nil {
-		s.logger.Warn("persisting torrent speed limits failed", "id", id, "err", err)
+		s.logger.WarnContext(r.Context(), "persisting torrent speed limits failed", "id", id, "error", err)
 	}
 
 	writeJSON(w, http.StatusOK, mgr.EngineSummary())

--- a/internal/downloads/health.go
+++ b/internal/downloads/health.go
@@ -75,6 +75,6 @@ func (h *HealthChecker) Run(ctx context.Context) error {
 
 func (h *HealthChecker) checkOne(ctx context.Context, id string) {
 	if _, err := h.svc.TestOne(ctx, id); err != nil {
-		h.svc.logger.Debug("download health check failed", "id", id, "err", err)
+		h.svc.logger.Debug("download health check failed", "id", id, "error", err)
 	}
 }

--- a/internal/downloads/monitor.go
+++ b/internal/downloads/monitor.go
@@ -226,7 +226,7 @@ func (m *Monitor) emitCompletions(ctx context.Context, items []Item) {
 					}
 				}
 
-				m.logger.Info("monitor: emitted DownloadCompleted",
+				m.logger.Debug("monitor: emitted DownloadCompleted",
 					"item_id", item.ID, "client_id", item.ClientID,
 					"title", item.Title, "status", string(item.Status))
 			}

--- a/internal/downloads/router.go
+++ b/internal/downloads/router.go
@@ -191,7 +191,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 			})
 			if addErr != nil {
 				r.logger.Warn("router failed to publish DownloadQueued",
-					"download_id", res.ItemID, "err", addErr)
+					"download_id", res.ItemID, "error", addErr)
 			}
 			r.logger.Info("router queued result",
 				"indexer_id", result.IndexerID, "title", result.Title,
@@ -205,7 +205,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 
 		// This client failed; log and try the next.
 		r.logger.Warn("router: Add failed, trying next client",
-			"client_id", client.ID(), "err", err,
+			"client_id", client.ID(), "error", err,
 			"title", result.Title)
 		addErr = err
 	}
@@ -219,7 +219,7 @@ func (r *Router) handleIndexerResult(ctx context.Context, ev eventbus.Event) err
 	})
 	telemetry.ObserveDownloadFailed("", "all_clients_failed")
 	if failErr != nil {
-		r.logger.Warn("router failed to publish DownloadFailed", "err", failErr)
+		r.logger.Warn("router failed to publish DownloadFailed", "error", failErr)
 	}
 	return nil
 }
@@ -357,7 +357,7 @@ func (r *Router) enrichMetadata(ctx context.Context, result *indexers.Result, do
 			SourceProvider: "all", // Would track which provider matched if needed
 		}); pubErr != nil {
 			r.logger.Warn("router failed to publish MetadataEnriched event",
-				"origin_result_id", result.GUID, "err", pubErr)
+				"origin_result_id", result.GUID, "error", pubErr)
 		} else {
 			r.logger.Debug("router enriched result with movie metadata",
 				"origin_result_id", result.GUID, "title", result.Title)
@@ -376,7 +376,7 @@ func (r *Router) enrichMetadata(ctx context.Context, result *indexers.Result, do
 			SourceProvider: "all",
 		}); pubErr != nil {
 			r.logger.Warn("router failed to publish MetadataEnriched event",
-				"origin_result_id", result.GUID, "err", pubErr)
+				"origin_result_id", result.GUID, "error", pubErr)
 		} else {
 			r.logger.Debug("router enriched result with series metadata",
 				"origin_result_id", result.GUID, "title", result.Title)
@@ -397,7 +397,7 @@ func (r *Router) enrichMetadata(ctx context.Context, result *indexers.Result, do
 		FailedAt:       r.clock.Now(),
 	}); pubErr != nil {
 		r.logger.Warn("router failed to publish MetadataFailure event",
-			"origin_result_id", result.GUID, "err", pubErr)
+			"origin_result_id", result.GUID, "error", pubErr)
 	} else {
 		r.logger.Debug("router could not enrich result with metadata",
 			"origin_result_id", result.GUID, "title", result.Title, "reason", reason)

--- a/internal/downloads/service.go
+++ b/internal/downloads/service.go
@@ -225,7 +225,7 @@ func (s *Service) HydrateAll(ctx context.Context) error {
 		}
 		if err := s.hydrateOne(ctx, def); err != nil {
 			s.logger.Warn("hydrate download client failed",
-				"id", def.ID, "kind", def.Kind, "err", err)
+				"id", def.ID, "kind", def.Kind, "error", err)
 		}
 	}
 	s.logger.Info("download clients hydrated",
@@ -265,7 +265,7 @@ func (s *Service) Create(ctx context.Context, def Definition) (Definition, error
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("create: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("create: hydrate failed", "id", saved.ID, "error", err)
 		}
 	}
 	_ = s.repo.UpsertHealth(ctx, Health{
@@ -335,7 +335,7 @@ func (s *Service) Replace(ctx context.Context, def Definition) (Definition, erro
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("replace: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("replace: hydrate failed", "id", saved.ID, "error", err)
 		}
 	} else {
 		s.registry.Remove(saved.ID)
@@ -354,7 +354,7 @@ func (s *Service) Patch(ctx context.Context, p Patch) (Definition, error) {
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("patch: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("patch: hydrate failed", "id", saved.ID, "error", err)
 		}
 	} else {
 		s.registry.Remove(saved.ID)
@@ -419,7 +419,7 @@ func (s *Service) TestOne(ctx context.Context, id string) (Health, error) {
 		}
 	}
 	if perr := s.repo.UpsertHealth(ctx, h); perr != nil {
-		s.logger.Warn("persist download client health failed", "id", id, "err", perr)
+		s.logger.Warn("persist download client health failed", "id", id, "error", perr)
 	}
 	return h, err
 }

--- a/internal/downloads/stall_handler.go
+++ b/internal/downloads/stall_handler.go
@@ -72,7 +72,7 @@ func NewStallHandler(opts StallHandlerOptions) *StallHandler {
 
 // Handle processes a stalled or failed item.
 func (h *StallHandler) Handle(ctx context.Context, item Item, reason string) {
-	h.logger.Warn("stall detected",
+	h.logger.WarnContext(ctx, "stall detected",
 		"item_id", item.ID,
 		"title", item.Title,
 		"reason", reason,
@@ -100,28 +100,28 @@ func (h *StallHandler) Handle(ctx context.Context, item Item, reason string) {
 	case StallActionRetry:
 		h.doRetry(ctx, item, reason)
 	default:
-		h.logger.Error("unknown stall action", "action", string(h.action))
+		h.logger.ErrorContext(ctx, "unknown stall action", "action", string(h.action))
 	}
 }
 
 func (h *StallHandler) doPause(ctx context.Context, item Item) {
 	for _, c := range h.registry.List() {
 		if err := c.Pause(ctx, item.ID); err == nil {
-			h.logger.Info("paused stalled download", "item_id", item.ID)
+			h.logger.DebugContext(ctx, "paused stalled download", "item_id", item.ID)
 			return
 		}
 	}
-	h.logger.Warn("could not pause stalled download on any client", "item_id", item.ID)
+	h.logger.WarnContext(ctx, "could not pause stalled download on any client", "item_id", item.ID)
 }
 
 func (h *StallHandler) doRemove(ctx context.Context, item Item, deleteFiles bool) {
 	for _, c := range h.registry.List() {
 		if err := c.Remove(ctx, []string{item.ID}, deleteFiles); err == nil {
-			h.logger.Info("removed stalled download", "item_id", item.ID, "delete_files", deleteFiles)
+			h.logger.DebugContext(ctx, "removed stalled download", "item_id", item.ID, "delete_files", deleteFiles)
 			return
 		}
 	}
-	h.logger.Warn("could not remove stalled download on any client", "item_id", item.ID)
+	h.logger.WarnContext(ctx, "could not remove stalled download on any client", "item_id", item.ID)
 }
 
 func (h *StallHandler) doRemoveAndBlocklist(ctx context.Context, item Item, reason string) {
@@ -136,9 +136,9 @@ func (h *StallHandler) doRemoveAndBlocklist(ctx context.Context, item Item, reas
 			CreatedAt:   h.clock.Now(),
 		}
 		if err := h.blocklist.Add(ctx, entry); err != nil {
-			h.logger.Error("failed to add to blocklist", "item_id", item.ID, "err", err)
+			h.logger.ErrorContext(ctx, "failed to add to blocklist", "item_id", item.ID, "error", err)
 		} else {
-			h.logger.Info("added to blocklist", "item_id", item.ID, "title", item.Title)
+			h.logger.DebugContext(ctx, "added to blocklist", "item_id", item.ID, "title", item.Title)
 		}
 	}
 }
@@ -146,14 +146,14 @@ func (h *StallHandler) doRemoveAndBlocklist(ctx context.Context, item Item, reas
 func (h *StallHandler) doRetry(ctx context.Context, item Item, reason string) {
 	h.retryCount[item.ID]++
 	if h.retryCount[item.ID] > h.maxRetries {
-		h.logger.Warn("max retries exceeded, removing and blocklisting",
+		h.logger.WarnContext(ctx, "max retries exceeded, removing and blocklisting",
 			"item_id", item.ID, "retries", h.retryCount[item.ID]-1)
 		h.doRemoveAndBlocklist(ctx, item, reason+"; max retries exceeded")
 		delete(h.retryCount, item.ID)
 		return
 	}
 
-	h.logger.Info("retrying stalled download",
+	h.logger.DebugContext(ctx, "retrying stalled download",
 		"item_id", item.ID,
 		"attempt", h.retryCount[item.ID],
 		"max_retries", h.maxRetries,

--- a/internal/episodeorder/handlers.go
+++ b/internal/episodeorder/handlers.go
@@ -42,7 +42,7 @@ func listMappings(store *Store) http.HandlerFunc {
 		orderingType := r.URL.Query().Get("type")
 		mappings, err := store.ListMappings(r.Context(), seriesID, orderingType)
 		if err != nil {
-			slog.Error("episodeorder: list mappings", "err", err)
+			slog.ErrorContext(r.Context(), "episodeorder: list mappings", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -91,7 +91,7 @@ func createMapping(store *Store) http.HandlerFunc {
 		}
 
 		if err := store.CreateMapping(r.Context(), m); err != nil {
-			slog.Error("episodeorder: create mapping", "err", err)
+			slog.ErrorContext(r.Context(), "episodeorder: create mapping", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -111,7 +111,7 @@ func deleteMapping(store *Store) http.HandlerFunc {
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "mapping not found"})
 				return
 			}
-			slog.Error("episodeorder: delete mapping", "err", err)
+			slog.ErrorContext(r.Context(), "episodeorder: delete mapping", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}

--- a/internal/healthmonitor/monitor.go
+++ b/internal/healthmonitor/monitor.go
@@ -169,7 +169,7 @@ func (m *Monitor) processAlerts(ctx context.Context, results []CheckResult) {
 		}
 		title := fmt.Sprintf("Health %s: %s", r.Status, r.Name)
 		if err := m.notifier(ctx, title, r.Message); err != nil {
-			m.logger.Warn("failed to send health alert", "check", r.Name, "err", err)
+			m.logger.Warn("failed to send health alert", "check", r.Name, "error", err)
 		} else {
 			m.recordAlert(r.Name)
 			m.logger.Info("health alert sent", "check", r.Name, "status", r.Status)

--- a/internal/importlists/discover.go
+++ b/internal/importlists/discover.go
@@ -37,7 +37,7 @@ func (m *SyncManager) DiscoverItems(ctx context.Context, mediaType string) ([]*D
 				}
 			}
 		} else {
-			m.logger.Warn("import-lists: discover list series failed", "err", err)
+			m.logger.Warn("import-lists: discover list series failed", "error", err)
 		}
 	}
 
@@ -118,7 +118,7 @@ func (m *SyncManager) AddDiscoverItem(ctx context.Context, itemID string) (*Impo
 
 	item.Status = ItemStatusAdded
 	if uErr := m.store.UpsertItem(ctx, item); uErr != nil {
-		m.logger.Error("import-lists: discover add status update failed", "err", uErr)
+		m.logger.Error("import-lists: discover add status update failed", "error", uErr)
 	}
 	return item, nil
 }

--- a/internal/importlists/handlers.go
+++ b/internal/importlists/handlers.go
@@ -221,7 +221,7 @@ func syncList(store *Store, syncMgr *SyncManager, logger *slog.Logger) http.Hand
 		}
 
 		if err := syncMgr.SyncList(r.Context(), l); err != nil {
-			logger.Error("import-lists: manual sync failed", "id", id, "err", err)
+			logger.Error("import-lists: manual sync failed", "id", id, "error", err)
 			writeError(w, http.StatusInternalServerError, "sync failed: "+err.Error())
 			return
 		}
@@ -322,7 +322,7 @@ func addDiscover(syncMgr *SyncManager, logger *slog.Logger) http.HandlerFunc {
 		}
 		item, err := syncMgr.AddDiscoverItem(r.Context(), body.ItemID)
 		if err != nil {
-			logger.Error("import-lists: discover add failed", "item", body.ItemID, "err", err)
+			logger.Error("import-lists: discover add failed", "item", body.ItemID, "error", err)
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/internal/importlists/sync.go
+++ b/internal/importlists/sync.go
@@ -122,7 +122,7 @@ func (m *SyncManager) Stop() {
 func (m *SyncManager) tick(ctx context.Context) {
 	lists, err := m.store.ListAll(ctx)
 	if err != nil {
-		m.logger.Error("import-lists: failed to list", "err", err)
+		m.logger.Error("import-lists: failed to list", "error", err)
 		return
 	}
 	now := time.Now().UTC()
@@ -138,7 +138,7 @@ func (m *SyncManager) tick(ctx context.Context) {
 		}
 		if err := m.SyncList(ctx, l); err != nil {
 			m.logger.Error("import-lists: sync failed",
-				"list", l.Name, "id", l.ID, "err", err)
+				"list", l.Name, "id", l.ID, "error", err)
 		}
 	}
 }
@@ -193,13 +193,13 @@ func (m *SyncManager) SyncList(ctx context.Context, l *ImportList) error {
 		// Check exclusions
 		excluded, err := m.store.IsExcluded(ctx, fi.IMDbID, fi.TMDbID, fi.TVDbID)
 		if err != nil {
-			m.logger.Error("import-lists: exclusion check failed", "err", err)
+			m.logger.Error("import-lists: exclusion check failed", "error", err)
 			continue
 		}
 
 		existing, err := m.store.FindItemByExternalID(ctx, l.ID, fi.ExternalID)
 		if err != nil {
-			m.logger.Error("import-lists: find item failed", "err", err)
+			m.logger.Error("import-lists: find item failed", "error", err)
 			continue
 		}
 
@@ -222,7 +222,7 @@ func (m *SyncManager) SyncList(ctx context.Context, l *ImportList) error {
 			}
 			m.enrichItem(ctx, existing, l)
 			if err := m.store.UpsertItem(ctx, existing); err != nil {
-				m.logger.Error("import-lists: upsert existing failed", "err", err)
+				m.logger.Error("import-lists: upsert existing failed", "error", err)
 			}
 			continue
 		}
@@ -245,13 +245,13 @@ func (m *SyncManager) SyncList(ctx context.Context, l *ImportList) error {
 		}
 		m.enrichItem(ctx, item, l)
 		if err := m.store.UpsertItem(ctx, item); err != nil {
-			m.logger.Error("import-lists: insert failed", "err", err)
+			m.logger.Error("import-lists: insert failed", "error", err)
 		}
 	}
 
 	now := time.Now().UTC()
 	if err := m.store.UpdateLastSync(ctx, l.ID, now); err != nil {
-		m.logger.Error("import-lists: update last_sync failed", "err", err)
+		m.logger.Error("import-lists: update last_sync failed", "error", err)
 	}
 
 	// Only auto-add to the library when the list is in auto mode. In discover
@@ -302,7 +302,7 @@ func (m *SyncManager) enrichItem(ctx context.Context, item *ImportListItem, l *I
 	if mediaType == string(MediaTypeSeries) {
 		meta, err := m.tmdbClient.GetTV(ctx, tmdbID)
 		if err != nil {
-			m.logger.Debug("import-lists: tmdb tv enrich failed", "title", item.Title, "err", err)
+			m.logger.Debug("import-lists: tmdb tv enrich failed", "title", item.Title, "error", err)
 			return
 		}
 		if item.PosterPath == "" {
@@ -319,7 +319,7 @@ func (m *SyncManager) enrichItem(ctx context.Context, item *ImportListItem, l *I
 
 	meta, err := m.tmdbClient.GetMovie(ctx, tmdbID)
 	if err != nil {
-		m.logger.Debug("import-lists: tmdb movie enrich failed", "title", item.Title, "err", err)
+		m.logger.Debug("import-lists: tmdb movie enrich failed", "title", item.Title, "error", err)
 		return
 	}
 	if item.PosterPath == "" {
@@ -392,7 +392,7 @@ func (m *SyncManager) GetTraktUserLists(ctx context.Context) ([]providers.TraktU
 func (m *SyncManager) findTraktConnection(ctx context.Context) *connect.Connection {
 	conns, err := m.connectSvc.ListConnections(ctx)
 	if err != nil {
-		m.logger.Warn("import-lists: failed to list connections for Trakt credentials", "err", err)
+		m.logger.Warn("import-lists: failed to list connections for Trakt credentials", "error", err)
 		return nil
 	}
 	for _, c := range conns {
@@ -407,7 +407,7 @@ func (m *SyncManager) findTraktConnection(ctx context.Context) *connect.Connecti
 func (m *SyncManager) processPendingItems(ctx context.Context, l *ImportList) {
 	items, err := m.store.ListItems(ctx, l.ID)
 	if err != nil {
-		m.logger.Error("import-lists: list pending items failed", "err", err)
+		m.logger.Error("import-lists: list pending items failed", "error", err)
 		return
 	}
 
@@ -433,14 +433,14 @@ func (m *SyncManager) processPendingItems(ctx context.Context, l *ImportList) {
 
 		if addErr != nil {
 			m.logger.Error("import-lists: add item failed",
-				"title", item.Title, "err", addErr)
+				"title", item.Title, "error", addErr)
 			item.Status = ItemStatusFailed
 		} else {
 			item.Status = ItemStatusAdded
 		}
 
 		if err := m.store.UpsertItem(ctx, item); err != nil {
-			m.logger.Error("import-lists: update item status failed", "err", err)
+			m.logger.Error("import-lists: update item status failed", "error", err)
 		}
 	}
 }
@@ -500,7 +500,7 @@ func (m *SyncManager) addMovieToLibrary(ctx context.Context, l *ImportList, item
 	// Enrich metadata (poster, overview, genres, etc.) from TMDb.
 	if err := m.moviesSvc.RefreshMovie(ctx, movie.ID); err != nil {
 		m.logger.Warn("import-lists: metadata enrichment failed (movie added without poster)",
-			"title", item.Title, "err", err)
+			"title", item.Title, "error", err)
 	}
 
 	m.logger.Info("import-lists: added movie", "title", item.Title, "tmdb_id", tmdbID)

--- a/internal/imports/decision_log.go
+++ b/internal/imports/decision_log.go
@@ -58,7 +58,6 @@ func (dl *DecisionLogger) Log(ctx context.Context, d ImportDecision) error {
 		d.ConflictPolicy, d.FileSize, d.FileQuality, d.CreatedAt,
 	)
 	if err != nil {
-		dl.logger.Error("failed to log import decision", "error", err, "action", d.Action, "source", d.SourcePath)
 		return fmt.Errorf("log import decision: %w", err)
 	}
 

--- a/internal/imports/reimport.go
+++ b/internal/imports/reimport.go
@@ -133,8 +133,6 @@ func (p *ImportPipeline) ReimportFile(ctx context.Context, mediaType MediaType, 
 
 	// Update library
 	if err := p.updateLibrary(ctx, match, destFile, sourcePath); err != nil {
-		p.logger.Error("library update failed after reimport, cleaning up",
-			"error", err, "dest", destFile)
 		_ = os.Remove(destFile)
 		return nil, fmt.Errorf("update library: %w", err)
 	}

--- a/internal/indexers/cardigann/engine.go
+++ b/internal/indexers/cardigann/engine.go
@@ -530,7 +530,7 @@ func (e *Engine) Search(ctx context.Context, q indexers.Query) (*indexers.Result
 	for i, sp := range paths {
 		method, target, params, headers, err := e.buildSearchRequestForPath(sp, tctx)
 		if err != nil {
-			slog.Warn("cardigann: search path error", "indexer", e.id, "path_idx", i, "err", err)
+			slog.Warn("cardigann: search path error", "indexer", e.id, "path_idx", i, "error", err)
 			pathErrors = append(pathErrors, fmt.Errorf("path %d build: %w", i, err))
 			continue
 		}
@@ -561,7 +561,7 @@ func (e *Engine) Search(ctx context.Context, q indexers.Query) (*indexers.Result
 
 		body, err := e.fetch(ctx, method, target, params, headers)
 		if err != nil {
-			slog.Warn("cardigann: search fetch error", "indexer", e.id, "path_idx", i, "err", err)
+			slog.Warn("cardigann: search fetch error", "indexer", e.id, "path_idx", i, "error", err)
 			pathErrors = append(pathErrors, fmt.Errorf("path %d fetch: %w", i, err))
 			continue
 		}
@@ -582,7 +582,7 @@ func (e *Engine) Search(ctx context.Context, q indexers.Query) (*indexers.Result
 			rows, err = e.extractRows(body, tctx)
 		}
 		if err != nil {
-			slog.Warn("cardigann: search extract error", "indexer", e.id, "path_idx", i, "err", err)
+			slog.Warn("cardigann: search extract error", "indexer", e.id, "path_idx", i, "error", err)
 			pathErrors = append(pathErrors, fmt.Errorf("path %d extract: %w", i, err))
 			continue
 		}
@@ -752,7 +752,6 @@ func (e *Engine) fetch(ctx context.Context, method, target string, params url.Va
 	// RoundTripper's PostResponse solve either wasn't triggered
 	// (no flaresolverr proxy) or it failed. Report the error.
 	if cloudflare.IsChallenge(resp, body) {
-		slog.Warn("cardigann: cloudflare challenge detected (unsolved)", "indexer", e.id, "url", full)
 		return nil, fmt.Errorf("cardigann: %s %s: %w", method, target, indexers.ErrCloudFlareChallenge)
 	}
 	if resp.StatusCode >= 500 {
@@ -906,7 +905,7 @@ func (e *Engine) extractOne(node *goquery.Selection, tctx templateContext) (inde
 			sel, err = e.expandTemplate(sel, fieldCtx)
 			if err != nil {
 				slog.Warn("cardigann: field selector template error",
-					"indexer", e.id, "field", name, "err", err)
+					"indexer", e.id, "field", name, "error", err)
 				continue
 			}
 		}
@@ -938,7 +937,7 @@ func (e *Engine) extractOne(node *goquery.Selection, tctx templateContext) (inde
 				expanded, terr = e.expandTemplate(expanded, fieldCtx)
 				if terr != nil {
 					slog.Warn("cardigann: field text template error",
-						"indexer", e.id, "field", name, "err", terr)
+						"indexer", e.id, "field", name, "error", terr)
 					continue
 				}
 			}
@@ -995,7 +994,7 @@ func (e *Engine) extractOne(node *goquery.Selection, tctx templateContext) (inde
 			fallback, terr = e.expandTemplate(fallback, fieldCtx)
 			if terr != nil {
 				slog.Warn("cardigann: field default template error",
-					"indexer", e.id, "field", name, "err", terr)
+					"indexer", e.id, "field", name, "error", terr)
 				continue
 			}
 		}
@@ -1265,7 +1264,7 @@ var cardigannFuncs = template.FuncMap{
 			compiled, err := regexp.Compile(pattern)
 			if err != nil {
 				slog.Warn("cardigann: re_replace: bad pattern",
-					"pattern", pattern, "err", err)
+					"pattern", pattern, "error", err)
 				return s
 			}
 			cached, _ = reCache.LoadOrStore(pattern, compiled)
@@ -1335,7 +1334,7 @@ func (e *Engine) expandFilterArg(arg any, ctx templateContext) any {
 		expanded, err := e.expandTemplate(v, ctx)
 		if err != nil {
 			slog.Warn("cardigann: filter arg template error",
-				"indexer", e.id, "err", err)
+				"indexer", e.id, "error", err)
 			return v
 		}
 		return expanded

--- a/internal/indexers/cardigann/json_extract.go
+++ b/internal/indexers/cardigann/json_extract.go
@@ -146,7 +146,7 @@ func (e *Engine) extractOneJSON(obj, parentObj map[string]any, tctx templateCont
 			sel, err = e.expandTemplate(sel, fieldCtx)
 			if err != nil {
 				slog.Warn("cardigann: json field selector template error",
-					"indexer", e.id, "field", name, "err", err)
+					"indexer", e.id, "field", name, "error", err)
 				continue
 			}
 		}

--- a/internal/indexers/handlers.go
+++ b/internal/indexers/handlers.go
@@ -512,7 +512,7 @@ func (s *Service) handleSearchStream(w http.ResponseWriter, r *http.Request) {
 			}
 			data, err := json.Marshal(evt)
 			if err != nil {
-				slog.Warn("sse: marshal error", "err", err)
+				slog.WarnContext(r.Context(), "sse: marshal error", "error", err)
 				continue
 			}
 			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", evt.Type, data)

--- a/internal/indexers/health.go
+++ b/internal/indexers/health.go
@@ -103,7 +103,7 @@ func (h *HealthChecker) Run(ctx context.Context) error {
 func (h *HealthChecker) checkOne(ctx context.Context, id string) {
 	health, err := h.svc.TestOne(ctx, id)
 	if err != nil {
-		h.svc.logger.Warn("health check completed", "id", id, "status", health.Status, "latency_ms", health.LatencyMS, "err", err)
+		h.svc.logger.Warn("health check completed", "id", id, "status", health.Status, "latency_ms", health.LatencyMS, "error", err)
 
 		h.mu.Lock()
 		h.consecutiveFailures[id]++

--- a/internal/indexers/proxies/flaresolverr.go
+++ b/internal/indexers/proxies/flaresolverr.go
@@ -184,7 +184,7 @@ func (c *FlareSolverrClient) do(ctx context.Context, cfg FlareSolverrConfig, bod
 	}
 	start := time.Now()
 	resp, err := c.httpc.Do(req)
-	slog.Debug("flaresolverr: response received", "cmd", body.Cmd, "elapsed", time.Since(start).String(), "err", err)
+	slog.Debug("flaresolverr: response received", "cmd", body.Cmd, "elapsed", time.Since(start).String(), "error", err)
 	if err != nil {
 		return flareEnvelope{}, fmt.Errorf("flaresolverr: do request: %w", err)
 	}

--- a/internal/indexers/service.go
+++ b/internal/indexers/service.go
@@ -184,7 +184,7 @@ func (s *Service) HydrateAll(ctx context.Context) error {
 		}
 		if err := s.hydrateOne(ctx, def); err != nil {
 			s.logger.Warn("hydrate indexer failed",
-				"id", def.ID, "kind", def.Kind, "err", err)
+				"id", def.ID, "kind", def.Kind, "error", err)
 		}
 	}
 	s.logger.Info("indexers hydrated",
@@ -221,7 +221,7 @@ func (s *Service) Create(ctx context.Context, def Definition) (Definition, error
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("create: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("create: hydrate failed", "id", saved.ID, "error", err)
 		}
 	}
 	// Seed a "unknown" health row so list endpoints have something
@@ -373,7 +373,7 @@ func (s *Service) RateLimitFor(indexerID string) (throttle.Config, bool) {
 	if err != nil {
 		if !errors.Is(err, ErrNotFound) {
 			s.logger.Warn("rate-limit lookup failed",
-				"id", indexerID, "err", err)
+				"id", indexerID, "error", err)
 		}
 		return throttle.Config{}, false
 	}
@@ -404,7 +404,7 @@ func (s *Service) SetRateLimit(ctx context.Context, id string, cfg throttle.Conf
 	}
 	if def.Enabled {
 		if herr := s.hydrateOne(ctx, def); herr != nil {
-			s.logger.Warn("rate-limit: hydrate failed", "id", id, "err", herr)
+			s.logger.Warn("rate-limit: hydrate failed", "id", id, "error", herr)
 		}
 	}
 	return nil
@@ -430,7 +430,7 @@ func (s *Service) Replace(ctx context.Context, def Definition) (Definition, erro
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("replace: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("replace: hydrate failed", "id", saved.ID, "error", err)
 		}
 	} else {
 		s.registry.Remove(saved.ID)
@@ -461,7 +461,7 @@ func (s *Service) Patch(ctx context.Context, p Patch) (Definition, error) {
 	}
 	if saved.Enabled {
 		if err := s.hydrateOne(ctx, saved); err != nil {
-			s.logger.Warn("patch: hydrate failed", "id", saved.ID, "err", err)
+			s.logger.Warn("patch: hydrate failed", "id", saved.ID, "error", err)
 		}
 	} else {
 		s.registry.Remove(saved.ID)
@@ -551,7 +551,7 @@ func (s *Service) TestOne(ctx context.Context, id string) (Health, error) {
 		h.LastSuccessAt = &t
 	}
 	if perr := s.repo.UpsertHealth(ctx, h); perr != nil {
-		s.logger.Warn("persist health failed", "id", id, "err", perr)
+		s.logger.Warn("persist health failed", "id", id, "error", perr)
 	}
 
 	status := "passed"
@@ -589,7 +589,7 @@ func (s *Service) proxyTimeoutOverrides(ctx context.Context, ids []string) map[s
 	}
 	defs, err := s.repo.List(ctx)
 	if err != nil {
-		s.logger.Warn("proxy timeout overrides: list definitions failed", "err", err)
+		s.logger.Warn("proxy timeout overrides: list definitions failed", "error", err)
 		return nil
 	}
 	want := make(map[string]struct{}, len(ids))
@@ -626,7 +626,7 @@ func (s *Service) Search(ctx context.Context, q Query, ids []string, perTimeout 
 	if s.queryLog != nil {
 		queryLogID = NewQueryID()
 		if err := s.queryLog.StartQuery(ctx, queryLogID, q.Term, "search", "", ""); err != nil {
-			s.logger.Warn("query log: start failed", "err", err)
+			s.logger.Warn("query log: start failed", "error", err)
 		}
 	}
 
@@ -705,10 +705,10 @@ func (s *Service) Search(ctx context.Context, q Query, ids []string, perTimeout 
 			if s.queryLog != nil && queryLogID != "" {
 				iqID := NewQueryID()
 				if err := s.queryLog.StartIndexerQuery(ctx, iqID, queryLogID, indexerID, d.Name); err != nil {
-					s.logger.Warn("query log: start indexer failed", "err", err)
+					s.logger.Warn("query log: start indexer failed", "error", err)
 				}
 				if err := s.queryLog.FinishIndexerQuery(ctx, iqID, d.ResultCount, d.ResponseTimeMS, searchErr); err != nil {
-					s.logger.Warn("query log: finish indexer failed", "err", err)
+					s.logger.Warn("query log: finish indexer failed", "error", err)
 				}
 			}
 		}
@@ -717,7 +717,7 @@ func (s *Service) Search(ctx context.Context, q Query, ids []string, perTimeout 
 	// Finish query log.
 	if s.queryLog != nil && queryLogID != "" {
 		if err := s.queryLog.FinishQuery(ctx, queryLogID, len(agg.Results), nil); err != nil {
-			s.logger.Warn("query log: finish failed", "err", err)
+			s.logger.Warn("query log: finish failed", "error", err)
 		}
 	}
 
@@ -756,7 +756,7 @@ func (s *Service) SearchStream(ctx context.Context, q Query, ids []string, perTi
 	if s.queryLog != nil {
 		queryLogID = NewQueryID()
 		if err := s.queryLog.StartQuery(ctx, queryLogID, q.Term, "search-stream", "", ""); err != nil {
-			s.logger.Warn("query log: start failed", "err", err)
+			s.logger.Warn("query log: start failed", "error", err)
 		}
 	}
 
@@ -800,10 +800,10 @@ func (s *Service) SearchStream(ctx context.Context, q Query, ids []string, perTi
 			if s.queryLog != nil && queryLogID != "" {
 				iqID := NewQueryID()
 				if err := s.queryLog.StartIndexerQuery(ctx, iqID, queryLogID, indexerID, evt.IndexerName); err != nil {
-					s.logger.Warn("query log: start indexer failed", "err", err)
+					s.logger.Warn("query log: start indexer failed", "error", err)
 				}
 				if err := s.queryLog.FinishIndexerQuery(ctx, iqID, evt.ResultCount, evt.ElapsedMS, searchErr); err != nil {
-					s.logger.Warn("query log: finish indexer failed", "err", err)
+					s.logger.Warn("query log: finish indexer failed", "error", err)
 				}
 			}
 			if evt.Type == EventIndexerResult {
@@ -825,7 +825,7 @@ func (s *Service) SearchStream(ctx context.Context, q Query, ids []string, perTi
 
 	if s.queryLog != nil && queryLogID != "" {
 		if err := s.queryLog.FinishQuery(ctx, queryLogID, totalResults, nil); err != nil {
-			s.logger.Warn("query log: finish failed", "err", err)
+			s.logger.Warn("query log: finish failed", "error", err)
 		}
 	}
 

--- a/internal/kernel/logging/capture_handler.go
+++ b/internal/kernel/logging/capture_handler.go
@@ -161,6 +161,10 @@ func (h *CaptureHandler) recordToEntry(ctx context.Context, r slog.Record) LogEn
 		flattenAttr(attrs, "", a)
 		return true
 	})
+	if traceID, spanID, ok := traceAttrsFromContext(ctx); ok {
+		attrs["trace_id"] = traceID
+		attrs["span_id"] = spanID
+	}
 
 	// Fallback: extract workflow_id from attrs if not already set.
 	if entry.WorkflowID == "" {

--- a/internal/kernel/logging/logging.go
+++ b/internal/kernel/logging/logging.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/ebenderooock/loom/internal/kernel/config"
 )
 
@@ -81,6 +83,12 @@ func (h *redactingHandler) Handle(ctx context.Context, r slog.Record) error {
 		rr.AddAttrs(redact(a))
 		return true
 	})
+	if traceID, spanID, ok := traceAttrsFromContext(ctx); ok {
+		rr.AddAttrs(
+			slog.String("trace_id", traceID),
+			slog.String("span_id", spanID),
+		)
+	}
 	return h.inner.Handle(ctx, rr)
 }
 
@@ -109,4 +117,12 @@ func redact(a slog.Attr) slog.Attr {
 		return slog.Attr{Key: a.Key, Value: slog.GroupValue(out...)}
 	}
 	return a
+}
+
+func traceAttrsFromContext(ctx context.Context) (traceID string, spanID string, ok bool) {
+	spanCtx := trace.SpanFromContext(ctx).SpanContext()
+	if !spanCtx.IsValid() {
+		return "", "", false
+	}
+	return spanCtx.TraceID().String(), spanCtx.SpanID().String(), true
 }

--- a/internal/kernel/logging/logging_test.go
+++ b/internal/kernel/logging/logging_test.go
@@ -2,8 +2,15 @@ package logging
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/ebenderooock/loom/internal/kernel/config"
 )
@@ -35,5 +42,77 @@ func TestParseLevel(t *testing.T) {
 	}
 	if _, err := parseLevel("trace"); err == nil {
 		t.Error("expected parseLevel(trace) to error")
+	}
+}
+
+func TestLoggerIncludesTraceContextAttrs(t *testing.T) {
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	var buf bytes.Buffer
+	l, err := newWith(&buf, config.LogConfig{Level: "info", Format: "json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "log-with-trace")
+	defer span.End()
+
+	l.InfoContext(ctx, "hello")
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("unmarshal log record: %v", err)
+	}
+
+	if got, want := record["trace_id"], span.SpanContext().TraceID().String(); got != want {
+		t.Fatalf("trace_id = %v, want %s", got, want)
+	}
+	if got, want := record["span_id"], span.SpanContext().SpanID().String(); got != want {
+		t.Fatalf("span_id = %v, want %s", got, want)
+	}
+}
+
+func TestCaptureHandlerIncludesTraceContextAttrs(t *testing.T) {
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	rb := NewRingBuffer(10)
+	logger := slog.New(NewCaptureHandler(CaptureHandlerConfig{
+		Inner:        slog.NewJSONHandler(io.Discard, nil),
+		Buffer:       rb,
+		CaptureLevel: slog.LevelInfo,
+	}))
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "capture-with-trace")
+	defer span.End()
+
+	logger.InfoContext(ctx, "hello")
+
+	entries := rb.Read(1, "")
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 captured log entry, got %d", len(entries))
+	}
+
+	var attrs map[string]any
+	if err := json.Unmarshal([]byte(entries[0].Attrs), &attrs); err != nil {
+		t.Fatalf("unmarshal captured attrs: %v", err)
+	}
+
+	if got, want := attrs["trace_id"], span.SpanContext().TraceID().String(); got != want {
+		t.Fatalf("trace_id = %v, want %s", got, want)
+	}
+	if got, want := attrs["span_id"], span.SpanContext().SpanID().String(); got != want {
+		t.Fatalf("span_id = %v, want %s", got, want)
 	}
 }

--- a/internal/kernel/scheduler/scheduler.go
+++ b/internal/kernel/scheduler/scheduler.go
@@ -326,7 +326,7 @@ func (s *Scheduler) fire(ctx context.Context, j *job, now time.Time) {
 	if !j.mu.TryLock() {
 		nextRun := j.parsed.Next(now)
 		if err := s.store.SetNextRun(context.Background(), j.name, nextRun); err != nil {
-			s.logger.Error("update next_run_at after skip", "job", j.name, "err", err)
+			s.logger.Error("update next_run_at after skip", "job", j.name, "error", err)
 		}
 		s.logger.Warn("job skipped: previous run still in flight", "job", j.name, "next_run_at", nextRun)
 		return
@@ -360,7 +360,7 @@ func (s *Scheduler) executeOnce(ctx context.Context, j *job, scheduledFor time.T
 		recordCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := s.store.RecordRun(recordCtx, j.name, startedAt, nextRun, status, errMsg); err != nil {
-			s.logger.Error("record job run", "job", j.name, "err", err)
+			s.logger.Error("record job run", "job", j.name, "error", err)
 		}
 	}()
 
@@ -368,7 +368,7 @@ func (s *Scheduler) executeOnce(ctx context.Context, j *job, scheduledFor time.T
 	if err := j.handler(ctx); err != nil {
 		status = StatusFailed
 		errMsg = err.Error()
-		s.logger.Error("job failed", "job", j.name, "err", err)
+		s.logger.Error("job failed", "job", j.name, "error", err)
 		return
 	}
 	s.logger.Debug("job succeeded", "job", j.name, "duration", s.clock.Now().Sub(startedAt))

--- a/internal/libraries/handlers.go
+++ b/internal/libraries/handlers.go
@@ -69,7 +69,7 @@ func listLibraries(store *Store, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		libs, err := store.List(r.Context())
 		if err != nil {
-			logger.Error("libraries: list", "err", err)
+			logger.Error("libraries: list", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -134,7 +134,7 @@ func createLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 				writeError(w, http.StatusConflict, "library path already exists")
 				return
 			}
-			logger.Error("libraries: create", "err", err)
+			logger.Error("libraries: create", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -152,7 +152,7 @@ func getLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 				writeError(w, http.StatusNotFound, err.Error())
 				return
 			}
-			logger.Error("libraries: get", "err", err)
+			logger.Error("libraries: get", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -161,7 +161,7 @@ func getLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 		// Include files in detail view.
 		files, err := store.ListFiles(r.Context(), id)
 		if err != nil {
-			logger.Error("libraries: list files", "err", err)
+			logger.Error("libraries: list files", "error", err)
 			files = []LibraryFile{}
 		}
 		if files == nil {
@@ -184,7 +184,7 @@ func updateLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 				writeError(w, http.StatusNotFound, err.Error())
 				return
 			}
-			logger.Error("libraries: get for update", "err", err)
+			logger.Error("libraries: get for update", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -212,7 +212,7 @@ func updateLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 		}
 
 		if err := store.Update(r.Context(), lib); err != nil {
-			logger.Error("libraries: update", "err", err)
+			logger.Error("libraries: update", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -229,7 +229,7 @@ func deleteLibrary(store *Store, logger *slog.Logger) http.HandlerFunc {
 				writeError(w, http.StatusNotFound, err.Error())
 				return
 			}
-			logger.Error("libraries: delete", "err", err)
+			logger.Error("libraries: delete", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -246,7 +246,7 @@ func scanLibrary(store *Store, scanner *Scanner, logger *slog.Logger) http.Handl
 				writeError(w, http.StatusNotFound, err.Error())
 				return
 			}
-			logger.Error("libraries: get for scan", "err", err)
+			logger.Error("libraries: get for scan", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal error")
 			return
 		}
@@ -256,7 +256,7 @@ func scanLibrary(store *Store, scanner *Scanner, logger *slog.Logger) http.Handl
 		scanCtx := context.WithoutCancel(r.Context())
 		go func() {
 			if err := scanner.ScanLibrary(scanCtx, lib); err != nil {
-				logger.Error("libraries: scan failed", "id", id, "err", err)
+				logger.Error("libraries: scan failed", "id", id, "error", err)
 			}
 		}()
 

--- a/internal/libraries/scanner.go
+++ b/internal/libraries/scanner.go
@@ -50,7 +50,7 @@ func (sc *Scanner) ScanLibrary(ctx context.Context, lib *Library) error {
 
 	err := filepath.WalkDir(lib.Path, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			sc.logger.Warn("walk error", "path", path, "err", err)
+			sc.logger.Warn("walk error", "path", path, "error", err)
 			return nil // skip inaccessible entries
 		}
 		if ctx.Err() != nil {
@@ -71,7 +71,7 @@ func (sc *Scanner) ScanLibrary(ctx context.Context, lib *Library) error {
 
 		info, err := d.Info()
 		if err != nil {
-			sc.logger.Warn("stat error", "path", path, "err", err)
+			sc.logger.Warn("stat error", "path", path, "error", err)
 			return nil
 		}
 
@@ -81,7 +81,7 @@ func (sc *Scanner) ScanLibrary(ctx context.Context, lib *Library) error {
 			SizeBytes: info.Size(),
 		}
 		if err := sc.store.UpsertFile(ctx, f); err != nil {
-			sc.logger.Error("upsert file", "path", path, "err", err)
+			sc.logger.Error("upsert file", "path", path, "error", err)
 		}
 		return nil
 	})
@@ -92,7 +92,7 @@ func (sc *Scanner) ScanLibrary(ctx context.Context, lib *Library) error {
 	// Clean up files that no longer exist on disk.
 	removed, err := sc.store.DeleteStaleFiles(ctx, lib.ID, scanStart)
 	if err != nil {
-		sc.logger.Error("delete stale files", "library", lib.ID, "err", err)
+		sc.logger.Error("delete stale files", "library", lib.ID, "error", err)
 	} else if removed > 0 {
 		sc.logger.Info("removed stale files", "library", lib.ID, "count", removed)
 	}

--- a/internal/mediainfo/handlers.go
+++ b/internal/mediainfo/handlers.go
@@ -29,7 +29,7 @@ func getPreferences(store *Store, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		prefs, err := store.GetPreferences(r.Context())
 		if err != nil {
-			logger.Error("mediainfo: get preferences", "err", err)
+			logger.Error("mediainfo: get preferences", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -54,7 +54,7 @@ func putPreferences(store *Store, logger *slog.Logger) http.HandlerFunc {
 		}
 
 		if err := store.UpsertPreferences(r.Context(), &prefs); err != nil {
-			logger.Error("mediainfo: upsert preferences", "err", err)
+			logger.Error("mediainfo: upsert preferences", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
@@ -62,7 +62,7 @@ func putPreferences(store *Store, logger *slog.Logger) http.HandlerFunc {
 		// Re-read to get timestamps
 		updated, err := store.GetPreferences(r.Context())
 		if err != nil {
-			logger.Error("mediainfo: re-read preferences", "err", err)
+			logger.Error("mediainfo: re-read preferences", "error", err)
 			writeJSON(w, http.StatusOK, prefs)
 			return
 		}

--- a/internal/migrate/prowlarr.go
+++ b/internal/migrate/prowlarr.go
@@ -53,7 +53,7 @@ func (imp *Importer) importProwlarrIndexers(ctx context.Context, src *sql.DB, tx
 		        COALESCE(Enable, 1), COALESCE(Priority, 25), COALESCE(Protocol, 1)
 		 FROM Indexers`)
 	if err != nil {
-		imp.logger.Warn("prowlarr: could not read Indexers", "err", err)
+		imp.logger.Warn("prowlarr: could not read Indexers", "error", err)
 		res.Errors = append(res.Errors, "read Indexers: "+err.Error())
 		return
 	}

--- a/internal/migrate/radarr.go
+++ b/internal/migrate/radarr.go
@@ -44,7 +44,7 @@ func (imp *Importer) ImportRadarr(ctx context.Context, radarrDBPath string) (*Im
 func (imp *Importer) importRadarrProfiles(ctx context.Context, src *sql.DB, tx *sql.Tx, res *ImportResult) {
 	rows, err := src.QueryContext(ctx, `SELECT Id, Name FROM QualityProfiles`)
 	if err != nil {
-		imp.logger.Warn("radarr: could not read QualityProfiles", "err", err)
+		imp.logger.Warn("radarr: could not read QualityProfiles", "error", err)
 		res.Errors = append(res.Errors, "read QualityProfiles: "+err.Error())
 		return
 	}
@@ -78,7 +78,7 @@ func (imp *Importer) importRadarrProfiles(ctx context.Context, src *sql.DB, tx *
 func (imp *Importer) importRadarrRootFolders(ctx context.Context, src *sql.DB, tx *sql.Tx, res *ImportResult) {
 	rows, err := src.QueryContext(ctx, `SELECT Id, Path FROM RootFolders`)
 	if err != nil {
-		imp.logger.Warn("radarr: could not read RootFolders", "err", err)
+		imp.logger.Warn("radarr: could not read RootFolders", "error", err)
 		res.Errors = append(res.Errors, "read RootFolders: "+err.Error())
 		return
 	}
@@ -117,7 +117,7 @@ func (imp *Importer) importRadarrMovies(ctx context.Context, src *sql.DB, tx *sq
 		        COALESCE(Images, '[]')
 		 FROM Movies`)
 	if err != nil {
-		imp.logger.Warn("radarr: could not read Movies", "err", err)
+		imp.logger.Warn("radarr: could not read Movies", "error", err)
 		res.Errors = append(res.Errors, "read Movies: "+err.Error())
 		return
 	}

--- a/internal/migrate/sonarr.go
+++ b/internal/migrate/sonarr.go
@@ -45,7 +45,7 @@ func (imp *Importer) ImportSonarr(ctx context.Context, sonarrDBPath string) (*Im
 func (imp *Importer) importSonarrProfiles(ctx context.Context, src *sql.DB, tx *sql.Tx, res *ImportResult) {
 	rows, err := src.QueryContext(ctx, `SELECT Id, Name FROM QualityProfiles`)
 	if err != nil {
-		imp.logger.Warn("sonarr: could not read QualityProfiles", "err", err)
+		imp.logger.Warn("sonarr: could not read QualityProfiles", "error", err)
 		res.Errors = append(res.Errors, "read QualityProfiles: "+err.Error())
 		return
 	}
@@ -79,7 +79,7 @@ func (imp *Importer) importSonarrProfiles(ctx context.Context, src *sql.DB, tx *
 func (imp *Importer) importSonarrRootFolders(ctx context.Context, src *sql.DB, tx *sql.Tx, res *ImportResult) {
 	rows, err := src.QueryContext(ctx, `SELECT Id, Path FROM RootFolders`)
 	if err != nil {
-		imp.logger.Warn("sonarr: could not read RootFolders", "err", err)
+		imp.logger.Warn("sonarr: could not read RootFolders", "error", err)
 		res.Errors = append(res.Errors, "read RootFolders: "+err.Error())
 		return
 	}
@@ -118,7 +118,7 @@ func (imp *Importer) importSonarrSeries(ctx context.Context, src *sql.DB, tx *sq
 		        COALESCE(SeasonFolder, 1)
 		 FROM Series`)
 	if err != nil {
-		imp.logger.Warn("sonarr: could not read Series", "err", err)
+		imp.logger.Warn("sonarr: could not read Series", "error", err)
 		res.Errors = append(res.Errors, "read Series: "+err.Error())
 		return
 	}
@@ -190,7 +190,7 @@ func (imp *Importer) importSonarrEpisodes(ctx context.Context, src *sql.DB, tx *
 		        COALESCE(AirDate, ''), Monitored
 		 FROM Episodes`)
 	if err != nil {
-		imp.logger.Warn("sonarr: could not read Episodes", "err", err)
+		imp.logger.Warn("sonarr: could not read Episodes", "error", err)
 		res.Errors = append(res.Errors, "read Episodes: "+err.Error())
 		return
 	}

--- a/internal/movies/handlers.go
+++ b/internal/movies/handlers.go
@@ -227,7 +227,7 @@ func refreshAllMovies(svc Service) http.HandlerFunc {
 		go func(ctx context.Context, movieIDs []string) {
 			for _, id := range movieIDs {
 				if err := svc.RefreshMovie(ctx, id); err != nil {
-					slog.Warn("movies: bulk refresh failed", "movie_id", id, "error", err)
+					slog.WarnContext(ctx, "movies: bulk refresh failed", "movie_id", id, "error", err)
 				}
 			}
 		}(ctx, ids)
@@ -268,7 +268,7 @@ func rescanAllMovieLibraries(
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
-					slog.Warn("movies: bulk rescan failed", "library_id", lib.ID, "error", err)
+					slog.WarnContext(ctx, "movies: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
 		}(ctx, movieLibraries)
@@ -406,7 +406,7 @@ func listMovies(svc Service, grabStore GrabChecker) http.HandlerFunc {
 			// No filters — total comes from the DB.
 			tc, err := svc.CountMovies(r.Context())
 			if err != nil {
-				slog.Warn("failed to count movies", "err", err)
+				slog.WarnContext(r.Context(), "failed to count movies", "error", err)
 				tc = len(movies)
 			}
 			totalCount = tc

--- a/internal/music/handlers.go
+++ b/internal/music/handlers.go
@@ -214,7 +214,7 @@ func handleRefreshAllArtists(svc Service) http.HandlerFunc {
 		go func(ctx context.Context, artistIDs []string) {
 			for _, id := range artistIDs {
 				if _, err := svc.RefreshArtistAlbums(ctx, id); err != nil {
-					slog.Warn("music: bulk refresh failed", "artist_id", id, "error", err)
+					slog.WarnContext(ctx, "music: bulk refresh failed", "artist_id", id, "error", err)
 				}
 			}
 		}(ctx, ids)
@@ -253,7 +253,7 @@ func handleRescanAllArtistLibraries(
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
-					slog.Warn("music: bulk rescan failed", "library_id", lib.ID, "error", err)
+					slog.WarnContext(ctx, "music: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
 		}(ctx, musicLibraries)

--- a/internal/qualityprofiles/handlers.go
+++ b/internal/qualityprofiles/handlers.go
@@ -69,7 +69,7 @@ func (h *qpHandler) create(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("quality profile created", "id", qp.ID, "name", qp.Name)
+	h.logger.InfoContext(r.Context(), "quality profile created", "id", qp.ID, "name", qp.Name)
 	writeJSON(w, http.StatusCreated, qp)
 }
 
@@ -89,7 +89,7 @@ func (h *qpHandler) update(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("quality profile updated", "id", qp.ID)
+	h.logger.InfoContext(r.Context(), "quality profile updated", "id", qp.ID)
 	writeJSON(w, http.StatusOK, qp)
 }
 
@@ -103,7 +103,7 @@ func (h *qpHandler) delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("quality profile deleted", "id", id)
+	h.logger.InfoContext(r.Context(), "quality profile deleted", "id", id)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -146,7 +146,7 @@ func (h *qpHandler) setFormatScores(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Info("format scores updated", "profile_id", id, "count", len(items))
+	h.logger.InfoContext(r.Context(), "format scores updated", "profile_id", id, "count", len(items))
 	writeJSON(w, http.StatusOK, map[string]any{"data": items})
 }
 

--- a/internal/requests/service.go
+++ b/internal/requests/service.go
@@ -304,7 +304,6 @@ func (s *Service) Approve(ctx context.Context, id, qualityProfileID, libraryID, 
 		fulfilledID, err = s.fulfiller.FulfillSeries(ctx, req.TMDBID, qualityProfileID, libraryID)
 	}
 	if err != nil {
-		s.logger.Warn("requests: fulfillment failed", "id", id, "tmdb", req.TMDBID, "err", err)
 		_ = s.store.MarkFailed(ctx, id, err.Error())
 		return Request{}, fmt.Errorf("requests: fulfillment failed: %w", err)
 	}

--- a/internal/rss/sources_handlers.go
+++ b/internal/rss/sources_handlers.go
@@ -116,7 +116,7 @@ func (s *SourcesService) handleCreateSource(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusConflict, "name_exists", "source name already exists")
 			return
 		}
-		s.logger.Error("create source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "create source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to create source")
 		return
 	}
@@ -139,7 +139,7 @@ func (s *SourcesService) handleGetSource(w http.ResponseWriter, r *http.Request)
 			writeError(w, http.StatusNotFound, "not_found", "source not found")
 			return
 		}
-		s.logger.Error("get source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "get source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get source")
 		return
 	}
@@ -152,7 +152,7 @@ func (s *SourcesService) handleGetSource(w http.ResponseWriter, r *http.Request)
 func (s *SourcesService) handleListSources(w http.ResponseWriter, r *http.Request) {
 	sources, err := s.ListSources(r.Context())
 	if err != nil {
-		s.logger.Error("list sources failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "list sources failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to list sources")
 		return
 	}
@@ -223,7 +223,7 @@ func (s *SourcesService) handleUpdateSource(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusConflict, "name_exists", "source name already exists")
 			return
 		}
-		s.logger.Error("update source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "update source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to update source")
 		return
 	}
@@ -260,7 +260,7 @@ func (s *SourcesService) handlePatchSource(w http.ResponseWriter, r *http.Reques
 			writeError(w, http.StatusNotFound, "not_found", "source not found")
 			return
 		}
-		s.logger.Error("get source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "get source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get source")
 		return
 	}
@@ -296,7 +296,7 @@ func (s *SourcesService) handlePatchSource(w http.ResponseWriter, r *http.Reques
 
 	source, err := s.UpdateSource(r.Context(), id, name, typ, enabled, config)
 	if err != nil {
-		s.logger.Error("patch source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "patch source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to patch source")
 		return
 	}
@@ -318,7 +318,7 @@ func (s *SourcesService) handleDeleteSource(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusNotFound, "not_found", "source not found")
 			return
 		}
-		s.logger.Error("delete source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "delete source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to delete source")
 		return
 	}
@@ -341,7 +341,7 @@ func (s *SourcesService) handleTestSource(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusNotFound, "not_found", "source not found")
 			return
 		}
-		s.logger.Error("get source failed", "err", err)
+		s.logger.ErrorContext(r.Context(), "get source failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "server_error", "failed to get source")
 		return
 	}

--- a/internal/scanner/music_scanner.go
+++ b/internal/scanner/music_scanner.go
@@ -240,7 +240,7 @@ func pickExactArtistLookup(name string, candidates []*music.ArtistLookupResult) 
 func (s *MusicScanner) scanArtistFolder(ctx context.Context, scanID string, result *ScanResult, artist *music.Artist, folderPath string) {
 	albums, err := s.musicSvc.ListAlbumsByArtist(ctx, artist.ID)
 	if err != nil {
-		s.logger.Warn("music: list albums failed", "artist", artist.ID, "err", err)
+		s.logger.Warn("music: list albums failed", "artist", artist.ID, "error", err)
 		s.mu.Lock()
 		result.Errors = append(result.Errors, fmt.Sprintf("list albums %q: %v", artist.Name, err))
 		s.mu.Unlock()
@@ -256,7 +256,7 @@ func (s *MusicScanner) scanArtistFolder(ctx context.Context, scanID string, resu
 
 	files, walkErr := walkAudioFolder(folderPath)
 	if walkErr != nil {
-		s.logger.Warn("music: error walking artist folder", "path", folderPath, "err", walkErr)
+		s.logger.Warn("music: error walking artist folder", "path", folderPath, "error", walkErr)
 	}
 
 	s.mu.Lock()
@@ -266,7 +266,7 @@ func (s *MusicScanner) scanArtistFolder(ctx context.Context, scanID string, resu
 	for _, f := range files {
 		tags, err := music.ReadAudioTags(f.Path)
 		if err != nil {
-			s.logger.Debug("music: failed to read tags", "path", f.Path, "err", err)
+			s.logger.Debug("music: failed to read tags", "path", f.Path, "error", err)
 			s.addMusicUnmatched(scanID, result, f.Path, f.Size, artist.Name, "", "")
 			continue
 		}
@@ -285,7 +285,7 @@ func (s *MusicScanner) scanArtistFolder(ctx context.Context, scanID string, resu
 		if !ok {
 			full, gerr := s.musicSvc.GetAlbum(ctx, album.ID)
 			if gerr != nil || full == nil {
-				s.logger.Warn("music: get album failed", "album", album.ID, "err", gerr)
+				s.logger.Warn("music: get album failed", "album", album.ID, "error", gerr)
 				tracks = nil
 			} else {
 				tracks = full.Tracks
@@ -304,7 +304,7 @@ func (s *MusicScanner) scanArtistFolder(ctx context.Context, scanID string, resu
 		s.mu.Unlock()
 
 		if err := s.importTrackFile(ctx, artist, album, track, f.Path, f.Size, tags); err != nil {
-			s.logger.Warn("music: failed to import track file", "path", f.Path, "err", err)
+			s.logger.Warn("music: failed to import track file", "path", f.Path, "error", err)
 			s.mu.Lock()
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", f.Path, err))
 			s.mu.Unlock()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -239,7 +239,7 @@ func (s *Scanner) runScan(ctx context.Context, scanID string, libraryPath string
 
 	for _, sf := range scanned {
 		if err := s.processFile(ctx, scanID, sf, result.LibraryID); err != nil {
-			s.logger.Warn("failed to process file", "path", sf.Path, "err", err)
+			s.logger.Warn("failed to process file", "path", sf.Path, "error", err)
 			s.mu.Lock()
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", sf.Path, err))
 			s.mu.Unlock()
@@ -904,7 +904,7 @@ func (s *Scanner) RescanMovie(ctx context.Context, movieID, libraryPath string) 
 			TMDBID: movie.TMDBID,
 			IMDBID: movie.IMDBID,
 		}, movie.LibraryID, movie.QualityProfileID); err != nil {
-			s.logger.Warn("rescan: failed to import", "movie", movie.Title, "path", sf.Path, "err", err)
+			s.logger.Warn("rescan: failed to import", "movie", movie.Title, "path", sf.Path, "error", err)
 			continue
 		}
 

--- a/internal/scanner/series_scanner.go
+++ b/internal/scanner/series_scanner.go
@@ -159,7 +159,7 @@ func (s *SeriesScanner) runSeriesScan(ctx context.Context, scanID, libraryID, ro
 
 		tmdbResults, err := s.seriesSvc.SearchTMDB(ctx, title)
 		if err != nil {
-			s.logger.Warn("TMDB search failed for show folder", "title", title, "err", err)
+			s.logger.Warn("TMDB search failed for show folder", "title", title, "error", err)
 			continue
 		}
 
@@ -185,7 +185,7 @@ func (s *SeriesScanner) runSeriesScan(ctx context.Context, scanID, libraryID, ro
 			if strings.Contains(err.Error(), "UNIQUE") || strings.Contains(err.Error(), "unique") || strings.Contains(err.Error(), "already exists") {
 				s.logger.Debug("series already exists, skipping", "tmdbId", tmdbID)
 			} else {
-				s.logger.Warn("failed to add series from TMDB", "tmdbId", tmdbID, "title", title, "err", err)
+				s.logger.Warn("failed to add series from TMDB", "tmdbId", tmdbID, "title", title, "error", err)
 				s.mu.Lock()
 				result.Errors = append(result.Errors, fmt.Sprintf("add series %q: %v", title, err))
 				s.mu.Unlock()
@@ -229,7 +229,7 @@ func (s *SeriesScanner) runSeriesScan(ctx context.Context, scanID, libraryID, ro
 		// Walk this show folder for video files
 		showFiles, walkErr := walkSeriesFolder(sf.Path)
 		if walkErr != nil {
-			s.logger.Warn("error walking show folder", "path", sf.Path, "err", walkErr)
+			s.logger.Warn("error walking show folder", "path", sf.Path, "error", walkErr)
 			continue
 		}
 
@@ -239,7 +239,7 @@ func (s *SeriesScanner) runSeriesScan(ctx context.Context, scanID, libraryID, ro
 
 		for _, ef := range showFiles {
 			if err := s.processEpisodeFileForSeries(ctx, scanID, matched, ef.Path, ef.Size); err != nil {
-				s.logger.Warn("failed to process episode file", "path", ef.Path, "err", err)
+				s.logger.Warn("failed to process episode file", "path", ef.Path, "error", err)
 				s.mu.Lock()
 				result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", ef.Path, err))
 				s.mu.Unlock()
@@ -469,7 +469,7 @@ func (s *SeriesScanner) importEpisodeFile(ctx context.Context, ep *series.Episod
 	ep.HasFile = true
 	ep.UpdatedAt = now
 	if err := s.seriesSvc.UpdateEpisode(ctx, ep); err != nil {
-		s.logger.Warn("failed to update episode has_file", "episodeId", ep.ID, "err", err)
+		s.logger.Warn("failed to update episode has_file", "episodeId", ep.ID, "error", err)
 	}
 
 	s.logger.Info("imported episode file",
@@ -659,7 +659,7 @@ func (s *SeriesScanner) RescanSeries(ctx context.Context, seriesID, libraryPath 
 
 	for _, ef := range files {
 		if err := s.processEpisodeFileForSeries(ctx, scanID, sr, ef.Path, ef.Size); err != nil {
-			s.logger.Warn("rescan: failed to process episode file", "path", ef.Path, "err", err)
+			s.logger.Warn("rescan: failed to process episode file", "path", ef.Path, "error", err)
 		}
 	}
 

--- a/internal/scheduler/library_scan.go
+++ b/internal/scheduler/library_scan.go
@@ -128,7 +128,7 @@ func (ps *PeriodicScanner) runScan(ctx context.Context) {
 
 	libs, err := ps.libProvider.ListAll(ctx)
 	if err != nil {
-		ps.logger.Error("periodic scan: failed to list libraries", "err", err)
+		ps.logger.Error("periodic scan: failed to list libraries", "error", err)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (ps *PeriodicScanner) runScan(ctx context.Context) {
 		}
 		ps.logger.Info("periodic scan: scanning library", "id", lib.ID, "path", lib.Path)
 		if _, err := ps.seriesScanner.StartSeriesScan(ctx, lib.ID, lib.Path); err != nil {
-			ps.logger.Error("periodic scan: failed", "library", lib.ID, "err", err)
+			ps.logger.Error("periodic scan: failed", "library", lib.ID, "error", err)
 		}
 	}
 }

--- a/internal/scheduler/rolling_search.go
+++ b/internal/scheduler/rolling_search.go
@@ -192,11 +192,11 @@ func (rs *RollingSearcher) runOnce(ctx context.Context) {
 	// the other queue. The target split remains a preference, not a hard cap.
 	movieCandidates, err := rs.store.GetCandidates(ctx, "movie", batchSize, cfg.MinResearchDays)
 	if err != nil {
-		rs.logger.Error("get movie candidates", "err", err)
+		rs.logger.Error("get movie candidates", "error", err)
 	}
 	epCandidates, err := rs.store.GetCandidates(ctx, "episode", batchSize, cfg.MinResearchDays)
 	if err != nil {
-		rs.logger.Error("get episode candidates", "err", err)
+		rs.logger.Error("get episode candidates", "error", err)
 	}
 
 	candidates := make([]SearchCandidate, 0, batchSize)
@@ -257,11 +257,11 @@ func (rs *RollingSearcher) searchCandidate(ctx context.Context, c SearchCandidat
 	if g != nil {
 		if err := g.Grab(ctx, c); err != nil {
 			rs.logger.Warn("search-and-grab failed", "type", c.MediaType,
-				"id", c.MediaID, "title", c.Title, "err", err)
+				"id", c.MediaID, "title", c.Title, "error", err)
 		}
 		// Record quota and last-searched regardless of grab outcome.
 		if err := rs.store.RecordSearch(ctx, c.MediaType, c.MediaID); err != nil {
-			rs.logger.Warn("record search state", "err", err)
+			rs.logger.Warn("record search state", "error", err)
 		}
 		return
 	}
@@ -293,7 +293,7 @@ func (rs *RollingSearcher) searchCandidate(ctx context.Context, c SearchCandidat
 	// Fan out across all enabled indexers, respecting quotas.
 	defs, err := rs.indexerSvc.List(ctx)
 	if err != nil {
-		rs.logger.Warn("list indexers", "err", err)
+		rs.logger.Warn("list indexers", "error", err)
 		return
 	}
 
@@ -318,6 +318,6 @@ func (rs *RollingSearcher) searchCandidate(ctx context.Context, c SearchCandidat
 
 	// Persist last-searched timestamp.
 	if err := rs.store.RecordSearch(ctx, c.MediaType, c.MediaID); err != nil {
-		rs.logger.Warn("record search state", "err", err)
+		rs.logger.Warn("record search state", "error", err)
 	}
 }

--- a/internal/series/handlers.go
+++ b/internal/series/handlers.go
@@ -182,7 +182,7 @@ func refreshAllSeries(svc Service) http.HandlerFunc {
 		go func(ctx context.Context, seriesIDs []string) {
 			for _, id := range seriesIDs {
 				if err := svc.RefreshSeries(ctx, id); err != nil {
-					slog.Warn("series: bulk refresh failed", "series_id", id, "error", err)
+					slog.WarnContext(ctx, "series: bulk refresh failed", "series_id", id, "error", err)
 				}
 			}
 		}(ctx, ids)
@@ -223,7 +223,7 @@ func rescanAllSeriesLibraries(
 			for _, lib := range libs {
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
-					slog.Warn("series: bulk rescan failed", "library_id", lib.ID, "error", err)
+					slog.WarnContext(ctx, "series: bulk rescan failed", "library_id", lib.ID, "error", err)
 				}
 			}
 		}(ctx, seriesLibraries)
@@ -285,7 +285,7 @@ func organizeSeries(
 		go func(ctx context.Context, ids []string, libs map[string]struct{}) {
 			for _, id := range ids {
 				if err := svc.RefreshSeries(ctx, id); err != nil {
-					slog.Warn("series: organize refresh failed", "series_id", id, "error", err)
+					slog.WarnContext(ctx, "series: organize refresh failed", "series_id", id, "error", err)
 				}
 			}
 
@@ -294,7 +294,7 @@ func organizeSeries(
 			}
 			allLibraries, err := store.List(ctx)
 			if err != nil {
-				slog.Warn("series: organize list libraries failed", "error", err)
+				slog.WarnContext(ctx, "series: organize list libraries failed", "error", err)
 				return
 			}
 			for _, lib := range allLibraries {
@@ -303,7 +303,7 @@ func organizeSeries(
 				}
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
-					slog.Warn("series: organize scan failed", "library_id", lib.ID, "error", err)
+					slog.WarnContext(ctx, "series: organize scan failed", "library_id", lib.ID, "error", err)
 				}
 			}
 		}(ctx, append([]string(nil), seriesIDs...), libraryIDSet)
@@ -342,7 +342,7 @@ func organizeSingleSeries(
 		ctx := context.WithoutCancel(r.Context())
 		go func(ctx context.Context, seriesID, libID string) {
 			if err := svc.RefreshSeries(ctx, seriesID); err != nil {
-				slog.Warn("series: organize refresh failed", "series_id", seriesID, "error", err)
+				slog.WarnContext(ctx, "series: organize refresh failed", "series_id", seriesID, "error", err)
 				return
 			}
 			if store == nil || scanner == nil || libID == "" {
@@ -350,7 +350,7 @@ func organizeSingleSeries(
 			}
 			allLibraries, err := store.List(ctx)
 			if err != nil {
-				slog.Warn("series: organize list libraries failed", "error", err)
+				slog.WarnContext(ctx, "series: organize list libraries failed", "error", err)
 				return
 			}
 			for _, lib := range allLibraries {
@@ -359,7 +359,7 @@ func organizeSingleSeries(
 				}
 				lib := lib
 				if err := scanner.ScanLibrary(ctx, &lib); err != nil {
-					slog.Warn("series: organize scan failed", "library_id", lib.ID, "error", err)
+					slog.WarnContext(ctx, "series: organize scan failed", "library_id", lib.ID, "error", err)
 				}
 				break
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1249,7 +1249,7 @@ func (s *Server) recoverer(next http.Handler) http.Handler {
 				}
 				stack := debug.Stack()
 				s.logger.Error("panic",
-					"err", fmt.Sprintf("%v", rv),
+					"error", fmt.Sprintf("%v", rv),
 					"path", r.URL.Path,
 					"method", r.Method,
 					"request_id", middleware.GetReqID(r.Context()),


### PR DESCRIPTION
Fixes #90

## What changed
- injected `trace_id` and `span_id` into slog output and captured system logs when a span is active, while preserving the existing PII-redacting logger pipeline
- switched high-value request-scoped and service-scoped logging paths to `InfoContext`/`WarnContext`/`ErrorContext` so HTTP and workflow-related logs carry trace context
- removed duplicated log-and-return handling in the identified request/import/startup paths and standardized structured error attributes on `"error"`
- demoted noisy per-sweep download monitor and stall-handler logs from info to debug

## Validation
- `go build ./...`
- `go test ./internal/kernel/logging/... ./internal/auditlog/... ./internal/downloads/...`
- `golangci-lint run --new-from-rev=origin/main ./...`