### PR TITLE
fix(helm): align Loom runtime UID/GID defaults

### DIFF
--- a/deploy/helm/loom/values.yaml
+++ b/deploy/helm/loom/values.yaml
@@ -22,12 +22,14 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  fsGroup: 65534
+  runAsUser: 999
+  runAsGroup: 1001
+  fsGroup: 1001
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 65534
-  runAsGroup: 65534
+  runAsUser: 999
+  runAsGroup: 1001
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   seccompProfile:


### PR DESCRIPTION
## Summary
- set container `securityContext.runAsUser` to `999` and `runAsGroup` to `1001`
- keep hardened container security defaults (`allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]`)
- align `podSecurityContext` defaults to `runAsUser: 999`, `runAsGroup: 1001`, and `fsGroup: 1001`

## Why
Container-level `securityContext` overrides pod-level values. The previous `65534` defaults caused Loom to run as distroless nonroot, which could not read existing `/config/loom.json` files owned by `999:1001` with restrictive permissions, causing startup failure and Helm upgrade rollback loops.

## Scope
- Helm chart defaults only (`deploy/helm/loom/values.yaml`)
- no Dockerfile `USER` changes