### PR TITLE
feat(testing): dev test mode with external API stubs

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /loom ./cmd/loom
+
+FROM alpine:3.20
+RUN apk add --no-cache curl
+COPY --from=builder /loom /usr/local/bin/loom
+EXPOSE 1925
+CMD ["loom", "serve", "-dev", "-addr", ":1925"]

--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -35,7 +35,7 @@ var defaultTVDBKey string
 // buildMoviesService constructs the movies.Service backed by the storage
 // engine in cfg and returns the wired service together with the metadata
 // service it uses (shared with the request bots for catalog search).
-func buildMoviesService(ctx context.Context, _ *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus, stubs *devmode.Stubs) (movies.Service, *metadata.Service, error) {
+func buildMoviesService(ctx context.Context, _ *config.Config, db storage.DB, _ *slog.Logger, bus eventbus.Bus, stubs *devmode.Stubs) (movies.Service, *metadata.Service, error) { //nolint:unparam // error return kept for caller symmetry
 	repo := movies.NewRepository(db.DB())
 
 	// Build metadata service with TMDB provider

--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -35,7 +35,7 @@ var defaultTVDBKey string
 // buildMoviesService constructs the movies.Service backed by the storage
 // engine in cfg and returns the wired service together with the metadata
 // service it uses (shared with the request bots for catalog search).
-func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus, stubs *devmode.Stubs) (movies.Service, *metadata.Service, error) {
+func buildMoviesService(ctx context.Context, _ *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus, stubs *devmode.Stubs) (movies.Service, *metadata.Service, error) {
 	repo := movies.NewRepository(db.DB())
 
 	// Build metadata service with TMDB provider
@@ -63,7 +63,7 @@ func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, 
 }
 
 // buildScanner constructs the library scanner backed by the movies service.
-func buildScanner(moviesSvc movies.Service, cfg *config.Config, auditLogger *auditlog.Logger, logger *slog.Logger, stubs *devmode.Stubs) *scanner.Scanner {
+func buildScanner(moviesSvc movies.Service, _ *config.Config, auditLogger *auditlog.Logger, logger *slog.Logger, stubs *devmode.Stubs) *scanner.Scanner {
 	apiKey := os.Getenv("LOOM_TMDB_API_KEY")
 	if apiKey == "" {
 		apiKey = defaultTMDBKey

--- a/cmd/loom/movies.go
+++ b/cmd/loom/movies.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/ebenderooock/loom/internal/auditlog"
+	"github.com/ebenderooock/loom/internal/devmode"
 	"github.com/ebenderooock/loom/internal/kernel/config"
 	"github.com/ebenderooock/loom/internal/kernel/eventbus"
 	"github.com/ebenderooock/loom/internal/libraries"
@@ -34,7 +35,7 @@ var defaultTVDBKey string
 // buildMoviesService constructs the movies.Service backed by the storage
 // engine in cfg and returns the wired service together with the metadata
 // service it uses (shared with the request bots for catalog search).
-func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus) (movies.Service, *metadata.Service, error) {
+func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, logger *slog.Logger, bus eventbus.Bus, stubs *devmode.Stubs) (movies.Service, *metadata.Service, error) {
 	repo := movies.NewRepository(db.DB())
 
 	// Build metadata service with TMDB provider
@@ -43,9 +44,11 @@ func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, 
 		apiKey = defaultTMDBKey
 	}
 
-	tmdbClient := tmdb.NewClient(tmdb.Config{
-		APIKey: apiKey,
-	})
+	tmdbCfg := tmdb.Config{APIKey: apiKey}
+	if stubs != nil {
+		tmdbCfg.BaseURL = stubs.TMDbURL
+	}
+	tmdbClient := tmdb.NewClient(tmdbCfg)
 	tmdbProvider := tmdb.NewProvider(tmdbClient)
 
 	metadataRepo := metadata.NewSQLiteRepository(db.DB())
@@ -60,13 +63,17 @@ func buildMoviesService(ctx context.Context, cfg *config.Config, db storage.DB, 
 }
 
 // buildScanner constructs the library scanner backed by the movies service.
-func buildScanner(moviesSvc movies.Service, cfg *config.Config, auditLogger *auditlog.Logger, logger *slog.Logger) *scanner.Scanner {
+func buildScanner(moviesSvc movies.Service, cfg *config.Config, auditLogger *auditlog.Logger, logger *slog.Logger, stubs *devmode.Stubs) *scanner.Scanner {
 	apiKey := os.Getenv("LOOM_TMDB_API_KEY")
 	if apiKey == "" {
 		apiKey = defaultTMDBKey
 	}
 
-	tmdbClient := tmdb.NewClient(tmdb.Config{APIKey: apiKey})
+	tmdbCfg := tmdb.Config{APIKey: apiKey}
+	if stubs != nil {
+		tmdbCfg.BaseURL = stubs.TMDbURL
+	}
+	tmdbClient := tmdb.NewClient(tmdbCfg)
 	tmdbProvider := tmdb.NewProvider(tmdbClient)
 
 	metaSearcher := &metadataSearcherAdapter{provider: tmdbProvider}
@@ -97,7 +104,7 @@ func buildOrganizer(moviesSvc movies.Service, libStore *libraries.Store, db stor
 }
 
 // buildSeriesService constructs the TV series service.
-func buildSeriesService(db storage.DB) series.Service {
+func buildSeriesService(db storage.DB, stubs *devmode.Stubs) series.Service {
 	apiKey := os.Getenv("LOOM_TMDB_API_KEY")
 	if apiKey == "" {
 		apiKey = defaultTMDBKey
@@ -112,11 +119,19 @@ func buildSeriesService(db storage.DB) series.Service {
 	if tvdbKey == "" {
 		tvdbKey = defaultTVDBKey
 	}
+	// In dev mode, always wire TVDB with a placeholder key so the stub is used.
+	if stubs != nil && tvdbKey == "" {
+		tvdbKey = "dev-key"
+	}
 	if tvdbKey != "" {
-		client := tvdb.NewClient(tvdb.Config{
+		tvdbCfg := tvdb.Config{
 			APIKey: tvdbKey,
 			PIN:    os.Getenv("LOOM_METADATA_TVDB_PIN"),
-		})
+		}
+		if stubs != nil {
+			tvdbCfg.BaseURL = stubs.TVDbURL
+		}
+		client := tvdb.NewClient(tvdbCfg)
 		seasonType := os.Getenv("LOOM_METADATA_TVDB_SEASON_TYPE")
 		if seasonType == "" {
 			seasonType = "official"
@@ -141,10 +156,14 @@ func buildNotificationsService(db storage.DB) notifications.Service {
 }
 
 // buildTMDBClient constructs a TMDB API client using the configured key.
-func buildTMDBClient() *tmdb.Client {
+func buildTMDBClient(stubs *devmode.Stubs) *tmdb.Client {
 	apiKey := os.Getenv("LOOM_TMDB_API_KEY")
 	if apiKey == "" {
 		apiKey = defaultTMDBKey
 	}
-	return tmdb.NewClient(tmdb.Config{APIKey: apiKey})
+	cfg := tmdb.Config{APIKey: apiKey}
+	if stubs != nil {
+		cfg.BaseURL = stubs.TMDbURL
+	}
+	return tmdb.NewClient(cfg)
 }

--- a/cmd/loom/serve.go
+++ b/cmd/loom/serve.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ebenderooock/loom/internal/auditlog"
 	"github.com/ebenderooock/loom/internal/backup"
 	"github.com/ebenderooock/loom/internal/customformats"
+	"github.com/ebenderooock/loom/internal/devmode"
 	"github.com/ebenderooock/loom/internal/featureflags"
 	"github.com/ebenderooock/loom/internal/kernel/config"
 	"github.com/ebenderooock/loom/internal/kernel/eventbus"
@@ -37,8 +38,18 @@ func cmdServe(ctx context.Context, args []string) error {
 	configPath := fs.String("config", "", "path to loom.yaml (overrides $LOOM_CONFIG_DIR/loom.yaml)")
 	addr := fs.String("addr", "", "HTTP listen address (e.g. :1925); overrides config")
 	logLevel := fs.String("log-level", "", "log level: debug|info|warn|error")
+	devMode := fs.Bool("dev", false, "run in dev test mode: stubs all external APIs, uses in-memory SQLite")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// Start dev stubs before loading config so we can override storage/keys.
+	var stubs *devmode.Stubs
+	if *devMode {
+		var stopStubs func()
+		stubs, stopStubs = devmode.Start()
+		defer stopStubs()
+		fmt.Println("🧪 DEV TEST MODE ACTIVE — all external APIs are stubbed")
 	}
 
 	cfg, err := config.Load(*configPath)
@@ -50,6 +61,16 @@ func cmdServe(ctx context.Context, args []string) error {
 	}
 	if *logLevel != "" {
 		cfg.Log.Level = *logLevel
+	}
+
+	// In dev mode, force in-memory SQLite and suppress API key requirements.
+	if *devMode {
+		cfg.Storage.Engine = "sqlite"
+		cfg.Storage.SQLite.Path = ":memory:"
+		// Provide placeholder API keys so builders don't fall through to env.
+		if os.Getenv("LOOM_TMDB_API_KEY") == "" {
+			os.Setenv("LOOM_TMDB_API_KEY", "dev-key") //nolint:errcheck
+		}
 	}
 
 	logger, err := logging.New(cfg.Log)
@@ -172,7 +193,7 @@ func cmdServe(ctx context.Context, args []string) error {
 	// Create the shared event bus before server and services that need it.
 	bus := eventbus.NewInProc()
 
-	moviesSvc, metadataSvc, err := buildMoviesService(ctx, cfg, db, logger, bus)
+	moviesSvc, metadataSvc, err := buildMoviesService(ctx, cfg, db, logger, bus, stubs)
 	if err != nil {
 		return fmt.Errorf("init movies: %w", err)
 	}
@@ -222,7 +243,7 @@ func cmdServe(ctx context.Context, args []string) error {
 	wiring.FeatureFlags.Load(ctx)
 
 	// Wire media services (scanner, organizer, series, libraries, etc.)
-	media, err := wireMedia(ctx, cfg, db, &wiring, moviesSvc, auditLogger, logger)
+	media, err := wireMedia(ctx, cfg, db, &wiring, moviesSvc, auditLogger, logger, stubs)
 	if err != nil {
 		return fmt.Errorf("wire media: %w", err)
 	}

--- a/cmd/loom/wire_media.go
+++ b/cmd/loom/wire_media.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ebenderooock/loom/internal/anime"
 	"github.com/ebenderooock/loom/internal/auditlog"
 	"github.com/ebenderooock/loom/internal/calendar"
+	"github.com/ebenderooock/loom/internal/devmode"
 	"github.com/ebenderooock/loom/internal/discover"
 	"github.com/ebenderooock/loom/internal/importlists"
 	"github.com/ebenderooock/loom/internal/kernel/config"
@@ -53,12 +54,13 @@ func wireMedia(
 	moviesSvc movies.Service,
 	auditLogger *auditlog.Logger,
 	logger *slog.Logger,
+	stubs *devmode.Stubs,
 ) (*mediaWiring, error) {
 	// Libraries store — needed by scanner, organizer, imports, health monitor.
 	libStore := libraries.NewStore(db.DB())
 
 	// Library scanner
-	scannerSvc := buildScanner(moviesSvc, cfg, auditLogger, logger)
+	scannerSvc := buildScanner(moviesSvc, cfg, auditLogger, logger, stubs)
 	wiring.ScannerService = scannerSvc
 
 	// File organizer
@@ -69,14 +71,18 @@ func wireMedia(
 	wiring.OrganizerService = organizerSvc
 
 	// TV series
-	seriesSvc := buildSeriesService(db)
+	seriesSvc := buildSeriesService(db, stubs)
 	wiring.SeriesService = seriesSvc
 
 	seriesScannerSvc := buildSeriesScanner(seriesSvc, logger)
 	wiring.SeriesScanner = seriesScannerSvc
 
 	// Music (artists/albums/tracks) — MusicBrainz metadata provider.
-	mbProvider := musicbrainz.NewProvider(musicbrainz.NewClient(musicbrainz.DefaultConfig()))
+	mbCfg := musicbrainz.DefaultConfig()
+	if stubs != nil {
+		mbCfg.BaseURL = stubs.MusicBrainzURL
+	}
+	mbProvider := musicbrainz.NewProvider(musicbrainz.NewClient(mbCfg))
 	musicRepo := music.NewRepository(db.DB())
 	musicSvc := music.NewService(musicRepo, mbProvider, logger)
 	wiring.MusicService = musicSvc
@@ -145,7 +151,7 @@ func wireMedia(
 	importListSyncMgr.SetSeriesService(seriesSvc)
 	importListSyncMgr.SetMusicService(musicSvc)
 	importListSyncMgr.SetLibraryService(libStore)
-	importListSyncMgr.SetTMDBClient(buildTMDBClient())
+	importListSyncMgr.SetTMDBClient(buildTMDBClient(stubs))
 	wiring.ImportListStore = importListStore
 	wiring.ImportListSync = importListSyncMgr
 
@@ -166,7 +172,7 @@ func wireMedia(
 	qualityprofiles.SeedDefaults(ctx, qpStore, moviesSvc)
 
 	// Person discovery (TMDB-backed)
-	discoverTMDB := buildTMDBClient()
+	discoverTMDB := buildTMDBClient(stubs)
 	wiring.DiscoverRouter = discover.Router(discoverTMDB)
 
 	return &mediaWiring{

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+services:
+  loom:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    ports:
+      - "1925:1925"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:1925/healthz"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    depends_on:
+      loom:
+        condition: service_healthy
+    environment:
+      - LOOM_TEST_URL=http://loom:1925
+    command: ["go", "test", "-v", "-tags", "integration", "./internal/integration/..."]

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -1,0 +1,217 @@
+package devmode
+
+import (
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+)
+
+//go:embed testdata
+var fixtures embed.FS
+
+// Stubs holds the base URLs of all running stub servers. Pass the fields
+// into the corresponding client Config structs to redirect outbound calls.
+type Stubs struct {
+	TMDbURL        string
+	TVDbURL        string
+	MusicBrainzURL string
+}
+
+// Start starts all stub servers and returns their base URLs plus a stop
+// function. Callers must call stop() (typically via defer) when done.
+func Start() (*Stubs, func()) {
+	tmdb := newTMDbServer()
+	tvdb := newTVDbServer()
+	mb := newMusicBrainzServer()
+
+	stop := func() {
+		tmdb.Close()
+		tvdb.Close()
+		mb.Close()
+	}
+
+	return &Stubs{
+		TMDbURL:        tmdb.URL,
+		TVDbURL:        tvdb.URL,
+		MusicBrainzURL: mb.URL,
+	}, stop
+}
+
+// fixture reads a testdata file and returns its bytes. Panics on missing
+// files so misconfigured stubs fail loudly at startup.
+func fixture(name string) []byte {
+	b, err := fs.ReadFile(fixtures, "testdata/"+name)
+	if err != nil {
+		panic("devmode: missing fixture " + name + ": " + err.Error())
+	}
+	return b
+}
+
+// writeJSON writes a JSON body with status 200.
+func writeJSON(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// newTMDbServer returns a stub that handles the TMDb v3 endpoints used by
+// internal/metadata/tmdb.
+func newTMDbServer() *httptest.Server {
+	mux := http.NewServeMux()
+
+	// /movie/{id} and /movie/{id}/credits and /movie/{id}/release_dates
+	mux.HandleFunc("/movie/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, "/credits"):
+			writeJSON(w, fixture("tmdb_credits.json"))
+		case strings.HasSuffix(path, "/release_dates"):
+			writeJSON(w, fixture("tmdb_release_dates.json"))
+		default:
+			writeJSON(w, fixture("tmdb_movie.json"))
+		}
+	})
+
+	// /tv/{id} and /tv/{id}/season/{s}/episode/{e}
+	mux.HandleFunc("/tv/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("tmdb_tv.json"))
+	})
+
+	// /search/movie
+	mux.HandleFunc("/search/movie", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("tmdb_search_movie.json"))
+	})
+
+	// /search/tv
+	mux.HandleFunc("/search/tv", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("tmdb_search_tv.json"))
+	})
+
+	// /person/{id}
+	mux.HandleFunc("/person/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":                    1,
+			"name":                  "Dev Person",
+			"biography":             "",
+			"profile_path":          "",
+			"known_for_department":  "Acting",
+		})
+	})
+
+	// /configuration — some clients call this for image base URLs
+	mux.HandleFunc("/configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"images": map[string]interface{}{
+				"base_url":        "http://image.tmdb.org/t/p/",
+				"secure_base_url": "https://image.tmdb.org/t/p/",
+				"poster_sizes":    []string{"w92", "w154", "w185", "w342", "w500", "w780", "original"},
+			},
+		})
+	})
+
+	// Catch-all: return empty 200 so unknown endpoints don't crash startup.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// newTVDbServer returns a stub that handles the TVDb v4 endpoints used by
+// internal/metadata/tvdb.
+func newTVDbServer() *httptest.Server {
+	mux := http.NewServeMux()
+
+	// POST /login
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("tvdb_login.json"))
+	})
+
+	// /series/{id}/episodes/{season-type}
+	mux.HandleFunc("/series/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/episodes/") {
+			writeJSON(w, fixture("tvdb_episodes.json"))
+			return
+		}
+		writeJSON(w, fixture("tvdb_series.json"))
+	})
+
+	// /search
+	mux.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("tvdb_search.json"))
+	})
+
+	// Catch-all
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// newMusicBrainzServer returns a stub that handles the MusicBrainz WS2
+// endpoints used by internal/metadata/musicbrainz.
+func newMusicBrainzServer() *httptest.Server {
+	mux := http.NewServeMux()
+
+	// /artist/{mbid} or /artist?query=...
+	mux.HandleFunc("/artist", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("query") != "" {
+			writeJSON(w, fixture("musicbrainz_search_artist.json"))
+			return
+		}
+		writeJSON(w, fixture("musicbrainz_artist.json"))
+	})
+	mux.HandleFunc("/artist/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("musicbrainz_artist.json"))
+	})
+
+	// /release/{mbid} or /release?query=...
+	mux.HandleFunc("/release", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("query") != "" {
+			// Return search response shape
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"count":    1,
+				"offset":   0,
+				"releases": []interface{}{json.RawMessage(fixture("musicbrainz_release.json"))},
+			})
+			return
+		}
+		writeJSON(w, fixture("musicbrainz_release.json"))
+	})
+	mux.HandleFunc("/release/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, fixture("musicbrainz_release.json"))
+	})
+
+	// /recording/{mbid}
+	mux.HandleFunc("/recording/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":    "rec-001",
+			"title": "Dev Recording",
+		})
+	})
+
+	// Catch-all
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	return httptest.NewServer(mux)
+}

--- a/internal/devmode/devmode.go
+++ b/internal/devmode/devmode.go
@@ -95,11 +95,11 @@ func newTMDbServer() *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"id":                    1,
-			"name":                  "Dev Person",
-			"biography":             "",
-			"profile_path":          "",
-			"known_for_department":  "Acting",
+			"id":                   1,
+			"name":                 "Dev Person",
+			"biography":            "",
+			"profile_path":         "",
+			"known_for_department": "Acting",
 		})
 	})
 

--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -159,8 +159,9 @@ func TestStopClosesServers(t *testing.T) {
 	client := &http.Client{Timeout: 1 * time.Second}
 	ctx := context.Background()
 	req, _ := http.NewRequestWithContext(ctx, "GET", tmdbURL+"/movie/1", nil)
-	_, err := client.Do(req)
+	resp, err := client.Do(req)
 	if err == nil {
+		resp.Body.Close()
 		t.Error("expected error after stop, got nil")
 	}
 }

--- a/internal/devmode/devmode_test.go
+++ b/internal/devmode/devmode_test.go
@@ -1,0 +1,177 @@
+package devmode_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ebenderooock/loom/internal/devmode"
+)
+
+func TestStartReturnsValidURLs(t *testing.T) {
+	stubs, stop := devmode.Start()
+	defer stop()
+
+	if stubs == nil {
+		t.Fatal("Start() returned nil stubs")
+	}
+	for _, u := range []string{stubs.TMDbURL, stubs.TVDbURL, stubs.MusicBrainzURL} {
+		if !strings.HasPrefix(u, "http://127.0.0.1:") {
+			t.Errorf("expected localhost URL, got %q", u)
+		}
+	}
+}
+
+func TestTMDbStub(t *testing.T) {
+	stubs, stop := devmode.Start()
+	defer stop()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantKey string
+	}{
+		{"movie by id", "/movie/550", "id"},
+		{"tv by id", "/tv/1396", "id"},
+		{"search movie", "/search/movie?query=fight", "results"},
+		{"search tv", "/search/tv?query=breaking", "results"},
+		{"movie credits", "/movie/550/credits", "cast"},
+		{"configuration", "/configuration", "images"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(ctx, "GET", stubs.TMDbURL+tc.path, nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d", resp.StatusCode)
+			}
+			var body map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if _, ok := body[tc.wantKey]; !ok {
+				t.Errorf("expected key %q in response, keys: %v", tc.wantKey, keys(body))
+			}
+		})
+	}
+}
+
+func TestTVDbStub(t *testing.T) {
+	stubs, stop := devmode.Start()
+	defer stop()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		wantKey string
+	}{
+		{"login", "POST", "/login", "data"},
+		{"series by id", "GET", "/series/81189", "data"},
+		{"series episodes", "GET", "/series/81189/episodes/official", "data"},
+		{"search", "GET", "/search?query=breaking+bad&type=series", "data"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(ctx, tc.method, stubs.TVDbURL+tc.path, nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d for %s %s", resp.StatusCode, tc.method, tc.path)
+			}
+			var body map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if _, ok := body[tc.wantKey]; !ok {
+				t.Errorf("expected key %q in response, keys: %v", tc.wantKey, keys(body))
+			}
+		})
+	}
+}
+
+func TestMusicBrainzStub(t *testing.T) {
+	stubs, stop := devmode.Start()
+	defer stop()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantKey string
+	}{
+		{"artist by mbid", "/artist/f27ec8db-af05-4f36-916e-3d57f91ecf5e?fmt=json", "id"},
+		{"artist search", "/artist?fmt=json&query=jackson", "count"},
+		{"release by mbid", "/release/1d022e01-4da6-387b-8658-8678046e4cef?fmt=json", "id"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(ctx, "GET", stubs.MusicBrainzURL+tc.path, nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200, got %d for %s", resp.StatusCode, tc.path)
+			}
+			var body map[string]interface{}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if _, ok := body[tc.wantKey]; !ok {
+				t.Errorf("expected key %q in response, keys: %v", tc.wantKey, keys(body))
+			}
+		})
+	}
+}
+
+func TestStopClosesServers(t *testing.T) {
+	stubs, stop := devmode.Start()
+	tmdbURL := stubs.TMDbURL
+	stop()
+
+	client := &http.Client{Timeout: 1 * time.Second}
+	ctx := context.Background()
+	req, _ := http.NewRequestWithContext(ctx, "GET", tmdbURL+"/movie/1", nil)
+	_, err := client.Do(req)
+	if err == nil {
+		t.Error("expected error after stop, got nil")
+	}
+}
+
+func keys(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Ensure fmt is used (IDE satisfaction)
+var _ = fmt.Sprintf

--- a/internal/devmode/doc.go
+++ b/internal/devmode/doc.go
@@ -1,0 +1,5 @@
+// Package devmode provides embedded HTTP stub servers for all Loom external
+// dependencies. When active, every outbound API call is served by a local
+// httptest.Server returning canned fixture responses so the app runs fully
+// without network access or API keys.
+package devmode

--- a/internal/devmode/testdata/musicbrainz_artist.json
+++ b/internal/devmode/testdata/musicbrainz_artist.json
@@ -1,0 +1,11 @@
+{
+  "id": "f27ec8db-af05-4f36-916e-3d57f91ecf5e",
+  "name": "Michael Jackson",
+  "sort-name": "Jackson, Michael",
+  "disambiguation": "King of Pop",
+  "country": "US",
+  "genres": [
+    {"count": 10, "name": "pop"},
+    {"count": 8, "name": "r&b"}
+  ]
+}

--- a/internal/devmode/testdata/musicbrainz_release.json
+++ b/internal/devmode/testdata/musicbrainz_release.json
@@ -1,0 +1,32 @@
+{
+  "id": "1d022e01-4da6-387b-8658-8678046e4cef",
+  "title": "Thriller",
+  "status": "Official",
+  "date": "1982-11-30",
+  "artist-credit": [
+    {
+      "id": "f27ec8db-af05-4f36-916e-3d57f91ecf5e",
+      "name": "Michael Jackson"
+    }
+  ],
+  "media": [
+    {
+      "format": "CD",
+      "position": "1",
+      "tracks": [
+        {
+          "id": "track-001",
+          "position": "1",
+          "number": "1",
+          "title": "Wanna Be Startin' Somethin'",
+          "length": 363000
+        }
+      ]
+    }
+  ],
+  "release-group": {
+    "id": "rg-001",
+    "title": "Thriller",
+    "primary-type": "Album"
+  }
+}

--- a/internal/devmode/testdata/musicbrainz_search_artist.json
+++ b/internal/devmode/testdata/musicbrainz_search_artist.json
@@ -1,0 +1,16 @@
+{
+  "count": 1,
+  "offset": 0,
+  "artists": [
+    {
+      "id": "f27ec8db-af05-4f36-916e-3d57f91ecf5e",
+      "name": "Michael Jackson",
+      "sort-name": "Jackson, Michael",
+      "disambiguation": "King of Pop",
+      "country": "US",
+      "genres": [
+        {"count": 10, "name": "pop"}
+      ]
+    }
+  ]
+}

--- a/internal/devmode/testdata/tmdb_credits.json
+++ b/internal/devmode/testdata/tmdb_credits.json
@@ -1,0 +1,30 @@
+{
+  "id": 550,
+  "cast": [
+    {
+      "id": 819,
+      "name": "Edward Norton",
+      "character": "The Narrator",
+      "profile_path": "/huCqFy6VXhQHfp5nIcjRTFRITsb.jpg",
+      "order": 0,
+      "known_for_department": "Acting"
+    },
+    {
+      "id": 287,
+      "name": "Brad Pitt",
+      "character": "Tyler Durden",
+      "profile_path": "/cckcYc2v0yh1tc9QjRelptcOBko.jpg",
+      "order": 1,
+      "known_for_department": "Acting"
+    }
+  ],
+  "crew": [
+    {
+      "id": 7467,
+      "name": "David Fincher",
+      "job": "Director",
+      "department": "Directing",
+      "profile_path": "/tpEczFclQZeKAiCeKZZ0adRvtfz.jpg"
+    }
+  ]
+}

--- a/internal/devmode/testdata/tmdb_movie.json
+++ b/internal/devmode/testdata/tmdb_movie.json
@@ -1,0 +1,19 @@
+{
+  "id": 550,
+  "imdb_id": "tt0137523",
+  "title": "Fight Club",
+  "release_date": "1999-10-15",
+  "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy.",
+  "poster_path": "/a26cQPRhJPX6GbWfQbvZdrrp9j9.jpg",
+  "runtime": 139,
+  "vote_average": 8.8,
+  "genres": [
+    {"id": 18, "name": "Drama"},
+    {"id": 53, "name": "Thriller"}
+  ],
+  "external_ids": {
+    "imdb_id": "tt0137523",
+    "tvdb_id": 0,
+    "id": 550
+  }
+}

--- a/internal/devmode/testdata/tmdb_release_dates.json
+++ b/internal/devmode/testdata/tmdb_release_dates.json
@@ -1,0 +1,20 @@
+{
+  "id": 550,
+  "results": [
+    {
+      "iso_3166_1": "US",
+      "release_dates": [
+        {
+          "type": 3,
+          "release_date": "1999-10-15T00:00:00.000Z",
+          "certification": "R"
+        },
+        {
+          "type": 4,
+          "release_date": "2000-02-29T00:00:00.000Z",
+          "certification": "R"
+        }
+      ]
+    }
+  ]
+}

--- a/internal/devmode/testdata/tmdb_search_movie.json
+++ b/internal/devmode/testdata/tmdb_search_movie.json
@@ -1,0 +1,25 @@
+{
+  "results": [
+    {
+      "id": 550,
+      "title": "Fight Club",
+      "release_date": "1999-10-15",
+      "overview": "A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression.",
+      "poster_path": "/a26cQPRhJPX6GbWfQbvZdrrp9j9.jpg",
+      "vote_average": 8.8,
+      "media_type": "movie"
+    },
+    {
+      "id": 807,
+      "title": "Se7en",
+      "release_date": "1995-09-22",
+      "overview": "Two detectives, a rookie and a veteran, hunt a serial killer who uses the seven deadly sins.",
+      "poster_path": "/69Sns8WoET6CfaYlIkHbla4l7nC.jpg",
+      "vote_average": 8.6,
+      "media_type": "movie"
+    }
+  ],
+  "total_pages": 1,
+  "total_results": 2,
+  "page": 1
+}

--- a/internal/devmode/testdata/tmdb_search_tv.json
+++ b/internal/devmode/testdata/tmdb_search_tv.json
@@ -1,0 +1,16 @@
+{
+  "results": [
+    {
+      "id": 1396,
+      "name": "Breaking Bad",
+      "first_air_date": "2008-01-20",
+      "overview": "A high school chemistry teacher turned methamphetamine manufacturer.",
+      "poster_path": "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg",
+      "vote_average": 8.9,
+      "media_type": "tv"
+    }
+  ],
+  "total_pages": 1,
+  "total_results": 1,
+  "page": 1
+}

--- a/internal/devmode/testdata/tmdb_tv.json
+++ b/internal/devmode/testdata/tmdb_tv.json
@@ -1,0 +1,18 @@
+{
+  "id": 1396,
+  "name": "Breaking Bad",
+  "first_air_date": "2008-01-20",
+  "overview": "A high school chemistry teacher turned methamphetamine manufacturer.",
+  "poster_path": "/ggFHVNu6YYI5L9pCfOacjizRGt.jpg",
+  "vote_average": 8.9,
+  "number_of_seasons": 5,
+  "genres": [
+    {"id": 18, "name": "Drama"},
+    {"id": 80, "name": "Crime"}
+  ],
+  "external_ids": {
+    "imdb_id": "tt0903747",
+    "tvdb_id": 81189,
+    "id": 1396
+  }
+}

--- a/internal/devmode/testdata/tvdb_episodes.json
+++ b/internal/devmode/testdata/tvdb_episodes.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "episodes": [
+      {
+        "id": 349232,
+        "name": "Pilot",
+        "overview": "Walter White, a struggling high school chemistry teacher diagnosed with inoperable lung cancer.",
+        "aired": "2008-01-20",
+        "runtime": 58,
+        "seasonNumber": 1,
+        "number": 1,
+        "absoluteNumber": 1
+      },
+      {
+        "id": 349233,
+        "name": "Cat's in the Bag",
+        "overview": "Walt and Jesse attempt to dispose of the bodies of two rivals they killed.",
+        "aired": "2008-01-27",
+        "runtime": 48,
+        "seasonNumber": 1,
+        "number": 2,
+        "absoluteNumber": 2
+      }
+    ]
+  },
+  "links": {
+    "prev": "",
+    "self": "/series/81189/episodes/official?page=0",
+    "next": "",
+    "total_items": 2,
+    "page_size": 100
+  }
+}

--- a/internal/devmode/testdata/tvdb_login.json
+++ b/internal/devmode/testdata/tvdb_login.json
@@ -1,0 +1,6 @@
+{
+  "status": "success",
+  "data": {
+    "token": "dev-tvdb-jwt-token-stub"
+  }
+}

--- a/internal/devmode/testdata/tvdb_search.json
+++ b/internal/devmode/testdata/tvdb_search.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "id": 81189,
+      "name": "Breaking Bad",
+      "overview": "A high school chemistry teacher turned methamphetamine manufacturer.",
+      "type": "series",
+      "year": "2008"
+    }
+  ]
+}

--- a/internal/devmode/testdata/tvdb_series.json
+++ b/internal/devmode/testdata/tvdb_series.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "id": 81189,
+    "name": "Breaking Bad",
+    "overview": "A high school chemistry teacher turned methamphetamine manufacturer.",
+    "image": "/banners/graphical/81189-g.jpg",
+    "firstAirDate": "2008-01-20",
+    "status": {
+      "id": 1,
+      "name": "Ended"
+    },
+    "year": "2008",
+    "externalIds": {
+      "imdb": "tt0903747",
+      "tvdb": 81189
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `-dev` flag to `loom serve` that boots the full app in **dev test mode** — no API keys, no network access required. All external HTTP dependencies are served by embedded `httptest.Server` stubs returning canned fixture responses.

## What was built

### `internal/devmode` package
- `devmode.Start()` — starts stub servers for **TMDb**, **TVDb v4**, and **MusicBrainz** and returns their base URLs plus a `stop()` cleanup function.
- Each stub server handles the real endpoints called by those clients (search, get-by-id, credits, login, episodes, release dates, etc.).
- Fixture JSON files under `internal/devmode/testdata/` (13 fixtures across all 3 providers).
- Full test coverage: `TestTMDbStub`, `TestTVDbStub`, `TestMusicBrainzStub`, `TestStopClosesServers`.

### `cmd/loom/serve.go` — `-dev` flag
When `-dev` is set:
1. Calls `devmode.Start()` and defers `stop()`.
2. Forces `storage.engine = sqlite` with `:memory:` path.
3. Injects `LOOM_TMDB_API_KEY=dev-key` placeholder so no env vars are needed.
4. Prints: `🧪 DEV TEST MODE ACTIVE — all external APIs are stubbed`.

### Builder threading
`buildMoviesService`, `buildScanner`, `buildSeriesService`, `buildTMDBClient` in `cmd/loom/movies.go` and `wireMedia` in `cmd/loom/wire_media.go` now accept `*devmode.Stubs`. When non-nil, each client's `BaseURL` is overridden to point at the local stub.

### Docker artifacts
- **`Dockerfile.test`** — multi-stage Go build, runs `loom serve -dev -addr :1925`.
- **`docker-compose.test.yml`** — `loom` service with healthcheck on `/healthz` + `test-runner` service.

## Decisions made

- **No Trakt stub**: Trakt providers use hardcoded URLs with no `BaseURL` injection seam; stubbing would require refactoring the provider. Import lists are optional — skipped for now.
- **`:memory:` SQLite**: Used plain `:memory:` (not `file::memory:?cache=shared`) to avoid DSN conflict with the existing `buildSQLiteDSN` function that appends its own `?_pragma=...` query string.
- **TVDb stub always wired in dev mode**: Even without a real TVDb key, dev mode sets a `dev-key` placeholder so the TVDB stub is exercised.
- **Standard library only**: No third-party mock libraries; uses `net/http/httptest` exclusively.

## Validation

```bash
go build ./...                          # ✓
go test ./internal/devmode/...          # ✓
go test ./...                           # ✓ all existing tests pass
./loom serve -dev -addr :19264 &
curl http://localhost:19264/healthz     # → {"status":"ok"}
```