### PR TITLE
test(workflows): increase waitForCondition minimum from 5s to 10s

### DIFF
--- a/internal/workflows/orchestrator_test.go
+++ b/internal/workflows/orchestrator_test.go
@@ -108,8 +108,8 @@ func waitForCondition(t *testing.T, timeout time.Duration, check func() bool) {
 	t.Helper()
 	// Race-enabled CI can be significantly slower than local runs; ensure short
 	// waits have enough headroom so asynchronous state transitions are observed.
-	if timeout < 5*time.Second {
-		timeout = 5 * time.Second
+	if timeout < 10*time.Second {
+		timeout = 10 * time.Second
 	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
TestOrchestratorImportFailure keeps timing out on loaded race-enabled CI runners (latest: run [30149594732](https://github.com/Ebenderooock/loom/actions/runs/30149594732)). The `waitForCondition` minimum has been bumped several times already; raise from 5s to 10s to give async state transitions more headroom under `-race`.