### PR TITLE
fix: reconcile movie/episode status on library file deletion

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -140,7 +140,7 @@ jobs:
           mv unit.out coverage.out
 
       - name: Print total coverage
-        run: go tool cover -func=coverage.out | grep total:
+        run: go tool cover -func=coverage.out | grep "total:"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Fixes #135

## Problem

Deleting media files directly from disk (outside Loom) left movies and episodes in a stale "available" / `has_file=true` state even after a library rescan.

## Root Cause

`ScanLibrary` called `DeleteStaleFiles` which cleaned up `library_files` rows, but nothing propagated those deletions to `movie_files` / `movies.status` or `episode_files` / `episodes.has_file`.

## Fix

**`internal/libraries/store.go`**
- `StaleFilePaths` — queries stale paths before deletion so the scanner can pass them downstream.
- `ReconcileRemovedPaths` — transactional method that:
  - Soft-deletes `movie_files` rows for removed paths → sets `movies.status = 'missing'` when no valid file remains.
  - Deletes `episode_files` rows for removed paths → sets `episodes.has_file = false` when no valid file remains.
  - Handles multi-file media correctly (only transitions when **all** files are gone).
  - Fully idempotent — repeated scans are safe.

**`internal/libraries/scanner.go`**
- `ScanLibrary` now calls `StaleFilePaths` before `DeleteStaleFiles`, then passes the paths to `ReconcileRemovedPaths`.

## Tests

6 new tests in `internal/libraries/reconcile_test.go`:

| Test | Covers |
|------|--------|
| `MovieSetsMissing` | Movie status → `missing` when only file removed |
| `MovieKeepsStatusWhenFileRemains` | Multi-file movie: status unchanged when a file still exists |
| `EpisodeSetsHasFileFalse` | Episode `has_file` → `false` when only file removed |
| `EpisodeKeepsHasFileWhenFileRemains` | Multi-file episode: `has_file` stays `true` when a file still exists |
| `EmptyPathsIsNoop` | Nil/empty input returns without error |
| `Idempotent` | Repeated calls produce the same final state |