### PR TITLE
test: add unit tests for untested packages

### DIFF
--- a/internal/imports/decision_test.go
+++ b/internal/imports/decision_test.go
@@ -1,0 +1,54 @@
+package imports
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeSpec struct {
+	name      string
+	rejection *ImportRejection
+}
+
+func (s fakeSpec) Name() string { return s.name }
+func (s fakeSpec) IsSatisfiedBy(context.Context, *ImportCandidate) *ImportRejection {
+	return s.rejection
+}
+
+func TestDecisionMakerEvaluateCollectsRejections(t *testing.T) {
+	t.Parallel()
+	dm := NewDecisionMaker(
+		fakeSpec{name: "ok-1"},
+		fakeSpec{name: "reject-1", rejection: &ImportRejection{
+			Reason:  RejectionSample,
+			Message: "sample file",
+		}},
+		fakeSpec{name: "reject-2", rejection: &ImportRejection{
+			Reason:  RejectionDangerousFile,
+			Message: "dangerous extension",
+		}},
+	)
+
+	eval := dm.Evaluate(context.Background(), &ImportCandidate{SourcePath: "/downloads/file.mkv"})
+	if eval.Approved() {
+		t.Fatal("expected evaluation to be rejected")
+	}
+	if len(eval.Rejections) != 2 {
+		t.Fatalf("expected 2 rejections, got %d", len(eval.Rejections))
+	}
+	if eval.Rejections[0].Reason != RejectionSample || eval.Rejections[1].Reason != RejectionDangerousFile {
+		t.Fatalf("unexpected rejections: %+v", eval.Rejections)
+	}
+}
+
+func TestDecisionMakerEvaluateApproved(t *testing.T) {
+	t.Parallel()
+	dm := NewDecisionMaker(fakeSpec{name: "ok-1"}, fakeSpec{name: "ok-2"})
+	eval := dm.Evaluate(context.Background(), &ImportCandidate{SourcePath: "/downloads/file.mkv"})
+	if !eval.Approved() {
+		t.Fatalf("expected approval, got rejections: %+v", eval.Rejections)
+	}
+	if len(eval.Rejections) != 0 {
+		t.Fatalf("expected 0 rejections, got %d", len(eval.Rejections))
+	}
+}

--- a/internal/imports/pipeline_test.go
+++ b/internal/imports/pipeline_test.go
@@ -1,0 +1,133 @@
+package imports
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/ebenderooock/loom/internal/downloads"
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
+	"github.com/ebenderooock/loom/internal/movies"
+	"github.com/ebenderooock/loom/internal/series"
+)
+
+type moviesSvcStub struct{ movies.Service }
+type seriesSvcStub struct{ series.Service }
+
+func newDownloadsSvcForPipelineTest(t *testing.T) *downloads.Service {
+	t.Helper()
+	svc, err := downloads.NewService(downloads.ServiceOptions{
+		Repository: resolvePathFakeRepo{},
+		Registry:   downloads.NewRegistry(),
+		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("downloads.NewService: %v", err)
+	}
+	return svc
+}
+
+func basePipelineOptions(t *testing.T) PipelineOptions {
+	t.Helper()
+	db := setupTestDB(t)
+	return PipelineOptions{
+		DB:          db,
+		Bus:         eventbus.NewInProc(),
+		DownloadSvc: newDownloadsSvcForPipelineTest(t),
+		MoviesSvc:   &moviesSvcStub{},
+		SeriesSvc:   &seriesSvcStub{},
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestNewPipeline_ValidatesRequiredDependencies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mut  func(*PipelineOptions)
+		want string
+	}{
+		{"missing db", func(o *PipelineOptions) { o.DB = nil }, "db required"},
+		{"missing bus", func(o *PipelineOptions) { o.Bus = nil }, "event bus required"},
+		{"missing downloads", func(o *PipelineOptions) { o.DownloadSvc = nil }, "download service required"},
+		{"missing movies", func(o *PipelineOptions) { o.MoviesSvc = nil }, "movies service required"},
+		{"missing series", func(o *PipelineOptions) { o.SeriesSvc = nil }, "series service required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := basePipelineOptions(t)
+			tt.mut(&opts)
+			if _, err := NewPipeline(opts); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestNewPipeline_DefaultImportMode(t *testing.T) {
+	t.Parallel()
+	opts := basePipelineOptions(t)
+	opts.ImportMode = ""
+	p, err := NewPipeline(opts)
+	if err != nil {
+		t.Fatalf("NewPipeline: %v", err)
+	}
+	if p.importMode != ImportModeMove {
+		t.Fatalf("default import mode = %q, want %q", p.importMode, ImportModeMove)
+	}
+}
+
+func TestPipelineUtilityHelpers(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/downloads/infohash:abc123", true},
+		{" /downloads/infohash:abc123 ", true},
+		{"/downloads/normal/path", false},
+	}
+	for _, tt := range tests {
+		if got := isUnresolvedContentPath(tt.path); got != tt.want {
+			t.Fatalf("isUnresolvedContentPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+
+	if got := metadataString(`{"content_path":"/a/b","n":1}`, "content_path"); got != "/a/b" {
+		t.Fatalf("metadataString(content_path) = %q", got)
+	}
+	if got := metadataString(`{"content_path":123}`, "content_path"); got != "" {
+		t.Fatalf("metadataString should return empty for non-string value, got %q", got)
+	}
+	if got := metadataString("not-json", "content_path"); got != "" {
+		t.Fatalf("metadataString should return empty for invalid json, got %q", got)
+	}
+}
+
+func TestProcessImport_PathMissingRecordsFailure(t *testing.T) {
+	t.Parallel()
+	opts := basePipelineOptions(t)
+	p, err := NewPipeline(opts)
+	if err != nil {
+		t.Fatalf("NewPipeline: %v", err)
+	}
+
+	missingPath := "/tmp/path-that-does-not-exist"
+	err = p.processImport(context.Background(), &downloads.DownloadCompletedEvent{Title: "Missing"}, missingPath)
+	if err == nil || !strings.Contains(err.Error(), "download path not found") {
+		t.Fatalf("expected missing path error, got %v", err)
+	}
+
+	var status string
+	rowErr := opts.DB.QueryRow(`SELECT status FROM import_history LIMIT 1`).Scan(&status)
+	if rowErr != nil {
+		t.Fatalf("expected failure row in import_history: %v", rowErr)
+	}
+	if status != string(StatusFailed) {
+		t.Fatalf("recorded status = %q, want %q", status, StatusFailed)
+	}
+}

--- a/internal/movies/service_test.go
+++ b/internal/movies/service_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/ebenderooock/loom/internal/kernel/eventbus"
 	"github.com/ebenderooock/loom/internal/metadata"
 )
 
@@ -20,6 +22,7 @@ type mockRepo struct {
 	addMovieErr     error
 	updateMovieErr  error
 	deleteMovieErr  error
+	statusUpdates   int
 }
 
 func newMockRepo() *mockRepo {
@@ -55,6 +58,7 @@ func (r *mockRepo) UpdateMovieStatus(_ context.Context, id string, status MovieS
 		return errors.New("not found")
 	}
 	m.Status = status
+	r.statusUpdates++
 	return nil
 }
 func (r *mockRepo) DeleteMovie(_ context.Context, id string) error {
@@ -793,5 +797,111 @@ func TestUpdateQualityProfile_Validation(t *testing.T) {
 	}
 	if err := svc.UpdateQualityProfile(ctx, &QualityProfile{Name: "x"}); err == nil {
 		t.Fatal("expected error for empty ID")
+	}
+}
+
+func TestAddMovieByTMDBID_AppliesProfileAndSlug(t *testing.T) {
+	t.Parallel()
+	repo := newMockRepo()
+	meta := &mockMetadata{
+		tmdbResult: &metadata.MovieMetadata{
+			Title:       "The Matrix Reloaded",
+			Year:        2003,
+			ReleaseDate: "2003-05-15",
+		},
+	}
+	svc := NewService(repo, WithMetadata(meta))
+
+	got, err := svc.AddMovieByTMDBID(context.Background(), "603", "qp-1080p", "lib-a", true)
+	if err != nil {
+		t.Fatalf("AddMovieByTMDBID: %v", err)
+	}
+	if got.ID != "the-matrix-reloaded-2003" {
+		t.Fatalf("slug/id = %q", got.ID)
+	}
+	if got.QualityProfileID != "qp-1080p" || got.LibraryID != "lib-a" {
+		t.Fatalf("quality profile/library not applied: %+v", got)
+	}
+	if got.Status != MovieStatusMissing {
+		t.Fatalf("status = %q, want %q", got.Status, MovieStatusMissing)
+	}
+	if got.MonitoringStatus != MonitoringStatusMonitored {
+		t.Fatalf("monitoring = %q, want %q", got.MonitoringStatus, MonitoringStatusMonitored)
+	}
+}
+
+func TestAddMovieByTMDBID_UnreleasedAndUnmonitored(t *testing.T) {
+	t.Parallel()
+	repo := newMockRepo()
+	future := time.Now().Add(48 * time.Hour).Format("2006-01-02")
+	meta := &mockMetadata{
+		tmdbResult: &metadata.MovieMetadata{
+			Title:       "Future Film",
+			Year:        time.Now().Year() + 1,
+			ReleaseDate: future,
+		},
+	}
+	svc := NewService(repo, WithMetadata(meta))
+
+	got, err := svc.AddMovieByTMDBID(context.Background(), "999", "qp", "lib", false)
+	if err != nil {
+		t.Fatalf("AddMovieByTMDBID: %v", err)
+	}
+	if got.Status != MovieStatusUnreleased {
+		t.Fatalf("status = %q, want %q", got.Status, MovieStatusUnreleased)
+	}
+	if got.MonitoringStatus != MonitoringStatusUnmonitored {
+		t.Fatalf("monitoring = %q, want %q", got.MonitoringStatus, MonitoringStatusUnmonitored)
+	}
+}
+
+func TestSetMovieStatus_NoOpSkipsUpdate(t *testing.T) {
+	t.Parallel()
+	repo := newMockRepo()
+	repo.movies["m1"] = &Movie{ID: "m1", Title: "Movie", Status: MovieStatusMissing}
+	svc := NewService(repo)
+
+	if err := svc.SetMovieStatus(context.Background(), "m1", MovieStatusMissing); err != nil {
+		t.Fatalf("SetMovieStatus no-op: %v", err)
+	}
+	if repo.statusUpdates != 0 {
+		t.Fatalf("expected no repo status update call for no-op, got %d", repo.statusUpdates)
+	}
+}
+
+func TestSetMovieStatus_TransitionPublishesEvent(t *testing.T) {
+	t.Parallel()
+	repo := newMockRepo()
+	repo.movies["m1"] = &Movie{ID: "m1", Title: "Movie", Status: MovieStatusMissing}
+	bus := eventbus.NewInProc()
+	defer bus.Close(2 * time.Second)
+	svc := NewService(repo, WithEventBus(bus))
+
+	events := make(chan *MovieStatusChangedEvent, 1)
+	unsub := bus.Subscribe(TopicMovieStatusChanged, func(_ context.Context, ev eventbus.Event) error {
+		if e, ok := ev.(*MovieStatusChangedEvent); ok {
+			events <- e
+		}
+		return nil
+	})
+	defer unsub()
+
+	if err := svc.SetMovieStatus(context.Background(), "m1", MovieStatusAvailableRightQuality); err != nil {
+		t.Fatalf("SetMovieStatus transition: %v", err)
+	}
+	if repo.movies["m1"].Status != MovieStatusAvailableRightQuality {
+		t.Fatalf("repo status not updated: %+v", repo.movies["m1"])
+	}
+	if repo.statusUpdates != 1 {
+		t.Fatalf("expected one repo status update call, got %d", repo.statusUpdates)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.MovieID != "m1" || ev.OldStatus != MovieStatusMissing || ev.NewStatus != MovieStatusAvailableRightQuality {
+			t.Fatalf("unexpected status event: %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for status event")
 	}
 }

--- a/internal/notifications/service_test.go
+++ b/internal/notifications/service_test.go
@@ -1,0 +1,206 @@
+package notifications
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openNotificationsTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file::memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+CREATE TABLE notification_connections (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	type TEXT NOT NULL,
+	enabled BOOLEAN DEFAULT true,
+	settings TEXT DEFAULT '{}',
+	on_grab BOOLEAN DEFAULT false,
+	on_download BOOLEAN DEFAULT false,
+	on_upgrade BOOLEAN DEFAULT false,
+	on_rename BOOLEAN DEFAULT false,
+	on_delete BOOLEAN DEFAULT false,
+	on_health_issue BOOLEAN DEFAULT false,
+	on_application_update BOOLEAN DEFAULT false,
+	on_playback BOOLEAN DEFAULT false,
+	tags TEXT DEFAULT '[]',
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE TABLE notification_history (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	connection_id TEXT REFERENCES notification_connections(id) ON DELETE SET NULL,
+	event_type TEXT NOT NULL,
+	title TEXT NOT NULL,
+	message TEXT DEFAULT '',
+	success BOOLEAN DEFAULT true,
+	error_message TEXT DEFAULT '',
+	sent_at TEXT NOT NULL
+);`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	return db
+}
+
+func makeTestConnection(id, name string) *Connection {
+	return &Connection{
+		ID:      id,
+		Name:    name,
+		Type:    ConnectionTypeWebhook,
+		Enabled: true,
+		Settings: ConnectionSettings{
+			WebhookURL: "https://example.test/hook",
+		},
+		OnDownload: true,
+		Tags:       []string{"movies"},
+	}
+}
+
+func TestServiceConnectionCRUD(t *testing.T) {
+	t.Parallel()
+	db := openNotificationsTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	c := makeTestConnection("", "Primary")
+	if err := svc.CreateConnection(ctx, c); err != nil {
+		t.Fatalf("CreateConnection: %v", err)
+	}
+	if c.ID == "" {
+		t.Fatal("CreateConnection should generate ID when empty")
+	}
+
+	got, err := svc.GetConnection(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	if got.Name != "Primary" || got.Type != ConnectionTypeWebhook {
+		t.Fatalf("unexpected connection: %+v", got)
+	}
+	if got.Settings.WebhookURL != "https://example.test/hook" {
+		t.Fatalf("settings not persisted: %+v", got.Settings)
+	}
+
+	got.Name = "Primary Updated"
+	got.Enabled = false
+	got.OnPlayback = true
+	got.Tags = []string{"movies", "manual"}
+	if err := svc.UpdateConnection(ctx, got); err != nil {
+		t.Fatalf("UpdateConnection: %v", err)
+	}
+
+	updated, err := svc.GetConnection(ctx, got.ID)
+	if err != nil {
+		t.Fatalf("GetConnection after update: %v", err)
+	}
+	if updated.Name != "Primary Updated" || updated.Enabled {
+		t.Fatalf("update not applied: %+v", updated)
+	}
+	if !updated.OnPlayback || len(updated.Tags) != 2 {
+		t.Fatalf("flags/tags not updated: %+v", updated)
+	}
+
+	if err := svc.DeleteConnection(ctx, got.ID); err != nil {
+		t.Fatalf("DeleteConnection: %v", err)
+	}
+	if _, err := svc.GetConnection(ctx, got.ID); err == nil {
+		t.Fatal("expected not found after delete")
+	}
+}
+
+func TestServiceListConnectionsAndErrors(t *testing.T) {
+	t.Parallel()
+	db := openNotificationsTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		id   string
+		name string
+	}{
+		{"b", "Beta"},
+		{"a", "Alpha"},
+	} {
+		c := makeTestConnection(tc.id, tc.name)
+		if err := svc.CreateConnection(ctx, c); err != nil {
+			t.Fatalf("CreateConnection(%s): %v", tc.name, err)
+		}
+	}
+
+	list, err := svc.ListConnections(ctx)
+	if err != nil {
+		t.Fatalf("ListConnections: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(list))
+	}
+	if list[0].Name != "Alpha" || list[1].Name != "Beta" {
+		t.Fatalf("connections should be sorted by name: %+v", list)
+	}
+
+	if _, err := svc.GetConnection(ctx, "missing"); err == nil {
+		t.Fatal("expected GetConnection error for missing id")
+	}
+	if err := svc.UpdateConnection(ctx, makeTestConnection("missing", "x")); err == nil {
+		t.Fatal("expected UpdateConnection error for missing id")
+	}
+	if err := svc.DeleteConnection(ctx, "missing"); err == nil {
+		t.Fatal("expected DeleteConnection error for missing id")
+	}
+}
+
+func TestServiceLogHistoryAndListHistory(t *testing.T) {
+	t.Parallel()
+	db := openNotificationsTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	c := makeTestConnection("c1", "History")
+	if err := svc.CreateConnection(ctx, c); err != nil {
+		t.Fatalf("CreateConnection: %v", err)
+	}
+
+	for i := 0; i < 60; i++ {
+		success := i%2 == 0
+		errMsg := ""
+		if !success {
+			errMsg = "failed"
+		}
+		if err := svc.LogHistory(ctx, &c.ID, string(EventOnDownload), "Download", "Completed", success, errMsg); err != nil {
+			t.Fatalf("LogHistory(%d): %v", i, err)
+		}
+	}
+
+	defaultLimited, err := svc.ListHistory(ctx, 0)
+	if err != nil {
+		t.Fatalf("ListHistory default limit: %v", err)
+	}
+	if len(defaultLimited) != 50 {
+		t.Fatalf("expected default limit 50, got %d", len(defaultLimited))
+	}
+
+	limited, err := svc.ListHistory(ctx, 5)
+	if err != nil {
+		t.Fatalf("ListHistory(5): %v", err)
+	}
+	if len(limited) != 5 {
+		t.Fatalf("expected 5 history entries, got %d", len(limited))
+	}
+	for _, h := range limited {
+		if h.ConnectionID == nil || *h.ConnectionID != c.ID {
+			t.Fatalf("unexpected connection_id in history: %+v", h)
+		}
+		if h.EventType != string(EventOnDownload) {
+			t.Fatalf("unexpected event type: %+v", h)
+		}
+	}
+}

--- a/internal/notifications/templates_test.go
+++ b/internal/notifications/templates_test.go
@@ -1,0 +1,77 @@
+package notifications
+
+import "testing"
+
+func TestDefaultTemplateFallback(t *testing.T) {
+	t.Parallel()
+	got := DefaultTemplate(EventType("unknown_event"))
+	if got != "{{.EventType}}: {{.Title}}" {
+		t.Fatalf("unexpected fallback template: %q", got)
+	}
+}
+
+func TestRenderTemplate_DefaultAndOverride(t *testing.T) {
+	t.Parallel()
+	data := map[string]any{
+		"title":   "Inception",
+		"year":    "2010",
+		"quality": "1080p",
+		"indexer": "IndexerA",
+	}
+
+	rendered, err := RenderTemplate("", EventOnGrab, data)
+	if err != nil {
+		t.Fatalf("RenderTemplate default: %v", err)
+	}
+	wantDefault := "Grabbed: Inception (2010) — 1080p from IndexerA"
+	if rendered != wantDefault {
+		t.Fatalf("default rendered = %q, want %q", rendered, wantDefault)
+	}
+
+	custom := "{{.Title}}/{{.MediaType}}/{{.EventType}}"
+	rendered, err = RenderTemplate(custom, EventOnDownload, map[string]any{
+		"title":      "Movie",
+		"media_type": "movie",
+	})
+	if err != nil {
+		t.Fatalf("RenderTemplate custom: %v", err)
+	}
+	if rendered != "Movie/movie/on_download" {
+		t.Fatalf("custom rendered = %q", rendered)
+	}
+}
+
+func TestRenderTemplate_InvalidTemplate(t *testing.T) {
+	t.Parallel()
+	if _, err := RenderTemplate("{{.Title", EventOnDownload, nil); err == nil {
+		t.Fatal("expected parse error for invalid template")
+	}
+}
+
+func TestAvailableVariables(t *testing.T) {
+	t.Parallel()
+	vars := AvailableVariables()
+	if len(vars) == 0 {
+		t.Fatal("expected template variables")
+	}
+
+	expected := map[string]bool{
+		"{{.Title}}":     false,
+		"{{.Year}}":      false,
+		"{{.Quality}}":   false,
+		"{{.Indexer}}":   false,
+		"{{.Size}}":      false,
+		"{{.EventType}}": false,
+		"{{.MediaType}}": false,
+	}
+	for _, v := range vars {
+		if _, ok := expected[v]; ok {
+			expected[v] = true
+		}
+	}
+	for k, seen := range expected {
+		if !seen {
+			t.Fatalf("missing variable %s in AvailableVariables", k)
+		}
+	}
+}

--- a/internal/organizer/organizer_test.go
+++ b/internal/organizer/organizer_test.go
@@ -1,0 +1,223 @@
+package organizer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ebenderooock/loom/internal/movies"
+)
+
+type organizerMoviesStub struct {
+	movie       *movies.Movie
+	files       []*movies.MovieFile
+	libraryPath string
+}
+
+func (s *organizerMoviesStub) GetMovie(_ context.Context, id string) (*movies.Movie, error) {
+	if s.movie == nil || s.movie.ID != id {
+		return nil, errors.New("not found")
+	}
+	return s.movie, nil
+}
+func (s *organizerMoviesStub) ListMovies(_ context.Context, _, _ int) ([]*movies.Movie, error) {
+	if s.movie == nil {
+		return nil, nil
+	}
+	return []*movies.Movie{s.movie}, nil
+}
+func (s *organizerMoviesStub) ListMovieFiles(_ context.Context, movieID string) ([]*movies.MovieFile, error) {
+	if s.movie == nil || s.movie.ID != movieID {
+		return nil, errors.New("not found")
+	}
+	return s.files, nil
+}
+func (s *organizerMoviesStub) GetLibraryPath(_ context.Context, libraryID string) (string, error) {
+	if s.movie == nil || s.movie.LibraryID != libraryID {
+		return "", errors.New("not found")
+	}
+	return s.libraryPath, nil
+}
+
+type organizerUpdaterStub struct {
+	updated []*movies.MovieFile
+}
+
+func (s *organizerUpdaterStub) UpdateMovieFile(_ context.Context, mf *movies.MovieFile) error {
+	s.updated = append(s.updated, mf)
+	return nil
+}
+
+type organizerConfigStub struct {
+	cfg *NamingConfig
+}
+
+func (s *organizerConfigStub) GetNamingConfig(context.Context) (*NamingConfig, error) {
+	return s.cfg, nil
+}
+func (s *organizerConfigStub) SaveNamingConfig(context.Context, *NamingConfig) error { return nil }
+
+func testOrganizerLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNamingFormatAndTargetPath(t *testing.T) {
+	t.Parallel()
+	m := &movies.Movie{
+		Title: "The Matrix: Reloaded",
+		Year:  2003,
+	}
+	f := &movies.MovieFile{
+		FilePath: "/tmp/The.Matrix.Reloaded.2003.1080p.BluRay.x264-GROUP.mkv",
+		Quality:  "Bluray-1080p",
+	}
+
+	tests := []struct {
+		name       string
+		cfg        *NamingConfig
+		wantFolder string
+		wantFile   string
+	}{
+		{
+			name:       "default format",
+			cfg:        DefaultNamingConfig(),
+			wantFolder: "The Matrix - Reloaded (2003)",
+			wantFile:   "The Matrix - Reloaded (2003) [Bluray-1080p]",
+		},
+		{
+			name: "clean title and source",
+			cfg: &NamingConfig{
+				MovieFolderFormat: "{Movie CleanTitle}",
+				MovieFileFormat:   "{Movie TitleThe} {Quality Source} {Quality Resolution}",
+				ColonReplacement:  "-",
+			},
+			wantFolder: "matrix reloaded",
+			wantFile:   "Matrix- Reloaded, The BluRay 1080p",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			folder := FormatFolderName(m, tt.cfg)
+			if folder != tt.wantFolder {
+				t.Fatalf("folder = %q, want %q", folder, tt.wantFolder)
+			}
+
+			name := FormatFileName(m, f, tt.cfg)
+			if name != tt.wantFile {
+				t.Fatalf("file = %q, want %q", name, tt.wantFile)
+			}
+
+			target := BuildTargetPath("/library", m, f, tt.cfg)
+			if !strings.HasSuffix(target, filepath.Join(tt.wantFolder, tt.wantFile+".mkv")) {
+				t.Fatalf("unexpected target path %q", target)
+			}
+		})
+	}
+}
+
+func TestOrganizeMovie_MoveMode(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "incoming")
+	library := filepath.Join(tmp, "library")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.MkdirAll(library, 0o755); err != nil {
+		t.Fatalf("mkdir library: %v", err)
+	}
+
+	src := filepath.Join(srcDir, "The.Matrix.1999.1080p.BluRay.mkv")
+	if err := os.WriteFile(src, []byte("video"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	mv := &movies.Movie{ID: "m1", Title: "The Matrix", Year: 1999, LibraryID: "lib1"}
+	mf := &movies.MovieFile{ID: "f1", MovieID: "m1", FilePath: src, Quality: "Bluray-1080p"}
+
+	mp := &organizerMoviesStub{movie: mv, files: []*movies.MovieFile{mf}, libraryPath: library}
+	up := &organizerUpdaterStub{}
+	cs := &organizerConfigStub{cfg: DefaultNamingConfig()}
+	org := New(mp, up, cs, testOrganizerLogger())
+
+	results, err := org.OrganizeMovie(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("OrganizeMovie: %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("unexpected organize result: %+v", results)
+	}
+
+	newPath := results[0].NewPath
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("expected destination file: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("source should be moved, stat err=%v", err)
+	}
+	if len(up.updated) != 1 || up.updated[0].FilePath != newPath {
+		t.Fatalf("movie file record not updated: %+v", up.updated)
+	}
+}
+
+func TestOrganizeMovie_HardlinkMode(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	srcDir := filepath.Join(tmp, "incoming")
+	library := filepath.Join(tmp, "library")
+	_ = os.MkdirAll(srcDir, 0o755)
+	_ = os.MkdirAll(library, 0o755)
+
+	src := filepath.Join(srcDir, "The.Matrix.1999.1080p.BluRay.mkv")
+	if err := os.WriteFile(src, []byte("video"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	mv := &movies.Movie{ID: "m1", Title: "The Matrix", Year: 1999, LibraryID: "lib1"}
+	mf := &movies.MovieFile{ID: "f1", MovieID: "m1", FilePath: src, Quality: "Bluray-1080p"}
+
+	mp := &organizerMoviesStub{movie: mv, files: []*movies.MovieFile{mf}, libraryPath: library}
+	up := &organizerUpdaterStub{}
+	cs := &organizerConfigStub{cfg: DefaultNamingConfig()}
+	org := New(mp, up, cs, testOrganizerLogger())
+	org.SetImportMode("hardlink")
+
+	results, err := org.OrganizeMovie(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("OrganizeMovie: %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("unexpected organize result: %+v", results)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source should remain in hardlink mode: %v", err)
+	}
+	if _, err := os.Stat(results[0].NewPath); err != nil {
+		t.Fatalf("expected destination file: %v", err)
+	}
+}
+
+func TestOrganizeMovie_RenameDisabled(t *testing.T) {
+	t.Parallel()
+	mv := &movies.Movie{ID: "m1", Title: "Movie", Year: 2000, LibraryID: "lib1"}
+	mp := &organizerMoviesStub{movie: mv, libraryPath: t.TempDir()}
+	up := &organizerUpdaterStub{}
+	cs := &organizerConfigStub{cfg: &NamingConfig{
+		ID:                "default",
+		MovieFolderFormat: "{Movie Title}",
+		MovieFileFormat:   "{Movie Title}",
+		ColonReplacement:  " -",
+		RenameMovies:      false,
+	}}
+	org := New(mp, up, cs, testOrganizerLogger())
+
+	if _, err := org.OrganizeMovie(context.Background(), "m1"); err == nil {
+		t.Fatal("expected error when rename_movies is disabled")
+	}
+}

--- a/internal/packs/detector_test.go
+++ b/internal/packs/detector_test.go
@@ -1,0 +1,59 @@
+package packs
+
+import "testing"
+
+func TestDetectPackPatterns(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		title       string
+		wantPack    bool
+		wantType    PackType
+		seasonStart int
+		seasonEnd   int
+		epStart     int
+		epEnd       int
+	}{
+		{"Show.S01-S03.1080p", true, PackTypeMultiSeason, 1, 3, 0, 0},
+		{"Show.S02.Complete.720p", true, PackTypeSingleSeason, 2, 2, 0, 0},
+		{"Show.Complete.Series.1080p", true, PackTypeCompleteSeries, -1, -1, 0, 0},
+		{"Show.S01E01-E10.1080p", true, PackTypeEpisodeRange, 1, 1, 1, 10},
+		{"Show.S04.720p", true, PackTypeSingleSeason, 4, 4, 0, 0},
+		{"Show.S01E02.720p", false, "", 0, 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := Detect(tt.title)
+			if got.IsPack != tt.wantPack {
+				t.Fatalf("IsPack = %v, want %v", got.IsPack, tt.wantPack)
+			}
+			if !tt.wantPack {
+				return
+			}
+			if got.Type != tt.wantType {
+				t.Fatalf("Type = %s, want %s", got.Type, tt.wantType)
+			}
+			if got.SeasonStart != tt.seasonStart || got.SeasonEnd != tt.seasonEnd {
+				t.Fatalf("season range = %d-%d, want %d-%d", got.SeasonStart, got.SeasonEnd, tt.seasonStart, tt.seasonEnd)
+			}
+			if got.EpisodeStart != tt.epStart || got.EpisodeEnd != tt.epEnd {
+				t.Fatalf("episode range = %d-%d, want %d-%d", got.EpisodeStart, got.EpisodeEnd, tt.epStart, tt.epEnd)
+			}
+		})
+	}
+}
+
+func TestIsPackAndCleanSeriesTitle(t *testing.T) {
+	t.Parallel()
+	if !IsPack("Series.Name.S01-S02.1080p") {
+		t.Fatal("expected IsPack to detect multi-season pack")
+	}
+	if IsPack("Series.Name.S01E01.1080p") {
+		t.Fatal("single episode should not be considered pack")
+	}
+
+	title := CleanSeriesTitle("Series.Name.S01-S02.1080p.BluRay")
+	if title != "Series Name" {
+		t.Fatalf("CleanSeriesTitle = %q, want %q", title, "Series Name")
+	}
+}

--- a/internal/packs/splitter_test.go
+++ b/internal/packs/splitter_test.go
@@ -1,0 +1,91 @@
+package packs
+
+import "testing"
+
+func TestDecidePack(t *testing.T) {
+	t.Parallel()
+	wanted := []WantedEpisodes{
+		{Season: 1, EpisodeNums: []int{1, 2, 3, 4, 5}, TotalInSeason: 10},
+	}
+
+	tests := []struct {
+		name       string
+		pack       DetectedPack
+		wantGrab   bool
+		wantReason string
+	}{
+		{
+			name:       "not a pack",
+			pack:       DetectedPack{IsPack: false},
+			wantGrab:   false,
+			wantReason: "not a pack",
+		},
+		{
+			name:       "50 percent threshold grabs",
+			pack:       DetectedPack{IsPack: true, Type: PackTypeSingleSeason, SeasonStart: 1, SeasonEnd: 1},
+			wantGrab:   true,
+			wantReason: "≥50% of episodes wanted",
+		},
+		{
+			name:       "below threshold prefers individual",
+			pack:       DetectedPack{IsPack: true, Type: PackTypeEpisodeRange, SeasonStart: 1, SeasonEnd: 1, EpisodeStart: 1, EpisodeEnd: 10},
+			wantGrab:   true,
+			wantReason: "≥50% of episodes wanted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := DecidePack(tt.pack, wanted, 10_000_000_000, 1_000_000_000)
+			if d.ShouldGrabPack != tt.wantGrab {
+				t.Fatalf("ShouldGrabPack = %v, want %v", d.ShouldGrabPack, tt.wantGrab)
+			}
+			if d.Reason != tt.wantReason {
+				t.Fatalf("Reason = %q, want %q", d.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestDecidePackBelowThresholdAndNoRange(t *testing.T) {
+	t.Parallel()
+	pack := DetectedPack{IsPack: true, Type: PackTypeEpisodeRange, SeasonStart: 1, SeasonEnd: 1, EpisodeStart: 1, EpisodeEnd: 10}
+	wanted := []WantedEpisodes{{Season: 1, EpisodeNums: []int{1, 2, 3}, TotalInSeason: 10}}
+	d := DecidePack(pack, wanted, 0, 0)
+	if d.ShouldGrabPack {
+		t.Fatal("expected not to grab when <50% wanted")
+	}
+	if d.Reason != "<50% of episodes wanted — prefer individual" {
+		t.Fatalf("unexpected reason: %q", d.Reason)
+	}
+
+	noRange := DecidePack(DetectedPack{IsPack: true, Type: PackTypeSingleSeason, SeasonStart: 2, SeasonEnd: 2}, wanted, 0, 0)
+	if noRange.Reason != "no episodes in pack range" {
+		t.Fatalf("unexpected no-range reason: %q", noRange.Reason)
+	}
+}
+
+func TestEpisodesFromPack(t *testing.T) {
+	t.Parallel()
+	packRange := DetectedPack{IsPack: true, Type: PackTypeEpisodeRange, SeasonStart: 3, SeasonEnd: 3, EpisodeStart: 4, EpisodeEnd: 6}
+	got := EpisodesFromPack(packRange, 3, 10)
+	want := []int{4, 5, 6}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("episode[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+
+	fullSeason := DetectedPack{IsPack: true, Type: PackTypeSingleSeason, SeasonStart: 1, SeasonEnd: 1}
+	got = EpisodesFromPack(fullSeason, 1, 4)
+	if len(got) != 4 || got[0] != 1 || got[3] != 4 {
+		t.Fatalf("unexpected full-season episodes: %+v", got)
+	}
+
+	if out := EpisodesFromPack(fullSeason, 2, 4); out != nil {
+		t.Fatalf("expected nil for season outside pack, got %+v", out)
+	}
+}

--- a/internal/searchdebug/handlers_test.go
+++ b/internal/searchdebug/handlers_test.go
@@ -1,0 +1,163 @@
+package searchdebug
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func openSearchDebugDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file::memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+CREATE TABLE search_debug_log (
+	id TEXT PRIMARY KEY,
+	created_at DATETIME NOT NULL,
+	media_type TEXT NOT NULL DEFAULT '',
+	media_id TEXT NOT NULL DEFAULT '',
+	title TEXT NOT NULL DEFAULT '',
+	year INTEGER NOT NULL DEFAULT 0,
+	season INTEGER NOT NULL DEFAULT 0,
+	episode INTEGER NOT NULL DEFAULT 0,
+	imdb_id TEXT NOT NULL DEFAULT '',
+	tvdb_id TEXT NOT NULL DEFAULT '',
+	tmdb_id TEXT NOT NULL DEFAULT '',
+	quality_profile_id TEXT NOT NULL DEFAULT '',
+	request_json TEXT NOT NULL DEFAULT '{}',
+	tiers_json TEXT NOT NULL DEFAULT '[]',
+	indexer_results_json TEXT NOT NULL DEFAULT '[]',
+	evaluation_json TEXT NOT NULL DEFAULT '[]',
+	total_results INTEGER NOT NULL DEFAULT 0,
+	total_rejected INTEGER NOT NULL DEFAULT 0,
+	grabbed_title TEXT NOT NULL DEFAULT '',
+	outcome TEXT NOT NULL DEFAULT '',
+	duration_ms INTEGER NOT NULL DEFAULT 0,
+	error_message TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT 'completed',
+	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	search_run_id TEXT NOT NULL DEFAULT ''
+);`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	return db
+}
+
+func seedEntry(t *testing.T, s *Store, id, title, outcome, status string, createdAt time.Time) {
+	t.Helper()
+	err := s.Create(context.Background(), &Entry{
+		ID:        id,
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+		Status:    status,
+		MediaType: "movie",
+		MediaID:   "m1",
+		Title:     title,
+		Outcome:   outcome,
+	})
+	if err != nil {
+		t.Fatalf("seed entry: %v", err)
+	}
+}
+
+func TestSearchDebugHandlers_ListGetStatsAndClear(t *testing.T) {
+	t.Parallel()
+	db := openSearchDebugDB(t)
+	store := NewStore(db)
+	hub := NewHub()
+	router := Router(store, hub, func(next http.Handler) http.Handler { return next })
+
+	now := time.Now().UTC()
+	seedEntry(t, store, "e1", "Movie One", "grabbed", StatusCompleted, now)
+	seedEntry(t, store, "e2", "Movie Two", "all_rejected", StatusFailed, now.Add(-time.Minute))
+
+	listReq := httptest.NewRequest(http.MethodGet, "/?limit=1&offset=0&media_type=movie", nil)
+	listRec := httptest.NewRecorder()
+	router.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", listRec.Code, listRec.Body.String())
+	}
+	var listBody struct {
+		Entries []Entry `json:"entries"`
+		Total   int     `json:"total"`
+		Limit   int     `json:"limit"`
+		Offset  int     `json:"offset"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listBody); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listBody.Total != 2 || len(listBody.Entries) != 1 || listBody.Limit != 1 {
+		t.Fatalf("unexpected list body: %+v", listBody)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/e1", nil)
+	getRec := httptest.NewRecorder()
+	router.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status = %d body=%s", getRec.Code, getRec.Body.String())
+	}
+	var got Entry
+	if err := json.Unmarshal(getRec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if got.ID != "e1" || got.Title != "Movie One" {
+		t.Fatalf("unexpected get entry: %+v", got)
+	}
+
+	missReq := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	missRec := httptest.NewRecorder()
+	router.ServeHTTP(missRec, missReq)
+	if missRec.Code != http.StatusNotFound {
+		t.Fatalf("missing get status = %d", missRec.Code)
+	}
+
+	statsReq := httptest.NewRequest(http.MethodGet, "/stats", nil)
+	statsRec := httptest.NewRecorder()
+	router.ServeHTTP(statsRec, statsReq)
+	if statsRec.Code != http.StatusOK {
+		t.Fatalf("stats status = %d", statsRec.Code)
+	}
+	var stats StatsResult
+	if err := json.Unmarshal(statsRec.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if stats.TotalSearches < 2 {
+		t.Fatalf("expected stats to include seeded rows: %+v", stats)
+	}
+
+	clearReq := httptest.NewRequest(http.MethodDelete, "/", nil)
+	clearRec := httptest.NewRecorder()
+	router.ServeHTTP(clearRec, clearReq)
+	if clearRec.Code != http.StatusNoContent {
+		t.Fatalf("clear status = %d", clearRec.Code)
+	}
+
+	afterClearReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	afterClearRec := httptest.NewRecorder()
+	router.ServeHTTP(afterClearRec, afterClearReq)
+	if afterClearRec.Code != http.StatusOK {
+		t.Fatalf("list after clear status = %d", afterClearRec.Code)
+	}
+	var after struct {
+		Entries []Entry `json:"entries"`
+		Total   int     `json:"total"`
+	}
+	if err := json.Unmarshal(afterClearRec.Body.Bytes(), &after); err != nil {
+		t.Fatalf("decode after clear list: %v", err)
+	}
+	if after.Total != 0 || len(after.Entries) != 0 {
+		t.Fatalf("expected empty state after clear, got %+v", after)
+	}
+}

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -1,0 +1,148 @@
+package validation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSizedFile(t *testing.T, path string, size int) {
+	t.Helper()
+	data := make([]byte, size)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+}
+
+func TestDefaultRulesAndConstructor(t *testing.T) {
+	t.Parallel()
+	v := NewValidator(nil)
+	rules := v.Rules()
+	if len(rules) == 0 {
+		t.Fatal("expected default rules when constructor receives nil")
+	}
+}
+
+func TestValidatorFileSizeRule(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		fileName string
+		size     int
+		ruleCfg  map[string]any
+		pass     bool
+	}{
+		{
+			name:     "zero bytes fails",
+			fileName: "movie.1080p.mkv",
+			size:     0,
+			ruleCfg:  map[string]any{"min_bytes_1080p": 1},
+			pass:     false,
+		},
+		{
+			name:     "below quality threshold fails",
+			fileName: "movie.1080p.mkv",
+			size:     100,
+			ruleCfg:  map[string]any{"min_bytes_1080p": 200},
+			pass:     false,
+		},
+		{
+			name:     "above quality threshold passes",
+			fileName: "movie.1080p.mkv",
+			size:     300,
+			ruleCfg:  map[string]any{"min_bytes_1080p": 200},
+			pass:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.fileName)
+			writeSizedFile(t, path, tt.size)
+
+			v := NewValidator([]ValidationRule{{
+				ID:      "file_size",
+				Enabled: true,
+				Config:  tt.ruleCfg,
+			}})
+			res := v.Validate(path)
+			if res.Valid != tt.pass {
+				t.Fatalf("Valid = %v, want %v (checks=%+v)", res.Valid, tt.pass, res.Checks)
+			}
+		})
+	}
+}
+
+func TestValidatorExtensionRule(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	v := NewValidator([]ValidationRule{{ID: "extension", Enabled: true}})
+
+	tests := []struct {
+		name     string
+		fileName string
+		pass     bool
+		msgPart  string
+	}{
+		{"video extension passes", "movie.mkv", true, "valid"},
+		{"subtitle extension passes", "movie.srt", true, "subtitle/info"},
+		{"dangerous extension fails", "movie.exe", false, "dangerous"},
+		{"unknown extension fails", "movie.abc", false, "unrecognized"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(dir, tt.fileName)
+			writeSizedFile(t, path, 16)
+			res := v.Validate(path)
+			if res.Valid != tt.pass {
+				t.Fatalf("Valid = %v, want %v", res.Valid, tt.pass)
+			}
+			if len(res.Checks) != 1 || !strings.Contains(res.Checks[0].Message, tt.msgPart) {
+				t.Fatalf("unexpected check message: %+v", res.Checks)
+			}
+		})
+	}
+}
+
+func TestValidatorArchiveRule(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	v := NewValidator([]ValidationRule{{ID: "archive_detection", Enabled: true}})
+
+	zipFile := filepath.Join(dir, "movie.zip")
+	writeSizedFile(t, zipFile, 32)
+	res := v.Validate(zipFile)
+	if res.Valid {
+		t.Fatalf("expected archive file to be rejected: %+v", res)
+	}
+
+	mkvFile := filepath.Join(dir, "movie.mkv")
+	writeSizedFile(t, mkvFile, 32)
+	res = v.Validate(mkvFile)
+	if !res.Valid {
+		t.Fatalf("expected non-archive to pass: %+v", res)
+	}
+}
+
+func TestValidatorMiscRules(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "movie.mkv")
+	writeSizedFile(t, path, 128)
+
+	v := NewValidator([]ValidationRule{
+		{ID: "min_duration", Enabled: true},
+		{ID: "unknown_rule", Enabled: true},
+		{ID: "file_size", Enabled: false},
+	})
+	res := v.Validate(path)
+	if !res.Valid {
+		t.Fatalf("expected checks to pass: %+v", res)
+	}
+	if len(res.Checks) != 2 {
+		t.Fatalf("expected 2 enabled checks, got %d", len(res.Checks))
+	}
+}


### PR DESCRIPTION
## Summary\n- add notifications unit tests for CRUD/history paths and template rendering\n- add organizer tests for naming output and organize move/hardlink behavior\n- add packs detector/splitter tests for pack parsing and decisions\n- add validation tests for file size, extension, archive, and misc rule handling\n- add searchdebug handler tests for list/get/stats/clear endpoints\n- extend movies service tests for AddMovieByTMDBID and status transitions/events\n- add imports decision and pipeline stage utility tests\n\n## Validation\n- === RUN   TestServiceConnectionCRUD
=== PAUSE TestServiceConnectionCRUD
=== RUN   TestServiceListConnectionsAndErrors
=== PAUSE TestServiceListConnectionsAndErrors
=== RUN   TestServiceLogHistoryAndListHistory
=== PAUSE TestServiceLogHistoryAndListHistory
=== RUN   TestDefaultTemplateFallback
=== PAUSE TestDefaultTemplateFallback
=== RUN   TestRenderTemplate_DefaultAndOverride
=== PAUSE TestRenderTemplate_DefaultAndOverride
=== RUN   TestRenderTemplate_InvalidTemplate
=== PAUSE TestRenderTemplate_InvalidTemplate
=== RUN   TestAvailableVariables
=== PAUSE TestAvailableVariables
=== CONT  TestServiceConnectionCRUD
=== CONT  TestRenderTemplate_DefaultAndOverride
=== CONT  TestServiceLogHistoryAndListHistory
=== CONT  TestServiceListConnectionsAndErrors
=== CONT  TestAvailableVariables
--- PASS: TestAvailableVariables (0.00s)
=== CONT  TestRenderTemplate_InvalidTemplate
=== CONT  TestDefaultTemplateFallback
--- PASS: TestDefaultTemplateFallback (0.00s)
--- PASS: TestRenderTemplate_InvalidTemplate (0.00s)
--- PASS: TestRenderTemplate_DefaultAndOverride (0.00s)
--- PASS: TestServiceConnectionCRUD (0.00s)
--- PASS: TestServiceListConnectionsAndErrors (0.00s)
--- PASS: TestServiceLogHistoryAndListHistory (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/notifications	(cached)
=== RUN   TestNamingFormatAndTargetPath
=== PAUSE TestNamingFormatAndTargetPath
=== RUN   TestOrganizeMovie_MoveMode
=== PAUSE TestOrganizeMovie_MoveMode
=== RUN   TestOrganizeMovie_HardlinkMode
=== PAUSE TestOrganizeMovie_HardlinkMode
=== RUN   TestOrganizeMovie_RenameDisabled
=== PAUSE TestOrganizeMovie_RenameDisabled
=== CONT  TestNamingFormatAndTargetPath
=== CONT  TestOrganizeMovie_HardlinkMode
=== CONT  TestOrganizeMovie_RenameDisabled
=== RUN   TestNamingFormatAndTargetPath/default_format
=== CONT  TestOrganizeMovie_MoveMode
--- PASS: TestOrganizeMovie_RenameDisabled (0.00s)
=== RUN   TestNamingFormatAndTargetPath/clean_title_and_source
--- PASS: TestNamingFormatAndTargetPath (0.00s)
    --- PASS: TestNamingFormatAndTargetPath/default_format (0.00s)
    --- PASS: TestNamingFormatAndTargetPath/clean_title_and_source (0.00s)
--- PASS: TestOrganizeMovie_MoveMode (0.00s)
--- PASS: TestOrganizeMovie_HardlinkMode (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/organizer	(cached)
=== RUN   TestDetectPackPatterns
=== PAUSE TestDetectPackPatterns
=== RUN   TestIsPackAndCleanSeriesTitle
=== PAUSE TestIsPackAndCleanSeriesTitle
=== RUN   TestDecidePack
=== PAUSE TestDecidePack
=== RUN   TestDecidePackBelowThresholdAndNoRange
=== PAUSE TestDecidePackBelowThresholdAndNoRange
=== RUN   TestEpisodesFromPack
=== PAUSE TestEpisodesFromPack
=== CONT  TestDetectPackPatterns
=== CONT  TestDecidePackBelowThresholdAndNoRange
--- PASS: TestDecidePackBelowThresholdAndNoRange (0.00s)
=== RUN   TestDetectPackPatterns/Show.S01-S03.1080p
=== CONT  TestDecidePack
=== RUN   TestDetectPackPatterns/Show.S02.Complete.720p
=== RUN   TestDetectPackPatterns/Show.Complete.Series.1080p
=== RUN   TestDecidePack/not_a_pack
=== RUN   TestDetectPackPatterns/Show.S01E01-E10.1080p
=== CONT  TestIsPackAndCleanSeriesTitle
=== RUN   TestDetectPackPatterns/Show.S04.720p
=== RUN   TestDecidePack/50_percent_threshold_grabs
--- PASS: TestIsPackAndCleanSeriesTitle (0.00s)
=== RUN   TestDetectPackPatterns/Show.S01E02.720p
--- PASS: TestDetectPackPatterns (0.00s)
    --- PASS: TestDetectPackPatterns/Show.S01-S03.1080p (0.00s)
    --- PASS: TestDetectPackPatterns/Show.S02.Complete.720p (0.00s)
    --- PASS: TestDetectPackPatterns/Show.Complete.Series.1080p (0.00s)
    --- PASS: TestDetectPackPatterns/Show.S01E01-E10.1080p (0.00s)
    --- PASS: TestDetectPackPatterns/Show.S04.720p (0.00s)
    --- PASS: TestDetectPackPatterns/Show.S01E02.720p (0.00s)
=== CONT  TestEpisodesFromPack
=== RUN   TestDecidePack/below_threshold_prefers_individual
--- PASS: TestEpisodesFromPack (0.00s)
--- PASS: TestDecidePack (0.00s)
    --- PASS: TestDecidePack/not_a_pack (0.00s)
    --- PASS: TestDecidePack/50_percent_threshold_grabs (0.00s)
    --- PASS: TestDecidePack/below_threshold_prefers_individual (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/packs	(cached)
=== RUN   TestDefaultRulesAndConstructor
=== PAUSE TestDefaultRulesAndConstructor
=== RUN   TestValidatorFileSizeRule
=== PAUSE TestValidatorFileSizeRule
=== RUN   TestValidatorExtensionRule
=== PAUSE TestValidatorExtensionRule
=== RUN   TestValidatorArchiveRule
=== PAUSE TestValidatorArchiveRule
=== RUN   TestValidatorMiscRules
=== PAUSE TestValidatorMiscRules
=== CONT  TestDefaultRulesAndConstructor
--- PASS: TestDefaultRulesAndConstructor (0.00s)
=== CONT  TestValidatorFileSizeRule
=== CONT  TestValidatorArchiveRule
=== CONT  TestValidatorExtensionRule
=== CONT  TestValidatorMiscRules
=== RUN   TestValidatorFileSizeRule/zero_bytes_fails
=== RUN   TestValidatorExtensionRule/video_extension_passes
=== RUN   TestValidatorFileSizeRule/below_quality_threshold_fails
=== RUN   TestValidatorExtensionRule/subtitle_extension_passes
=== RUN   TestValidatorFileSizeRule/above_quality_threshold_passes
=== RUN   TestValidatorExtensionRule/dangerous_extension_fails
=== RUN   TestValidatorExtensionRule/unknown_extension_fails
--- PASS: TestValidatorMiscRules (0.00s)
--- PASS: TestValidatorArchiveRule (0.00s)
--- PASS: TestValidatorFileSizeRule (0.00s)
    --- PASS: TestValidatorFileSizeRule/zero_bytes_fails (0.00s)
    --- PASS: TestValidatorFileSizeRule/below_quality_threshold_fails (0.00s)
    --- PASS: TestValidatorFileSizeRule/above_quality_threshold_passes (0.00s)
--- PASS: TestValidatorExtensionRule (0.00s)
    --- PASS: TestValidatorExtensionRule/video_extension_passes (0.00s)
    --- PASS: TestValidatorExtensionRule/subtitle_extension_passes (0.00s)
    --- PASS: TestValidatorExtensionRule/dangerous_extension_fails (0.00s)
    --- PASS: TestValidatorExtensionRule/unknown_extension_fails (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/validation	(cached)\n- === RUN   TestSearchDebugHandlers_ListGetStatsAndClear
=== PAUSE TestSearchDebugHandlers_ListGetStatsAndClear
=== CONT  TestSearchDebugHandlers_ListGetStatsAndClear
--- PASS: TestSearchDebugHandlers_ListGetStatsAndClear (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/searchdebug	(cached)
=== RUN   TestValidateCustomFormatAllowedFields
--- PASS: TestValidateCustomFormatAllowedFields (0.00s)
=== RUN   TestValidateCustomFormatConditions
=== RUN   TestValidateCustomFormatConditions/equals-string
=== RUN   TestValidateCustomFormatConditions/regex-valid
=== RUN   TestValidateCustomFormatConditions/range-valid
=== RUN   TestValidateCustomFormatConditions/in-valid
=== RUN   TestValidateCustomFormatConditions/gt-valid
=== RUN   TestValidateCustomFormatConditions/gte-valid
=== RUN   TestValidateCustomFormatConditions/lt-valid
=== RUN   TestValidateCustomFormatConditions/lte-valid
=== RUN   TestValidateCustomFormatConditions/regex-invalid
=== RUN   TestValidateCustomFormatConditions/range-non-numeric
=== RUN   TestValidateCustomFormatConditions/gt-non-numeric
=== RUN   TestValidateCustomFormatConditions/gte-non-numeric
=== RUN   TestValidateCustomFormatConditions/in-empty
--- PASS: TestValidateCustomFormatConditions (0.00s)
    --- PASS: TestValidateCustomFormatConditions/equals-string (0.00s)
    --- PASS: TestValidateCustomFormatConditions/regex-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/range-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/in-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/gt-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/gte-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/lt-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/lte-valid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/regex-invalid (0.00s)
    --- PASS: TestValidateCustomFormatConditions/range-non-numeric (0.00s)
    --- PASS: TestValidateCustomFormatConditions/gt-non-numeric (0.00s)
    --- PASS: TestValidateCustomFormatConditions/gte-non-numeric (0.00s)
    --- PASS: TestValidateCustomFormatConditions/in-empty (0.00s)
=== RUN   TestValidateCustomFormatEmptyFilters
--- PASS: TestValidateCustomFormatEmptyFilters (0.00s)
=== RUN   TestValidateCustomFormatEmptyName
--- PASS: TestValidateCustomFormatEmptyName (0.00s)
=== RUN   TestValidateFilterValueReDoS
--- PASS: TestValidateFilterValueReDoS (0.00s)
=== RUN   TestFilterMatches
=== RUN   TestFilterMatches/equals-match
=== RUN   TestFilterMatches/equals-mismatch
=== RUN   TestFilterMatches/regex-match
=== RUN   TestFilterMatches/regex-mismatch
=== RUN   TestFilterMatches/in-first
=== RUN   TestFilterMatches/in-middle
=== RUN   TestFilterMatches/in-last
=== RUN   TestFilterMatches/in-none
=== RUN   TestFilterMatches/regex-invalid-pattern
=== RUN   TestFilterMatches/unknown-condition
--- PASS: TestFilterMatches (0.00s)
    --- PASS: TestFilterMatches/equals-match (0.00s)
    --- PASS: TestFilterMatches/equals-mismatch (0.00s)
    --- PASS: TestFilterMatches/regex-match (0.00s)
    --- PASS: TestFilterMatches/regex-mismatch (0.00s)
    --- PASS: TestFilterMatches/in-first (0.00s)
    --- PASS: TestFilterMatches/in-middle (0.00s)
    --- PASS: TestFilterMatches/in-last (0.00s)
    --- PASS: TestFilterMatches/in-none (0.00s)
    --- PASS: TestFilterMatches/regex-invalid-pattern (0.00s)
    --- PASS: TestFilterMatches/unknown-condition (0.00s)
=== RUN   TestCustomFormatWithTimestamps
--- PASS: TestCustomFormatWithTimestamps (0.00s)
=== RUN   TestCustomFormatFilterOrder
--- PASS: TestCustomFormatFilterOrder (0.00s)
=== RUN   TestConditionEquality
--- PASS: TestConditionEquality (0.00s)
=== RUN   TestValidateFilterValueRangeFormat
=== RUN   TestValidateFilterValueRangeFormat/valid-range
=== RUN   TestValidateFilterValueRangeFormat/valid-range-open-start
=== RUN   TestValidateFilterValueRangeFormat/valid-range-open-end
=== RUN   TestValidateFilterValueRangeFormat/invalid-range-both-open
=== RUN   TestValidateFilterValueRangeFormat/invalid-non-numeric-start
=== RUN   TestValidateFilterValueRangeFormat/invalid-non-numeric-end
=== RUN   TestValidateFilterValueRangeFormat/invalid-no-comma
=== RUN   TestValidateFilterValueRangeFormat/invalid-empty
--- PASS: TestValidateFilterValueRangeFormat (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/valid-range (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/valid-range-open-start (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/valid-range-open-end (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/invalid-range-both-open (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/invalid-non-numeric-start (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/invalid-non-numeric-end (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/invalid-no-comma (0.00s)
    --- PASS: TestValidateFilterValueRangeFormat/invalid-empty (0.00s)
=== RUN   TestRegexCompilationCache
--- PASS: TestRegexCompilationCache (0.00s)
=== RUN   TestNumericFilterConditions
=== RUN   TestNumericFilterConditions/bitdepth_10-bit_equals
=== RUN   TestNumericFilterConditions/bitdepth_10-bit_less_than
=== RUN   TestNumericFilterConditions/bitdepth_10-bit_range
=== RUN   TestNumericFilterConditions/bitdepth_8-bit_(implicit)_less_than_10
=== RUN   TestNumericFilterConditions/bitdepth_12-bit_greater_than_10
=== RUN   TestNumericFilterConditions/bitdepth_10-bit_not_in_range
=== RUN   TestNumericFilterConditions/year_2024_equals
=== RUN   TestNumericFilterConditions/year_2023_less_than_2024
=== RUN   TestNumericFilterConditions/year_2020_in_range
=== RUN   TestNumericFilterConditions/year_2010_not_greater_than_2020
=== RUN   TestNumericFilterConditions/year_with_bracket_format
=== RUN   TestNumericFilterConditions/resolution_1080p_equals
=== RUN   TestNumericFilterConditions/resolution_720p_less_than_1080p
=== RUN   TestNumericFilterConditions/resolution_2160p_in_range
=== RUN   TestNumericFilterConditions/resolution_480p_not_greater_than_1080
=== RUN   TestNumericFilterConditions/resolution_2160p_4K
=== RUN   TestNumericFilterConditions/no_year_found,_field_zero
=== RUN   TestNumericFilterConditions/no_resolution_found
--- PASS: TestNumericFilterConditions (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_10-bit_equals (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_10-bit_less_than (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_10-bit_range (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_8-bit_(implicit)_less_than_10 (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_12-bit_greater_than_10 (0.00s)
    --- PASS: TestNumericFilterConditions/bitdepth_10-bit_not_in_range (0.00s)
    --- PASS: TestNumericFilterConditions/year_2024_equals (0.00s)
    --- PASS: TestNumericFilterConditions/year_2023_less_than_2024 (0.00s)
    --- PASS: TestNumericFilterConditions/year_2020_in_range (0.00s)
    --- PASS: TestNumericFilterConditions/year_2010_not_greater_than_2020 (0.00s)
    --- PASS: TestNumericFilterConditions/year_with_bracket_format (0.00s)
    --- PASS: TestNumericFilterConditions/resolution_1080p_equals (0.00s)
    --- PASS: TestNumericFilterConditions/resolution_720p_less_than_1080p (0.00s)
    --- PASS: TestNumericFilterConditions/resolution_2160p_in_range (0.00s)
    --- PASS: TestNumericFilterConditions/resolution_480p_not_greater_than_1080 (0.00s)
    --- PASS: TestNumericFilterConditions/resolution_2160p_4K (0.00s)
    --- PASS: TestNumericFilterConditions/no_year_found,_field_zero (0.00s)
    --- PASS: TestNumericFilterConditions/no_resolution_found (0.00s)
=== RUN   TestNumericFilterRangeFormat
=== RUN   TestNumericFilterRangeFormat/bitdepth_in_range
=== RUN   TestNumericFilterRangeFormat/bitdepth_below_range
=== RUN   TestNumericFilterRangeFormat/bitdepth_above_range
=== RUN   TestNumericFilterRangeFormat/year_in_range
=== RUN   TestNumericFilterRangeFormat/year_below_range
=== RUN   TestNumericFilterRangeFormat/resolution_in_range
=== RUN   TestNumericFilterRangeFormat/bitdepth_at_least_10
=== RUN   TestNumericFilterRangeFormat/year_up_to_2025
--- PASS: TestNumericFilterRangeFormat (0.00s)
    --- PASS: TestNumericFilterRangeFormat/bitdepth_in_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/bitdepth_below_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/bitdepth_above_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/year_in_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/year_below_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/resolution_in_range (0.00s)
    --- PASS: TestNumericFilterRangeFormat/bitdepth_at_least_10 (0.00s)
    --- PASS: TestNumericFilterRangeFormat/year_up_to_2025 (0.00s)
=== RUN   TestValidateQualityProfile
=== RUN   TestValidateQualityProfile/valid_profile_with_cutoff_in_items_and_allowed
=== RUN   TestValidateQualityProfile/invalid_profile:_cutoff_not_in_items
=== RUN   TestValidateQualityProfile/invalid_profile:_cutoff_in_items_but_not_allowed
=== RUN   TestValidateQualityProfile/valid_profile:_single_item_as_cutoff
=== RUN   TestValidateQualityProfile/invalid_profile:_empty_cutoff
=== RUN   TestValidateQualityProfile/invalid_profile:_empty_items
--- PASS: TestValidateQualityProfile (0.00s)
    --- PASS: TestValidateQualityProfile/valid_profile_with_cutoff_in_items_and_allowed (0.00s)
    --- PASS: TestValidateQualityProfile/invalid_profile:_cutoff_not_in_items (0.00s)
    --- PASS: TestValidateQualityProfile/invalid_profile:_cutoff_in_items_but_not_allowed (0.00s)
    --- PASS: TestValidateQualityProfile/valid_profile:_single_item_as_cutoff (0.00s)
    --- PASS: TestValidateQualityProfile/invalid_profile:_empty_cutoff (0.00s)
    --- PASS: TestValidateQualityProfile/invalid_profile:_empty_items (0.00s)
=== RUN   TestQualityDefinitionFieldValidation
--- PASS: TestQualityDefinitionFieldValidation (0.00s)
=== RUN   TestQualityProfileItemDefaults
--- PASS: TestQualityProfileItemDefaults (0.00s)
=== RUN   TestListMovies_DefaultLimit
=== PAUSE TestListMovies_DefaultLimit
=== RUN   TestListMovies_ClampLimits
=== PAUSE TestListMovies_ClampLimits
=== RUN   TestListMovies_NegativeOffset
=== PAUSE TestListMovies_NegativeOffset
=== RUN   TestSearchMovies_EmptyQuery
=== PAUSE TestSearchMovies_EmptyQuery
=== RUN   TestSearchMovies_ValidQuery
=== PAUSE TestSearchMovies_ValidQuery
=== RUN   TestGetMovie_EmptyID
=== PAUSE TestGetMovie_EmptyID
=== RUN   TestGetMovie_CacheHit
=== PAUSE TestGetMovie_CacheHit
=== RUN   TestGetMovie_NotFound
=== PAUSE TestGetMovie_NotFound
=== RUN   TestAddMovie_NilMovie
=== PAUSE TestAddMovie_NilMovie
=== RUN   TestAddMovie_EmptyTitle
=== PAUSE TestAddMovie_EmptyTitle
=== RUN   TestAddMovie_EmptyLibrary
=== PAUSE TestAddMovie_EmptyLibrary
=== RUN   TestAddMovie_Success
=== PAUSE TestAddMovie_Success
=== RUN   TestAddMovie_InvalidatesCache
=== PAUSE TestAddMovie_InvalidatesCache
=== RUN   TestAddMovie_RepoError
=== PAUSE TestAddMovie_RepoError
=== RUN   TestUpdateMovie_NilMovie
=== PAUSE TestUpdateMovie_NilMovie
=== RUN   TestUpdateMovie_EmptyID
=== PAUSE TestUpdateMovie_EmptyID
=== RUN   TestUpdateMovie_Success
=== PAUSE TestUpdateMovie_Success
=== RUN   TestDeleteMovie_EmptyID
=== PAUSE TestDeleteMovie_EmptyID
=== RUN   TestDeleteMovie_Success
=== PAUSE TestDeleteMovie_Success
=== RUN   TestSetMonitoringStatus_EmptyID
=== PAUSE TestSetMonitoringStatus_EmptyID
=== RUN   TestSetMonitoringStatus_ValidStatuses
=== PAUSE TestSetMonitoringStatus_ValidStatuses
=== RUN   TestSetMonitoringStatus_InvalidStatus
=== PAUSE TestSetMonitoringStatus_InvalidStatus
=== RUN   TestSetMonitoringStatus_MovieNotFound
=== PAUSE TestSetMonitoringStatus_MovieNotFound
=== RUN   TestLookupMovies_EmptyTerm
=== PAUSE TestLookupMovies_EmptyTerm
=== RUN   TestLookupMovies_NoMetadataProvider
=== PAUSE TestLookupMovies_NoMetadataProvider
=== RUN   TestLookupMovies_Success
=== PAUSE TestLookupMovies_Success
=== RUN   TestGetMovieCredits_NoProvider
=== PAUSE TestGetMovieCredits_NoProvider
=== RUN   TestGetMovieCredits_MovieNotFound
=== PAUSE TestGetMovieCredits_MovieNotFound
=== RUN   TestGetMovieCredits_NoTMDBID
=== PAUSE TestGetMovieCredits_NoTMDBID
=== RUN   TestRefreshMovie_EmptyID
=== PAUSE TestRefreshMovie_EmptyID
=== RUN   TestRefreshMovie_NoMetadataProvider
=== PAUSE TestRefreshMovie_NoMetadataProvider
=== RUN   TestRefreshMovie_Success
=== PAUSE TestRefreshMovie_Success
=== RUN   TestListMovieFiles_EmptyMovieID
=== PAUSE TestListMovieFiles_EmptyMovieID
=== RUN   TestAddMovieFile_Validation
=== PAUSE TestAddMovieFile_Validation
=== RUN   TestAddQualityDefinition_Validation
=== PAUSE TestAddQualityDefinition_Validation
=== RUN   TestAddQualityProfile_Validation
=== PAUSE TestAddQualityProfile_Validation
=== RUN   TestDeleteQualityDefinition_EmptyID
=== PAUSE TestDeleteQualityDefinition_EmptyID
=== RUN   TestDeleteQualityProfile_EmptyID
=== PAUSE TestDeleteQualityProfile_EmptyID
=== RUN   TestGetQualityDefinition_EmptyID
=== PAUSE TestGetQualityDefinition_EmptyID
=== RUN   TestGetQualityProfile_EmptyID
=== PAUSE TestGetQualityProfile_EmptyID
=== RUN   TestUpdateQualityDefinition_Validation
=== PAUSE TestUpdateQualityDefinition_Validation
=== RUN   TestUpdateQualityProfile_Validation
=== PAUSE TestUpdateQualityProfile_Validation
=== RUN   TestAddMovieByTMDBID_AppliesProfileAndSlug
=== PAUSE TestAddMovieByTMDBID_AppliesProfileAndSlug
=== RUN   TestAddMovieByTMDBID_UnreleasedAndUnmonitored
=== PAUSE TestAddMovieByTMDBID_UnreleasedAndUnmonitored
=== RUN   TestSetMovieStatus_NoOpSkipsUpdate
=== PAUSE TestSetMovieStatus_NoOpSkipsUpdate
=== RUN   TestSetMovieStatus_TransitionPublishesEvent
=== PAUSE TestSetMovieStatus_TransitionPublishesEvent
=== CONT  TestListMovies_DefaultLimit
=== CONT  TestAddQualityProfile_Validation
--- PASS: TestListMovies_DefaultLimit (0.00s)
=== CONT  TestRefreshMovie_EmptyID
=== CONT  TestLookupMovies_EmptyTerm
--- PASS: TestLookupMovies_EmptyTerm (0.00s)
=== CONT  TestAddQualityDefinition_Validation
=== RUN   TestAddQualityDefinition_Validation/nil
=== CONT  TestGetMovieCredits_NoTMDBID
=== RUN   TestAddQualityProfile_Validation/nil
=== CONT  TestListMovieFiles_EmptyMovieID
=== CONT  TestGetMovieCredits_NoProvider
=== CONT  TestLookupMovies_Success
=== CONT  TestLookupMovies_NoMetadataProvider
=== CONT  TestAddMovie_InvalidatesCache
=== CONT  TestRefreshMovie_Success
=== CONT  TestRefreshMovie_NoMetadataProvider
=== CONT  TestSetMonitoringStatus_InvalidStatus
=== CONT  TestSetMonitoringStatus_ValidStatuses
=== CONT  TestSetMonitoringStatus_EmptyID
=== CONT  TestAddMovieFile_Validation
=== CONT  TestDeleteMovie_Success
=== RUN   TestAddMovieFile_Validation/empty_movie_id
=== CONT  TestUpdateMovie_Success
=== CONT  TestDeleteMovie_EmptyID
=== RUN   TestSetMonitoringStatus_ValidStatuses/monitored
--- PASS: TestRefreshMovie_EmptyID (0.00s)
--- PASS: TestListMovieFiles_EmptyMovieID (0.00s)
=== RUN   TestAddQualityProfile_Validation/empty_name
=== RUN   TestAddQualityDefinition_Validation/empty_name
--- PASS: TestGetMovieCredits_NoProvider (0.00s)
--- PASS: TestLookupMovies_Success (0.00s)
--- PASS: TestLookupMovies_NoMetadataProvider (0.00s)
--- PASS: TestAddMovie_InvalidatesCache (0.00s)
--- PASS: TestRefreshMovie_Success (0.00s)
--- PASS: TestRefreshMovie_NoMetadataProvider (0.00s)
=== CONT  TestSetMonitoringStatus_MovieNotFound
=== RUN   TestAddQualityProfile_Validation/empty_cutoff
=== CONT  TestUpdateMovie_NilMovie
=== CONT  TestGetMovie_CacheHit
=== CONT  TestAddMovie_Success
=== CONT  TestAddMovie_EmptyLibrary
=== CONT  TestGetMovieCredits_MovieNotFound
=== CONT  TestUpdateMovie_EmptyID
=== CONT  TestAddMovie_NilMovie
=== CONT  TestGetMovie_NotFound
=== CONT  TestUpdateQualityProfile_Validation
=== CONT  TestAddMovie_RepoError
=== CONT  TestSetMovieStatus_NoOpSkipsUpdate
=== CONT  TestAddMovieByTMDBID_UnreleasedAndUnmonitored
=== CONT  TestAddMovieByTMDBID_AppliesProfileAndSlug
=== CONT  TestAddMovie_EmptyTitle
=== CONT  TestGetQualityDefinition_EmptyID
=== CONT  TestUpdateQualityDefinition_Validation
=== CONT  TestDeleteQualityProfile_EmptyID
=== CONT  TestGetQualityProfile_EmptyID
--- PASS: TestSetMonitoringStatus_InvalidStatus (0.00s)
--- PASS: TestSetMonitoringStatus_EmptyID (0.00s)
--- PASS: TestGetMovieCredits_NoTMDBID (0.00s)
=== CONT  TestDeleteQualityDefinition_EmptyID
--- PASS: TestDeleteMovie_Success (0.00s)
--- PASS: TestUpdateMovie_Success (0.00s)
=== CONT  TestGetMovie_EmptyID
--- PASS: TestGetMovie_EmptyID (0.00s)
=== CONT  TestSearchMovies_ValidQuery
=== RUN   TestAddMovieFile_Validation/empty_file_path
--- PASS: TestSearchMovies_ValidQuery (0.00s)
=== CONT  TestListMovies_ClampLimits
=== RUN   TestListMovies_ClampLimits/negative_limit_defaults_to_25
--- PASS: TestDeleteMovie_EmptyID (0.00s)
=== RUN   TestSetMonitoringStatus_ValidStatuses/unmonitored
=== CONT  TestListMovies_NegativeOffset
--- PASS: TestSetMonitoringStatus_MovieNotFound (0.00s)
--- PASS: TestUpdateMovie_NilMovie (0.00s)
--- PASS: TestListMovies_NegativeOffset (0.00s)
=== CONT  TestSearchMovies_EmptyQuery
--- PASS: TestGetMovie_CacheHit (0.00s)
--- PASS: TestAddMovie_Success (0.00s)
--- PASS: TestAddMovie_EmptyLibrary (0.00s)
--- PASS: TestUpdateMovie_EmptyID (0.00s)
--- PASS: TestGetMovieCredits_MovieNotFound (0.00s)
--- PASS: TestAddMovie_NilMovie (0.00s)
=== CONT  TestSetMovieStatus_TransitionPublishesEvent
=== RUN   TestSetMonitoringStatus_ValidStatuses/deleted
=== RUN   TestAddQualityDefinition_Validation/empty_source
--- PASS: TestGetMovie_NotFound (0.00s)
--- PASS: TestUpdateQualityProfile_Validation (0.00s)
--- PASS: TestAddMovie_RepoError (0.00s)
--- PASS: TestSetMovieStatus_NoOpSkipsUpdate (0.00s)
--- PASS: TestAddMovieByTMDBID_AppliesProfileAndSlug (0.00s)
--- PASS: TestGetQualityDefinition_EmptyID (0.00s)
--- PASS: TestUpdateQualityDefinition_Validation (0.00s)
--- PASS: TestAddMovie_EmptyTitle (0.00s)
--- PASS: TestDeleteQualityProfile_EmptyID (0.00s)
--- PASS: TestGetQualityProfile_EmptyID (0.00s)
--- PASS: TestDeleteQualityDefinition_EmptyID (0.00s)
--- PASS: TestAddMovieByTMDBID_UnreleasedAndUnmonitored (0.00s)
=== RUN   TestAddQualityDefinition_Validation/empty_resolution
=== RUN   TestAddMovieFile_Validation/valid
=== RUN   TestListMovies_ClampLimits/zero_limit_defaults_to_25
=== RUN   TestAddQualityProfile_Validation/no_items
--- PASS: TestSearchMovies_EmptyQuery (0.00s)
--- PASS: TestSetMonitoringStatus_ValidStatuses (0.00s)
    --- PASS: TestSetMonitoringStatus_ValidStatuses/monitored (0.00s)
    --- PASS: TestSetMonitoringStatus_ValidStatuses/unmonitored (0.00s)
    --- PASS: TestSetMonitoringStatus_ValidStatuses/deleted (0.00s)
--- PASS: TestSetMovieStatus_TransitionPublishesEvent (0.00s)
=== RUN   TestAddQualityDefinition_Validation/valid
--- PASS: TestAddQualityDefinition_Validation (0.00s)
    --- PASS: TestAddQualityDefinition_Validation/nil (0.00s)
    --- PASS: TestAddQualityDefinition_Validation/empty_name (0.00s)
    --- PASS: TestAddQualityDefinition_Validation/empty_source (0.00s)
    --- PASS: TestAddQualityDefinition_Validation/empty_resolution (0.00s)
    --- PASS: TestAddQualityDefinition_Validation/valid (0.00s)
--- PASS: TestAddMovieFile_Validation (0.00s)
    --- PASS: TestAddMovieFile_Validation/empty_movie_id (0.00s)
    --- PASS: TestAddMovieFile_Validation/empty_file_path (0.00s)
    --- PASS: TestAddMovieFile_Validation/valid (0.00s)
=== RUN   TestAddQualityProfile_Validation/cutoff_not_in_items
=== RUN   TestListMovies_ClampLimits/over_1000_clamped_to_1000
=== RUN   TestAddQualityProfile_Validation/cutoff_not_allowed
--- PASS: TestListMovies_ClampLimits (0.00s)
    --- PASS: TestListMovies_ClampLimits/negative_limit_defaults_to_25 (0.00s)
    --- PASS: TestListMovies_ClampLimits/zero_limit_defaults_to_25 (0.00s)
    --- PASS: TestListMovies_ClampLimits/over_1000_clamped_to_1000 (0.00s)
=== RUN   TestAddQualityProfile_Validation/valid
--- PASS: TestAddQualityProfile_Validation (0.00s)
    --- PASS: TestAddQualityProfile_Validation/nil (0.00s)
    --- PASS: TestAddQualityProfile_Validation/empty_name (0.00s)
    --- PASS: TestAddQualityProfile_Validation/empty_cutoff (0.00s)
    --- PASS: TestAddQualityProfile_Validation/no_items (0.00s)
    --- PASS: TestAddQualityProfile_Validation/cutoff_not_in_items (0.00s)
    --- PASS: TestAddQualityProfile_Validation/cutoff_not_allowed (0.00s)
    --- PASS: TestAddQualityProfile_Validation/valid (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/movies	(cached)
=== RUN   TestAltTitleMatcher_MatchMovieByAltTitle
=== PAUSE TestAltTitleMatcher_MatchMovieByAltTitle
=== RUN   TestAltTitleMatcher_MatchSeriesByAltTitle
=== PAUSE TestAltTitleMatcher_MatchSeriesByAltTitle
=== RUN   TestAltTitleMatcher_NoMatch
=== PAUSE TestAltTitleMatcher_NoMatch
=== RUN   TestIsJunk
=== PAUSE TestIsJunk
=== RUN   TestCleanFolder_OnlyJunk
=== PAUSE TestCleanFolder_OnlyJunk
=== RUN   TestCleanFolder_WithRealFiles
=== PAUSE TestCleanFolder_WithRealFiles
=== RUN   TestCleanFolder_EmptyFolder
=== PAUSE TestCleanFolder_EmptyFolder
=== RUN   TestCleanFolder_NestedJunkOnly
=== PAUSE TestCleanFolder_NestedJunkOnly
=== RUN   TestDecisionMakerEvaluateCollectsRejections
=== PAUSE TestDecisionMakerEvaluateCollectsRejections
=== RUN   TestDecisionMakerEvaluateApproved
=== PAUSE TestDecisionMakerEvaluateApproved
=== RUN   TestFindExtras
=== PAUSE TestFindExtras
=== RUN   TestFindExtras_NoExtras
=== PAUSE TestFindExtras_NoExtras
=== RUN   TestImportExtra
=== PAUSE TestImportExtra
=== RUN   TestMoveFileRelocatesAndRemovesSource
--- PASS: TestMoveFileRelocatesAndRemovesSource (0.00s)
=== RUN   TestRemoveAfterCopyToleratesMissingSource
--- PASS: TestRemoveAfterCopyToleratesMissingSource (0.00s)
=== RUN   TestParseReleaseName
=== PAUSE TestParseReleaseName
=== RUN   TestCleanTitle
=== PAUSE TestCleanTitle
=== RUN   TestTitleSimilarity
=== PAUSE TestTitleSimilarity
=== RUN   TestTitleSimilarity_ExactMatch100
=== PAUSE TestTitleSimilarity_ExactMatch100
=== RUN   TestNormalise
=== PAUSE TestNormalise
=== RUN   TestSanitizeDirName
=== PAUSE TestSanitizeDirName
=== RUN   TestFuzzyMatchMovie_EmptyCandidates
=== PAUSE TestFuzzyMatchMovie_EmptyCandidates
=== RUN   TestFuzzyMatchMovie_ExactMatch
=== PAUSE TestFuzzyMatchMovie_ExactMatch
=== RUN   TestFuzzyMatchMovie_YearBoost
=== PAUSE TestFuzzyMatchMovie_YearBoost
=== RUN   TestFuzzyMatchMovie_BelowThreshold
=== PAUSE TestFuzzyMatchMovie_BelowThreshold
=== RUN   TestFuzzyMatchSeries_EmptyCandidates
=== PAUSE TestFuzzyMatchSeries_EmptyCandidates
=== RUN   TestFuzzyMatchSeries_ExactMatch
=== PAUSE TestFuzzyMatchSeries_ExactMatch
=== RUN   TestFuzzyMatchSeries_YearBoost
=== PAUSE TestFuzzyMatchSeries_YearBoost
=== RUN   TestFuzzyMatchSeries_BelowThreshold
=== PAUSE TestFuzzyMatchSeries_BelowThreshold
=== RUN   TestResolveDownloadPathPrefersExistingCandidate
=== PAUSE TestResolveDownloadPathPrefersExistingCandidate
=== RUN   TestNewPipeline_ValidatesRequiredDependencies
=== PAUSE TestNewPipeline_ValidatesRequiredDependencies
=== RUN   TestNewPipeline_DefaultImportMode
=== PAUSE TestNewPipeline_DefaultImportMode
=== RUN   TestPipelineUtilityHelpers
=== PAUSE TestPipelineUtilityHelpers
=== RUN   TestProcessImport_PathMissingRecordsFailure
=== PAUSE TestProcessImport_PathMissingRecordsFailure
=== RUN   TestRecycle_PreservesPathStructure
=== PAUSE TestRecycle_PreservesPathStructure
=== RUN   TestRecycle_DisabledDeletesFile
=== PAUSE TestRecycle_DisabledDeletesFile
=== RUN   TestNewRecycleBin_FromConfig
=== PAUSE TestNewRecycleBin_FromConfig
=== RUN   TestCleanOld_RemovesExpiredFiles
=== PAUSE TestCleanOld_RemovesExpiredFiles
=== RUN   TestAlreadyImported_RejectsKnownFile
=== PAUSE TestAlreadyImported_RejectsKnownFile
=== RUN   TestAlreadyImported_AllowsNewFile
=== PAUSE TestAlreadyImported_AllowsNewFile
=== RUN   TestAlreadyImported_AllowsFailedImport
=== PAUSE TestAlreadyImported_AllowsFailedImport
=== RUN   TestAlreadyImported_NilDB
=== PAUSE TestAlreadyImported_NilDB
=== RUN   TestUpgradeSpec_NoExistingFile_Allows
=== PAUSE TestUpgradeSpec_NoExistingFile_Allows
=== RUN   TestUpgradeSpec_HigherQuality_Allows
=== PAUSE TestUpgradeSpec_HigherQuality_Allows
=== RUN   TestUpgradeSpec_SameQuality_Rejects
=== PAUSE TestUpgradeSpec_SameQuality_Rejects
=== RUN   TestUpgradeSpec_LowerQuality_Rejects
=== PAUSE TestUpgradeSpec_LowerQuality_Rejects
=== RUN   TestUpgradeSpec_ProperSameQuality_Allows
=== PAUSE TestUpgradeSpec_ProperSameQuality_Allows
=== RUN   TestUpgradeSpec_RepackSameQuality_Allows
=== PAUSE TestUpgradeSpec_RepackSameQuality_Allows
=== RUN   TestUpgradeSpec_UpgradesDisabled_Rejects
=== PAUSE TestUpgradeSpec_UpgradesDisabled_Rejects
=== RUN   TestUpgradeSpec_NoProfile_Allows
=== PAUSE TestUpgradeSpec_NoProfile_Allows
=== RUN   TestFindSubtitles
=== PAUSE TestFindSubtitles
=== RUN   TestFindSubtitles_NoSubtitles
=== PAUSE TestFindSubtitles_NoSubtitles
=== RUN   TestExtractLanguage
=== PAUSE TestExtractLanguage
=== RUN   TestImportSubtitle
=== PAUSE TestImportSubtitle
=== RUN   TestVerify_ValidFile
=== PAUSE TestVerify_ValidFile
=== RUN   TestVerify_MissingFile
=== PAUSE TestVerify_MissingFile
=== RUN   TestVerify_WrongSize
=== PAUSE TestVerify_WrongSize
=== RUN   TestVerify_ZeroByte
=== PAUSE TestVerify_ZeroByte
=== RUN   TestVerify_SkipSizeCheck_WhenExpectedZero
=== PAUSE TestVerify_SkipSizeCheck_WhenExpectedZero
=== CONT  TestAltTitleMatcher_MatchMovieByAltTitle
=== CONT  TestNewPipeline_DefaultImportMode
=== CONT  TestVerify_MissingFile
=== CONT  TestAlreadyImported_RejectsKnownFile
--- PASS: TestVerify_MissingFile (0.00s)
=== CONT  TestVerify_ValidFile
=== CONT  TestUpgradeSpec_LowerQuality_Rejects
=== CONT  TestVerify_SkipSizeCheck_WhenExpectedZero
=== CONT  TestVerify_ZeroByte
=== CONT  TestVerify_WrongSize
--- PASS: TestUpgradeSpec_LowerQuality_Rejects (0.00s)
=== CONT  TestTitleSimilarity
=== RUN   TestTitleSimilarity/the_matrix_vs_the_matrix
--- PASS: TestVerify_ValidFile (0.00s)
=== CONT  TestFuzzyMatchMovie_YearBoost
=== RUN   TestTitleSimilarity/The_Matrix_vs_the_matrix
--- PASS: TestFuzzyMatchMovie_YearBoost (0.00s)
=== CONT  TestFuzzyMatchMovie_ExactMatch
=== RUN   TestTitleSimilarity/the_matrix_vs_matrix
--- PASS: TestFuzzyMatchMovie_ExactMatch (0.00s)
=== CONT  TestFuzzyMatchMovie_EmptyCandidates
--- PASS: TestFuzzyMatchMovie_EmptyCandidates (0.00s)
=== RUN   TestTitleSimilarity/breaking_bad_vs_breaking_bad
=== CONT  TestSanitizeDirName
=== RUN   TestSanitizeDirName/Normal_Title
=== RUN   TestTitleSimilarity/some_movie_vs_completely_different
=== RUN   TestSanitizeDirName/Title:_Subtitle
=== RUN   TestTitleSimilarity/_vs_
=== RUN   TestSanitizeDirName/What/Where
=== RUN   TestSanitizeDirName/Star*Wars
=== RUN   TestSanitizeDirName/Who?
=== CONT  TestNormalise
--- PASS: TestVerify_WrongSize (0.00s)
=== RUN   TestNormalise/The_Matrix
=== RUN   TestSanitizeDirName/He_said_"hello"
=== RUN   TestSanitizeDirName/A<B>C
=== RUN   TestTitleSimilarity/abc_vs_
=== RUN   TestSanitizeDirName/Pipe|Line
=== RUN   TestSanitizeDirName/Back\Slash
--- PASS: TestSanitizeDirName (0.00s)
    --- PASS: TestSanitizeDirName/Normal_Title (0.00s)
    --- PASS: TestSanitizeDirName/Title:_Subtitle (0.00s)
    --- PASS: TestSanitizeDirName/What/Where (0.00s)
    --- PASS: TestSanitizeDirName/Star*Wars (0.00s)
    --- PASS: TestSanitizeDirName/Who? (0.00s)
    --- PASS: TestSanitizeDirName/He_said_"hello" (0.00s)
    --- PASS: TestSanitizeDirName/A<B>C (0.00s)
    --- PASS: TestSanitizeDirName/Pipe|Line (0.00s)
    --- PASS: TestSanitizeDirName/Back\Slash (0.00s)
=== CONT  TestTitleSimilarity_ExactMatch100
--- PASS: TestTitleSimilarity (0.00s)
    --- PASS: TestTitleSimilarity/the_matrix_vs_the_matrix (0.00s)
    --- PASS: TestTitleSimilarity/The_Matrix_vs_the_matrix (0.00s)
    --- PASS: TestTitleSimilarity/the_matrix_vs_matrix (0.00s)
    --- PASS: TestTitleSimilarity/breaking_bad_vs_breaking_bad (0.00s)
    --- PASS: TestTitleSimilarity/some_movie_vs_completely_different (0.00s)
    --- PASS: TestTitleSimilarity/_vs_ (0.00s)
    --- PASS: TestTitleSimilarity/abc_vs_ (0.00s)
=== CONT  TestFuzzyMatchMovie_BelowThreshold
--- PASS: TestTitleSimilarity_ExactMatch100 (0.00s)
=== CONT  TestFindSubtitles
=== RUN   TestNormalise/Game.of.Thrones
=== RUN   TestNormalise/Mr._Robot!
=== RUN   TestNormalise/__spaces__
=== RUN   TestNormalise/123_Test
=== RUN   TestNormalise/#00
--- PASS: TestNormalise (0.00s)
    --- PASS: TestNormalise/The_Matrix (0.00s)
    --- PASS: TestNormalise/Game.of.Thrones (0.00s)
    --- PASS: TestNormalise/Mr._Robot! (0.00s)
    --- PASS: TestNormalise/__spaces__ (0.00s)
    --- PASS: TestNormalise/123_Test (0.00s)
    --- PASS: TestNormalise/#00 (0.00s)
=== CONT  TestNewPipeline_ValidatesRequiredDependencies
=== RUN   TestNewPipeline_ValidatesRequiredDependencies/missing_db
--- PASS: TestFuzzyMatchMovie_BelowThreshold (0.00s)
=== CONT  TestImportSubtitle
--- PASS: TestVerify_SkipSizeCheck_WhenExpectedZero (0.00s)
--- PASS: TestVerify_ZeroByte (0.00s)
=== CONT  TestResolveDownloadPathPrefersExistingCandidate
=== CONT  TestExtractLanguage
--- PASS: TestExtractLanguage (0.00s)
=== CONT  TestFuzzyMatchSeries_BelowThreshold
--- PASS: TestFuzzyMatchSeries_BelowThreshold (0.00s)
=== CONT  TestFindSubtitles_NoSubtitles
=== CONT  TestFuzzyMatchSeries_YearBoost
--- PASS: TestFindSubtitles_NoSubtitles (0.00s)
--- PASS: TestFuzzyMatchSeries_YearBoost (0.00s)
=== CONT  TestFuzzyMatchSeries_ExactMatch
--- PASS: TestNewPipeline_DefaultImportMode (0.00s)
=== CONT  TestFuzzyMatchSeries_EmptyCandidates
--- PASS: TestFuzzyMatchSeries_EmptyCandidates (0.00s)
=== CONT  TestDecisionMakerEvaluateCollectsRejections
--- PASS: TestDecisionMakerEvaluateCollectsRejections (0.00s)
=== CONT  TestFindExtras_NoExtras
--- PASS: TestResolveDownloadPathPrefersExistingCandidate (0.00s)
=== CONT  TestFindExtras
--- PASS: TestFuzzyMatchSeries_ExactMatch (0.00s)
=== CONT  TestImportExtra
=== RUN   TestNewPipeline_ValidatesRequiredDependencies/missing_bus
--- PASS: TestAltTitleMatcher_MatchMovieByAltTitle (0.00s)
=== CONT  TestDecisionMakerEvaluateApproved
--- PASS: TestDecisionMakerEvaluateApproved (0.00s)
=== CONT  TestCleanFolder_OnlyJunk
--- PASS: TestFindSubtitles (0.00s)
=== CONT  TestCleanTitle
=== RUN   TestCleanTitle/dots_to_spaces
=== RUN   TestCleanTitle/underscores_to_spaces
=== RUN   TestCleanTitle/quality_tags_stripped
--- PASS: TestAlreadyImported_RejectsKnownFile (0.00s)
=== CONT  TestCleanFolder_NestedJunkOnly
=== RUN   TestNewPipeline_ValidatesRequiredDependencies/missing_downloads
=== RUN   TestCleanTitle/multiple_spaces_collapsed
=== RUN   TestCleanTitle/empty_string
=== RUN   TestCleanTitle/only_quality_tags
=== RUN   TestCleanTitle/mixed_separators
=== RUN   TestCleanTitle/group_suffix_stripped
--- PASS: TestImportSubtitle (0.00s)
=== CONT  TestParseReleaseName
=== RUN   TestParseReleaseName/movie_with_year_and_quality
--- PASS: TestFindExtras_NoExtras (0.00s)
=== RUN   TestCleanTitle/multi_tag_stripped
=== CONT  TestUpgradeSpec_RepackSameQuality_Allows
--- PASS: TestUpgradeSpec_RepackSameQuality_Allows (0.00s)
=== CONT  TestUpgradeSpec_NoProfile_Allows
--- PASS: TestUpgradeSpec_NoProfile_Allows (0.00s)
=== CONT  TestCleanFolder_EmptyFolder
=== RUN   TestCleanTitle/empty_parens_removed
=== RUN   TestNewPipeline_ValidatesRequiredDependencies/missing_movies
--- PASS: TestCleanFolder_EmptyFolder (0.00s)
=== RUN   TestCleanTitle/empty_brackets_removed
--- PASS: TestCleanTitle (0.00s)
    --- PASS: TestCleanTitle/dots_to_spaces (0.00s)
    --- PASS: TestCleanTitle/underscores_to_spaces (0.00s)
    --- PASS: TestCleanTitle/quality_tags_stripped (0.00s)
    --- PASS: TestCleanTitle/multiple_spaces_collapsed (0.00s)
    --- PASS: TestCleanTitle/empty_string (0.00s)
    --- PASS: TestCleanTitle/only_quality_tags (0.00s)
    --- PASS: TestCleanTitle/mixed_separators (0.00s)
    --- PASS: TestCleanTitle/group_suffix_stripped (0.00s)
    --- PASS: TestCleanTitle/multi_tag_stripped (0.00s)
    --- PASS: TestCleanTitle/empty_parens_removed (0.00s)
    --- PASS: TestCleanTitle/empty_brackets_removed (0.00s)
=== CONT  TestUpgradeSpec_NoExistingFile_Allows
=== RUN   TestParseReleaseName/tv_show_with_S01E05
=== CONT  TestCleanFolder_WithRealFiles
=== RUN   TestNewPipeline_ValidatesRequiredDependencies/missing_series
--- PASS: TestNewPipeline_ValidatesRequiredDependencies (0.00s)
    --- PASS: TestNewPipeline_ValidatesRequiredDependencies/missing_db (0.00s)
    --- PASS: TestNewPipeline_ValidatesRequiredDependencies/missing_bus (0.00s)
    --- PASS: TestNewPipeline_ValidatesRequiredDependencies/missing_downloads (0.00s)
    --- PASS: TestNewPipeline_ValidatesRequiredDependencies/missing_movies (0.00s)
    --- PASS: TestNewPipeline_ValidatesRequiredDependencies/missing_series (0.00s)
=== CONT  TestUpgradeSpec_SameQuality_Rejects
--- PASS: TestUpgradeSpec_SameQuality_Rejects (0.00s)
=== CONT  TestUpgradeSpec_HigherQuality_Allows
--- PASS: TestUpgradeSpec_HigherQuality_Allows (0.00s)
=== CONT  TestUpgradeSpec_UpgradesDisabled_Rejects
--- PASS: TestUpgradeSpec_UpgradesDisabled_Rejects (0.00s)
=== CONT  TestProcessImport_PathMissingRecordsFailure
--- PASS: TestProcessImport_PathMissingRecordsFailure (0.00s)
--- PASS: TestCleanFolder_NestedJunkOnly (0.00s)
=== CONT  TestPipelineUtilityHelpers
=== CONT  TestRecycle_PreservesPathStructure
--- PASS: TestPipelineUtilityHelpers (0.00s)
=== CONT  TestCleanOld_RemovesExpiredFiles
--- PASS: TestCleanFolder_OnlyJunk (0.00s)
=== CONT  TestNewRecycleBin_FromConfig
--- PASS: TestNewRecycleBin_FromConfig (0.00s)
=== CONT  TestAlreadyImported_AllowsFailedImport
--- PASS: TestCleanFolder_WithRealFiles (0.00s)
=== CONT  TestRecycle_DisabledDeletesFile
=== RUN   TestParseReleaseName/tv_show_lowercase
--- PASS: TestUpgradeSpec_NoExistingFile_Allows (0.00s)
=== CONT  TestAlreadyImported_NilDB
--- PASS: TestAlreadyImported_NilDB (0.00s)
=== CONT  TestIsJunk
=== RUN   TestIsJunk/thumbs.db
=== PAUSE TestIsJunk/thumbs.db
=== RUN   TestIsJunk/ds_store
=== PAUSE TestIsJunk/ds_store
=== RUN   TestIsJunk/desktop.ini
=== PAUSE TestIsJunk/desktop.ini
=== RUN   TestIsJunk/nfo_file
=== PAUSE TestIsJunk/nfo_file
=== RUN   TestIsJunk/txt_file
=== PAUSE TestIsJunk/txt_file
=== RUN   TestIsJunk/url_file
=== PAUSE TestIsJunk/url_file
=== RUN   TestIsJunk/website_file
=== CONT  TestAltTitleMatcher_MatchSeriesByAltTitle
=== PAUSE TestIsJunk/website_file
=== RUN   TestIsJunk/case_insensitive
=== PAUSE TestIsJunk/case_insensitive
=== RUN   TestIsJunk/media_file
=== PAUSE TestIsJunk/media_file
=== RUN   TestIsJunk/subtitle
=== PAUSE TestIsJunk/subtitle
=== RUN   TestIsJunk/image
=== PAUSE TestIsJunk/image
--- PASS: TestImportExtra (0.00s)
=== CONT  TestUpgradeSpec_ProperSameQuality_Allows
--- PASS: TestUpgradeSpec_ProperSameQuality_Allows (0.00s)
=== CONT  TestAlreadyImported_AllowsNewFile
=== RUN   TestParseReleaseName/movie_with_parenthesized_year
--- PASS: TestRecycle_DisabledDeletesFile (0.00s)
=== CONT  TestAltTitleMatcher_NoMatch
=== RUN   TestParseReleaseName/simple_title_no_markers
--- PASS: TestAlreadyImported_AllowsNewFile (0.00s)
=== CONT  TestIsJunk/thumbs.db
=== CONT  TestIsJunk/image
=== CONT  TestIsJunk/subtitle
=== CONT  TestIsJunk/media_file
=== CONT  TestIsJunk/case_insensitive
=== CONT  TestIsJunk/website_file
=== CONT  TestIsJunk/url_file
=== CONT  TestIsJunk/txt_file
=== CONT  TestIsJunk/nfo_file
=== CONT  TestIsJunk/desktop.ini
=== CONT  TestIsJunk/ds_store
--- PASS: TestIsJunk (0.00s)
    --- PASS: TestIsJunk/thumbs.db (0.00s)
    --- PASS: TestIsJunk/image (0.00s)
    --- PASS: TestIsJunk/subtitle (0.00s)
    --- PASS: TestIsJunk/media_file (0.00s)
    --- PASS: TestIsJunk/case_insensitive (0.00s)
    --- PASS: TestIsJunk/website_file (0.00s)
    --- PASS: TestIsJunk/url_file (0.00s)
    --- PASS: TestIsJunk/txt_file (0.00s)
    --- PASS: TestIsJunk/nfo_file (0.00s)
    --- PASS: TestIsJunk/desktop.ini (0.00s)
    --- PASS: TestIsJunk/ds_store (0.00s)
--- PASS: TestAlreadyImported_AllowsFailedImport (0.00s)
--- PASS: TestAltTitleMatcher_MatchSeriesByAltTitle (0.00s)
=== RUN   TestParseReleaseName/movie_with_underscores_and_year
--- PASS: TestCleanOld_RemovesExpiredFiles (0.00s)
--- PASS: TestAltTitleMatcher_NoMatch (0.00s)
=== RUN   TestParseReleaseName/series_double_digit_season_episode
--- PASS: TestFindExtras (0.00s)
=== RUN   TestParseReleaseName/year_as_part_of_title_preserved
--- PASS: TestRecycle_PreservesPathStructure (0.00s)
=== RUN   TestParseReleaseName/torrent_name_with_MULTI_and_DTS
=== RUN   TestParseReleaseName/bracket_tags
=== RUN   TestParseReleaseName/web-dl_series_with_atmos
=== RUN   TestParseReleaseName/simple_name_no_year
--- PASS: TestParseReleaseName (0.01s)
    --- PASS: TestParseReleaseName/movie_with_year_and_quality (0.00s)
    --- PASS: TestParseReleaseName/tv_show_with_S01E05 (0.00s)
    --- PASS: TestParseReleaseName/tv_show_lowercase (0.00s)
    --- PASS: TestParseReleaseName/movie_with_parenthesized_year (0.00s)
    --- PASS: TestParseReleaseName/simple_title_no_markers (0.00s)
    --- PASS: TestParseReleaseName/movie_with_underscores_and_year (0.00s)
    --- PASS: TestParseReleaseName/series_double_digit_season_episode (0.00s)
    --- PASS: TestParseReleaseName/year_as_part_of_title_preserved (0.00s)
    --- PASS: TestParseReleaseName/torrent_name_with_MULTI_and_DTS (0.00s)
    --- PASS: TestParseReleaseName/bracket_tags (0.00s)
    --- PASS: TestParseReleaseName/web-dl_series_with_atmos (0.00s)
    --- PASS: TestParseReleaseName/simple_name_no_year (0.00s)
PASS
ok  	github.com/ebenderooock/loom/internal/imports	(cached)\n- ?   	github.com/ebenderooock/loom/cmd/loom	[no test files]
?   	github.com/ebenderooock/loom/internal/alttitles	[no test files]
ok  	github.com/ebenderooock/loom/internal/analytics	(cached)
ok  	github.com/ebenderooock/loom/internal/anime	(cached)
?   	github.com/ebenderooock/loom/internal/apikeys	[no test files]
?   	github.com/ebenderooock/loom/internal/appconfig	[no test files]
ok  	github.com/ebenderooock/loom/internal/auditlog	(cached)
ok  	github.com/ebenderooock/loom/internal/auth	(cached)
ok  	github.com/ebenderooock/loom/internal/autosearch	(cached)
?   	github.com/ebenderooock/loom/internal/backup	[no test files]
ok  	github.com/ebenderooock/loom/internal/bots	(cached)
ok  	github.com/ebenderooock/loom/internal/bots/discord	(cached)
ok  	github.com/ebenderooock/loom/internal/bots/telegram	(cached)
ok  	github.com/ebenderooock/loom/internal/buildinfo	(cached)
?   	github.com/ebenderooock/loom/internal/calendar	[no test files]
ok  	github.com/ebenderooock/loom/internal/cleanup	(cached)
?   	github.com/ebenderooock/loom/internal/commands	[no test files]
?   	github.com/ebenderooock/loom/internal/compat/prowlarrv1	[no test files]
?   	github.com/ebenderooock/loom/internal/compat/radarrv3	[no test files]
?   	github.com/ebenderooock/loom/internal/compat/sonarrv3	[no test files]
?   	github.com/ebenderooock/loom/internal/compat/syncprofiles	[no test files]
?   	github.com/ebenderooock/loom/internal/connect	[no test files]
ok  	github.com/ebenderooock/loom/internal/customformats	(cached)
?   	github.com/ebenderooock/loom/internal/discover	[no test files]
?   	github.com/ebenderooock/loom/internal/diskspace	[no test files]
ok  	github.com/ebenderooock/loom/internal/downloads	(cached)
?   	github.com/ebenderooock/loom/internal/downloads/builtin/null	[no test files]
ok  	github.com/ebenderooock/loom/internal/downloads/deluge	(cached)
ok  	github.com/ebenderooock/loom/internal/downloads/nzbget	(cached)
ok  	github.com/ebenderooock/loom/internal/downloads/qbittorrent	(cached)
ok  	github.com/ebenderooock/loom/internal/downloads/sabnzbd	(cached)
ok  	github.com/ebenderooock/loom/internal/downloads/torrent	(cached)
?   	github.com/ebenderooock/loom/internal/downloads/torrentutil	[no test files]
ok  	github.com/ebenderooock/loom/internal/downloads/transmission	(cached)
?   	github.com/ebenderooock/loom/internal/episodeorder	[no test files]
ok  	github.com/ebenderooock/loom/internal/featureflags	(cached)
ok  	github.com/ebenderooock/loom/internal/healthmonitor	(cached)
ok  	github.com/ebenderooock/loom/internal/importlists	(cached)
ok  	github.com/ebenderooock/loom/internal/importlists/providers	(cached)
ok  	github.com/ebenderooock/loom/internal/imports	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/cardigann	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/cloudflare	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/newznab	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/newznabserver	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/proxies	(cached)
ok  	github.com/ebenderooock/loom/internal/indexers/throttle	(cached)
ok  	github.com/ebenderooock/loom/internal/kernel/config	(cached)
ok  	github.com/ebenderooock/loom/internal/kernel/eventbus	(cached)
ok  	github.com/ebenderooock/loom/internal/kernel/logging	(cached)
ok  	github.com/ebenderooock/loom/internal/kernel/scheduler	(cached)
ok  	github.com/ebenderooock/loom/internal/kernel/telemetry	(cached)
?   	github.com/ebenderooock/loom/internal/languages	[no test files]
ok  	github.com/ebenderooock/loom/internal/libraries	(cached)
ok  	github.com/ebenderooock/loom/internal/mediafiles	(cached)
?   	github.com/ebenderooock/loom/internal/mediainfo	[no test files]
ok  	github.com/ebenderooock/loom/internal/metadata	(cached)
ok  	github.com/ebenderooock/loom/internal/metadata/musicbrainz	(cached)
ok  	github.com/ebenderooock/loom/internal/metadata/tmdb	(cached)
ok  	github.com/ebenderooock/loom/internal/metadata/tvdb	(cached)
?   	github.com/ebenderooock/loom/internal/migrate	[no test files]
ok  	github.com/ebenderooock/loom/internal/movies	(cached)
ok  	github.com/ebenderooock/loom/internal/music	(cached)
ok  	github.com/ebenderooock/loom/internal/musicsearch	(cached)
ok  	github.com/ebenderooock/loom/internal/notifications	(cached)
ok  	github.com/ebenderooock/loom/internal/organizer	(cached)
ok  	github.com/ebenderooock/loom/internal/packs	(cached)
ok  	github.com/ebenderooock/loom/internal/parser	(cached)
ok  	github.com/ebenderooock/loom/internal/plugins	(cached)
ok  	github.com/ebenderooock/loom/internal/qualityprofiles	(cached)
ok  	github.com/ebenderooock/loom/internal/requests	(cached)
ok  	github.com/ebenderooock/loom/internal/rss	(cached)
ok  	github.com/ebenderooock/loom/internal/safety	(cached)
ok  	github.com/ebenderooock/loom/internal/scanner	(cached)
ok  	github.com/ebenderooock/loom/internal/scheduler	(cached)
ok  	github.com/ebenderooock/loom/internal/searchdebug	(cached)
ok  	github.com/ebenderooock/loom/internal/series	(cached)
ok  	github.com/ebenderooock/loom/internal/server	(cached)
ok  	github.com/ebenderooock/loom/internal/storage	(cached)
?   	github.com/ebenderooock/loom/internal/storage/db/postgres	[no test files]
?   	github.com/ebenderooock/loom/internal/storage/db/sqlite	[no test files]
ok  	github.com/ebenderooock/loom/internal/systemlogs	(cached)
ok  	github.com/ebenderooock/loom/internal/validation	(cached)
ok  	github.com/ebenderooock/loom/internal/workflows	(cached)
?   	github.com/ebenderooock/loom/web	[no test files]\n- 	github.com/ebenderooock/loom/cmd/loom		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/alttitles		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/analytics	(cached)	coverage: 61.1% of statements
ok  	github.com/ebenderooock/loom/internal/anime	(cached)	coverage: 34.1% of statements
	github.com/ebenderooock/loom/internal/apikeys		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/appconfig		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/auditlog	(cached)	coverage: 15.9% of statements
ok  	github.com/ebenderooock/loom/internal/auth	(cached)	coverage: 34.8% of statements
ok  	github.com/ebenderooock/loom/internal/autosearch	(cached)	coverage: 34.9% of statements
	github.com/ebenderooock/loom/internal/backup		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/bots	(cached)	coverage: 55.1% of statements
ok  	github.com/ebenderooock/loom/internal/bots/discord	(cached)	coverage: 23.6% of statements
ok  	github.com/ebenderooock/loom/internal/bots/telegram	(cached)	coverage: 62.6% of statements
ok  	github.com/ebenderooock/loom/internal/buildinfo	(cached)	coverage: 100.0% of statements
	github.com/ebenderooock/loom/internal/calendar		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/cleanup	(cached)	coverage: 62.1% of statements
	github.com/ebenderooock/loom/internal/commands		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/compat/prowlarrv1		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/compat/radarrv3		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/compat/sonarrv3		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/compat/syncprofiles		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/connect		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/customformats	(cached)	coverage: 21.4% of statements
	github.com/ebenderooock/loom/internal/discover		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/diskspace		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/downloads	(cached)	coverage: 40.7% of statements
?   	github.com/ebenderooock/loom/internal/downloads/builtin/null	[no test files]
ok  	github.com/ebenderooock/loom/internal/downloads/deluge	(cached)	coverage: 39.9% of statements
ok  	github.com/ebenderooock/loom/internal/downloads/nzbget	(cached)	coverage: 81.0% of statements
ok  	github.com/ebenderooock/loom/internal/downloads/qbittorrent	(cached)	coverage: 72.5% of statements
ok  	github.com/ebenderooock/loom/internal/downloads/sabnzbd	(cached)	coverage: 77.4% of statements
ok  	github.com/ebenderooock/loom/internal/downloads/torrent	(cached)	coverage: 12.6% of statements
	github.com/ebenderooock/loom/internal/downloads/torrentutil		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/downloads/transmission	(cached)	coverage: 59.1% of statements
	github.com/ebenderooock/loom/internal/episodeorder		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/featureflags	(cached)	coverage: 66.7% of statements
ok  	github.com/ebenderooock/loom/internal/healthmonitor	(cached)	coverage: 59.3% of statements
ok  	github.com/ebenderooock/loom/internal/importlists	(cached)	coverage: 1.7% of statements
ok  	github.com/ebenderooock/loom/internal/importlists/providers	(cached)	coverage: 3.3% of statements
ok  	github.com/ebenderooock/loom/internal/imports	(cached)	coverage: 25.0% of statements
ok  	github.com/ebenderooock/loom/internal/indexers	(cached)	coverage: 36.5% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/cardigann	(cached)	coverage: 43.9% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/cloudflare	(cached)	coverage: 100.0% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/newznab	(cached)	coverage: 76.3% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/newznabserver	(cached)	coverage: 89.8% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/proxies	(cached)	coverage: 51.4% of statements
ok  	github.com/ebenderooock/loom/internal/indexers/throttle	(cached)	coverage: 79.4% of statements
ok  	github.com/ebenderooock/loom/internal/kernel/config	(cached)	coverage: 78.1% of statements
ok  	github.com/ebenderooock/loom/internal/kernel/eventbus	(cached)	coverage: 94.7% of statements
ok  	github.com/ebenderooock/loom/internal/kernel/logging	(cached)	coverage: 54.7% of statements
ok  	github.com/ebenderooock/loom/internal/kernel/scheduler	(cached)	coverage: 73.1% of statements
ok  	github.com/ebenderooock/loom/internal/kernel/telemetry	(cached)	coverage: 35.3% of statements
	github.com/ebenderooock/loom/internal/languages		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/libraries	(cached)	coverage: 27.8% of statements
ok  	github.com/ebenderooock/loom/internal/mediafiles	(cached)	coverage: 25.0% of statements
	github.com/ebenderooock/loom/internal/mediainfo		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/metadata	(cached)	coverage: 30.0% of statements
ok  	github.com/ebenderooock/loom/internal/metadata/musicbrainz	(cached)	coverage: 45.8% of statements
ok  	github.com/ebenderooock/loom/internal/metadata/tmdb	(cached)	coverage: 61.8% of statements
ok  	github.com/ebenderooock/loom/internal/metadata/tvdb	(cached)	coverage: 71.0% of statements
	github.com/ebenderooock/loom/internal/migrate		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/movies	(cached)	coverage: 18.0% of statements
ok  	github.com/ebenderooock/loom/internal/music	(cached)	coverage: 47.0% of statements
ok  	github.com/ebenderooock/loom/internal/musicsearch	(cached)	coverage: 32.0% of statements
ok  	github.com/ebenderooock/loom/internal/notifications	(cached)	coverage: 20.7% of statements
ok  	github.com/ebenderooock/loom/internal/organizer	(cached)	coverage: 38.0% of statements
ok  	github.com/ebenderooock/loom/internal/packs	(cached)	coverage: 65.2% of statements
ok  	github.com/ebenderooock/loom/internal/parser	(cached)	coverage: 95.4% of statements
ok  	github.com/ebenderooock/loom/internal/plugins	(cached)	coverage: 69.5% of statements
ok  	github.com/ebenderooock/loom/internal/qualityprofiles	(cached)	coverage: 10.3% of statements
ok  	github.com/ebenderooock/loom/internal/requests	(cached)	coverage: 53.0% of statements
ok  	github.com/ebenderooock/loom/internal/rss	(cached)	coverage: 50.8% of statements
ok  	github.com/ebenderooock/loom/internal/safety	(cached)	coverage: 15.6% of statements
ok  	github.com/ebenderooock/loom/internal/scanner	(cached)	coverage: 2.7% of statements
ok  	github.com/ebenderooock/loom/internal/scheduler	(cached)	coverage: 7.0% of statements
ok  	github.com/ebenderooock/loom/internal/searchdebug	(cached)	coverage: 50.2% of statements
ok  	github.com/ebenderooock/loom/internal/series	(cached)	coverage: 13.5% of statements
ok  	github.com/ebenderooock/loom/internal/server	(cached)	coverage: 29.4% of statements
ok  	github.com/ebenderooock/loom/internal/storage	(cached)	coverage: 39.3% of statements
	github.com/ebenderooock/loom/internal/storage/db/postgres		coverage: 0.0% of statements
	github.com/ebenderooock/loom/internal/storage/db/sqlite		coverage: 0.0% of statements
ok  	github.com/ebenderooock/loom/internal/systemlogs	(cached)	coverage: 20.0% of statements
ok  	github.com/ebenderooock/loom/internal/validation	(cached)	coverage: 58.8% of statements
ok  	github.com/ebenderooock/loom/internal/workflows	(cached)	coverage: 43.3% of statements
?   	github.com/ebenderooock/loom/web	[no test files]
total:											(statements)				32.5%\n\n## Coverage\n- total coverage: **32.5%** (up from ~30.5%)