### PR TITLE
Filter skipped indexers out of search errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
       - run: go mod download
       - run: go vet ./...
@@ -76,15 +76,15 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
       # golangci-lint's published binaries are built with an older Go that
-      # refuses our go1.26 target ("Go language version used to build
+      # refuses our go1.26.6 target ("Go language version used to build
       # golangci-lint is lower than the targeted Go version"), so build it from
       # source with the toolchain selected above. Only issues NEW relative to
       # the default branch fail CI; the existing backlog is grandfathered and
       # tracked for gradual cleanup.
-      - name: Install golangci-lint (built with go1.26)
+      - name: Install golangci-lint (built with go1.26.6)
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
       # Grandfather the existing backlog: only issues NEW relative to the base
       # fail CI. For PRs that's the merge-base with the target branch; for
@@ -116,11 +116,11 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       # Package-level scan flags vulnerable imported packages quickly; standard
-      # library advisories are covered by tracking the latest go1.26 patch above.
+      # library advisories are covered by tracking the latest go1.26 patch (currently 1.26.6) above.
       - run: govulncheck -scan package ./...
 
   build:
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
       - run: go build -trimpath -ldflags="-s -w" -o /tmp/loom ./cmd/loom
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
 
       - run: go mod download
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
 
       - run: go mod download
@@ -118,7 +118,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
 
       - run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26"
+          go-version: "1.26.6"
           cache: true
       - uses: pnpm/action-setup@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ebenderooock/loom
 go 1.26
 
 toolchain go1.26.6
+
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/antchfx/htmlquery v1.3.6
@@ -22,10 +23,10 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.21.0
 	github.com/sqlc-dev/pqtype v0.3.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
@@ -91,7 +92,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/ebenderooock/loom
 
 go 1.26
 
+toolchain go1.26.6
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/antchfx/htmlquery v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/web/src/components/search/release-search-dialog.tsx
+++ b/web/src/components/search/release-search-dialog.tsx
@@ -29,6 +29,7 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
+  MinusCircle,
 } from "lucide-react";
 import { cn, formatBytes } from "@/lib/utils";
 import { toast } from "sonner";
@@ -299,6 +300,7 @@ function IndexerStatusGrid({
   const failed = entries.filter(
     (i) => i.status === "error" || i.status === "timeout",
   ).length;
+  const skipped = entries.filter((i) => i.status === "skipped").length;
   const totalResults = entries.reduce((sum, i) => sum + i.resultCount, 0);
 
   return (
@@ -326,6 +328,12 @@ function IndexerStatusGrid({
               · {failed} failed
             </span>
           )}
+          {skipped > 0 && (
+            <span className="text-muted-foreground">
+              {" "}
+              · {skipped} skipped
+            </span>
+          )}
         </span>
       </div>
       <div className="flex flex-wrap gap-1.5 px-3 pb-2">
@@ -343,6 +351,8 @@ function IndexerStatusGrid({
                 "bg-red-500/10 text-red-700 dark:text-red-300",
               ix.status === "timeout" &&
                 "bg-yellow-500/10 text-yellow-700 dark:text-yellow-300",
+              ix.status === "skipped" &&
+                "bg-muted text-muted-foreground opacity-60",
             )}
             title={ix.error ? `${ix.name}: ${ix.error}` : ix.name}
           >
@@ -353,6 +363,7 @@ function IndexerStatusGrid({
             {ix.status === "done" && <CheckCircle2 className="h-3 w-3" />}
             {ix.status === "error" && <XCircle className="h-3 w-3" />}
             {ix.status === "timeout" && <AlertTriangle className="h-3 w-3" />}
+            {ix.status === "skipped" && <MinusCircle className="h-3 w-3" />}
             <span className="max-w-[8rem] truncate">{ix.name}</span>
             {ix.status === "done" && ix.resultCount > 0 && (
               <span className="tabular-nums opacity-70">{ix.resultCount}</span>
@@ -740,7 +751,11 @@ export function ReleaseSearchDialog({
             });
           },
           onIndexerError: (id, name, error, status, elapsedMs) => {
-            setErrors((prev) => ({ ...prev, [name]: error }));
+            // Skipped indexers (e.g. wrong category) are not real errors —
+            // don't surface them in the error banner.
+            if (status !== "skipped") {
+              setErrors((prev) => ({ ...prev, [name]: error }));
+            }
             setIndexerStates((prev) => {
               const next = new Map(prev);
               next.set(id, {
@@ -748,7 +763,9 @@ export function ReleaseSearchDialog({
                 name: next.get(id)?.name ?? name,
                 status: (status === "timeout"
                   ? "timeout"
-                  : "error") as IndexerStatus,
+                  : status === "skipped"
+                    ? "skipped"
+                    : "error") as IndexerStatus,
                 resultCount: 0,
                 elapsedMs,
                 error,

--- a/web/src/components/search/release-search-dialog.tsx
+++ b/web/src/components/search/release-search-dialog.tsx
@@ -329,10 +329,7 @@ function IndexerStatusGrid({
             </span>
           )}
           {skipped > 0 && (
-            <span className="text-muted-foreground">
-              {" "}
-              · {skipped} skipped
-            </span>
+            <span className="text-muted-foreground"> · {skipped} skipped</span>
           )}
         </span>
       </div>

--- a/web/src/lib/indexers-api.ts
+++ b/web/src/lib/indexers-api.ts
@@ -451,7 +451,8 @@ export type IndexerStatus =
   | "searching"
   | "done"
   | "error"
-  | "timeout";
+  | "timeout"
+  | "skipped";
 
 export interface IndexerStreamState {
   id: string;


### PR DESCRIPTION
## Summary
- add `skipped` to the indexer status type used by the search UI
- stop treating skipped indexers as real errors in the search dialog
- render skipped indexers as muted status chips instead of failed ones

## Notes
This prevents category-mismatched indexers like YTS on TV searches from showing up in the "indexers reported errors" banner.