### PR TITLE
fix(ci): quote grep pattern to avoid YAML colon parsing error

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,7 +140,7 @@ jobs:
           mv unit.out coverage.out
 
       - name: Print total coverage
-        run: go tool cover -func=coverage.out | grep total:
+        run: go tool cover -func=coverage.out | grep "total:"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
The integration workflow was broken immediately after merging: `grep total:` on line 143 was parsed as a YAML mapping key due to the trailing colon. Quoting as `grep "total:"` fixes the YAML parse error.

Fixes the workflow run: https://github.com/Ebenderooock/loom/actions/runs/30149472023